### PR TITLE
Various shop fixes and .NET Core 3.1

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.103
+        dotnet-version: 3.1
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 sudo: required  
 dist: xenial  
 mono: none
-dotnet: 2.2.103
+dotnet: 3.1
 script:  
   - dotnet restore
   - dotnet build

--- a/AAEmu.Commons/AAEmu.Commons.csproj
+++ b/AAEmu.Commons/AAEmu.Commons.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;win7-x86;win8-x64;win8-x86;win81-x64;win81-x86;win10-x64;win10-x86;centos.7-x64;debian.9-x64;ubuntu.18.04-x64;sles-x64;sles.12-x64;sles.12.1-x64;sles.12.2-x64;sles.12.3-x64;alpine-x64;alpine.3.7-x64</RuntimeIdentifiers>
     <VersionPrefix>0.0.2.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>

--- a/AAEmu.Game/AAEmu.Game.csproj
+++ b/AAEmu.Game/AAEmu.Game.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <RuntimeIdentifiers>win7-x64;win7-x86;win8-x64;win8-x86;win81-x64;win81-x86;win10-x64;win10-x86;centos.7-x64;debian.9-x64;ubuntu.18.04-x64;sles-x64;sles.12-x64;sles.12.1-x64;sles.12.2-x64;sles.12.3-x64;alpine-x64;alpine.3.7-x64</RuntimeIdentifiers>
         <VersionPrefix>0.0.2.0</VersionPrefix>
         <VersionSuffix>alpha</VersionSuffix>

--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -1257,7 +1257,9 @@ namespace AAEmu.Game.Core.Managers
                             continue;
                         if (item.SlotType == SlotType.None)
                         {
-                            _log.Warn(string.Format("Found SlotType.None in itemslist, skipping ID:{0} - Template:{1}", item.Id, item.TemplateId));
+                            // Only give a error if it has no owner, otherwise it's likely a BuyBack item
+                            if (item.OwnerId <= 0)
+                                _log.Warn(string.Format("Found SlotType.None in itemslist, skipping ID:{0} - Template:{1}", item.Id, item.TemplateId));
                             continue;
                         }
                         if (!item.IsDirty)
@@ -1429,6 +1431,13 @@ namespace AAEmu.Game.Core.Managers
             {
                 procTemplate.SkillTemplate = SkillManager.Instance.GetSkillTemplate(procTemplate.SkillId);
             }
+        }
+
+        public bool IsAutoEquipTradePack(uint itemTemplateId)
+        {
+            var template = GetTemplate(itemTemplateId);
+            // Is a valid item, is a backpack item, doesn't bind on equip (it can bind on pickup)
+            return ((template != null) && (template is BackpackTemplate bt) && !template.BindType.HasFlag(ItemBindType.BindOnEquip));
         }
     }
 }

--- a/AAEmu.Game/Core/Managers/SaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SaveManager.cs
@@ -79,7 +79,7 @@ namespace AAEmu.Game.Core.Managers
                 try
                 {
                     // Save stuff
-                    _log.Info("Saving DB ...");
+                    _log.Debug("Saving DB ...");
                     using (var connection = MySQL.CreateConnection())
                     {
                         using (var transaction = connection.BeginTransaction())
@@ -112,7 +112,7 @@ namespace AAEmu.Game.Core.Managers
 
                             if (totalCommits <= 0)
                             {
-                                _log.Info("No data to update ...");
+                                _log.Debug("No data to update ...");
                                 saved = true;
                             }
                             else
@@ -120,11 +120,18 @@ namespace AAEmu.Game.Core.Managers
                                 try
                                 {
                                     transaction.Commit();
-                                    _log.Info("Updated {0} and deleted {1} houses ...", savedHouses.Item1, savedHouses.Item2);
-                                    _log.Info("Updated {0} and deleted {1} mails ...", savedMails.Item1, savedMails.Item2);
-                                    _log.Info("Updated {0} and deleted {1} items ...", saveItems.Item1, saveItems.Item2);
-                                    _log.Info("Updated {0} and deleted {1} auction items ...", savedAuctionHouse.Item1, savedAuctionHouse.Item2);
-                                    _log.Info("Updated {0} characters ...", savedCharacters);
+
+                                    if ((savedHouses.Item1 + savedHouses.Item2) > 0)
+                                        _log.Debug("Updated {0} and deleted {1} houses ...", savedHouses.Item1, savedHouses.Item2);
+                                    if ((savedMails.Item1 + savedMails.Item2) > 0)
+                                        _log.Debug("Updated {0} and deleted {1} mails ...", savedMails.Item1, savedMails.Item2);
+                                    if ((saveItems.Item1 + saveItems.Item2) > 0)
+                                        _log.Debug("Updated {0} and deleted {1} items ...", saveItems.Item1, saveItems.Item2);
+                                    if ((savedAuctionHouse.Item1 + savedAuctionHouse.Item2) > 0)
+                                        _log.Debug("Updated {0} and deleted {1} auction items ...", savedAuctionHouse.Item1, savedAuctionHouse.Item2);
+                                    if (savedCharacters > 0)
+                                        _log.Debug("Updated {0} characters ...", savedCharacters);
+
                                     saved = true;
                                 }
                                 catch (Exception e)
@@ -150,7 +157,7 @@ namespace AAEmu.Game.Core.Managers
                     _log.Error(string.Format("DoSave Exception: {0}", e.Message));
                 }
                 stopWatch.Stop();
-                _log.Info("Saving data took {0}", stopWatch.Elapsed);
+                _log.Debug("Saving data took {0}", stopWatch.Elapsed);
             }
             _isSaving = false;
             return saved;

--- a/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
@@ -486,15 +486,8 @@ namespace AAEmu.Game.Core.Managers.UnitManagers
 
                             var itemId = reader.GetUInt32("item_id");
                             var grade = reader.GetByte("grade_id");
-                            if (_goods[id].Items.ContainsKey(itemId))
-                            {
-                                if (_goods[id].Items[itemId].IndexOf(grade) > -1)
-                                    continue;
 
-                                _goods[id].Items[itemId].Add(grade);
-                            }
-                            else
-                                _goods[id].Items.Add(itemId, new List<byte> { grade });
+                            _goods[id].AddItemToStock(itemId, grade);
                         }
                     }
                 }

--- a/AAEmu.Game/Core/Packets/C2G/CSBuyCoinItemPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSBuyCoinItemPacket.cs
@@ -1,4 +1,4 @@
-using AAEmu.Commons.Network;
+﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
@@ -16,10 +16,25 @@ namespace AAEmu.Game.Core.Packets.C2G
             var objId = stream.ReadBc();
             var id = stream.ReadUInt32();
 
-            _log.Debug("BuyCoinItem, objId: {0}, id: {1}", objId, id);
+            _log.Trace("BuyCoinItem, objId: {0}, id: {1}", objId, id);
             var doodad = WorldManager.Instance.GetDoodad(objId);
+            if (doodad == null)
+            {
+                _log.Warn("BuyCoinItem, no such doodad objId: {0}", objId);
+                return;
+            }
             var doodadFunc = DoodadManager.Instance.GetFunc(id);
+            if (doodadFunc == null)
+            {
+                _log.Warn("BuyCoinItem, no doodadFunc for objId: {0}, id: {1}", objId, id);
+                return;
+            }
             var funcTemplate = DoodadManager.Instance.GetFuncTemplate(doodadFunc.FuncId, doodadFunc.FuncType);
+            if (funcTemplate == null)
+            {
+                _log.Warn("BuyCoinItem, no funcTemplate found with doodad func for objId: {0}, id: {1} funcId: {2}, funcType: {3}", objId, id, doodadFunc.FuncId, doodadFunc.FuncType);
+                return;
+            }
             funcTemplate.Use(Connection.ActiveChar, doodad, 0);
         }
     }

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -86,19 +86,18 @@ namespace AAEmu.Game.Models.Game.Char
             foreach (var product in _craft.CraftProducts)
             {
                 // Check if we're crafting a tradepack, if so, try to remove currently equipped backpack slot
-                bool isTradePack = false;
-                var productResultItemTemplate = ItemManager.Instance.GetTemplate(product.ItemId);
-                if ((productResultItemTemplate != null) && (productResultItemTemplate is BackpackTemplate bt))
-                {
-                    if (bt.BackpackType == BackpackType.TradePack)
-                        isTradePack = true;
-                }
-                if (isTradePack == false)
+                if (ItemManager.Instance.IsAutoEquipTradePack(product.ItemId) == false)
                 {
                     Owner.Inventory.Bag.AcquireDefaultItem(Items.Actions.ItemTaskType.CraftPickupProduct, product.ItemId, product.Amount);
                 }
                 else
                 {
+                    if (!Owner.Inventory.TryEquipNewBackPack(Items.Actions.ItemTaskType.CraftPickupProduct, product.ItemId, product.Amount))
+                    {
+                        CancelCraft();
+                        return;
+                    }
+                    /*
                     // Remove player backpack
                     if (Owner.Inventory.TakeoffBackpack(Items.Actions.ItemTaskType.CraftPickupProduct,true))
                     {
@@ -110,6 +109,7 @@ namespace AAEmu.Game.Models.Game.Char
                         CancelCraft();
                         return;
                     }
+                    */
                 }
             }
 

--- a/AAEmu.Game/Models/Game/Char/Inventory.cs
+++ b/AAEmu.Game/Models/Game/Char/Inventory.cs
@@ -452,6 +452,17 @@ namespace AAEmu.Game.Models.Game.Char
             return true;
         }
 
+        public bool TryEquipNewBackPack(ItemTaskType taskType, uint itemId, int itemCount, int gradeToAdd = -1)
+        {
+            // Remove player backpack
+            if (Owner.Inventory.TakeoffBackpack(taskType, true))
+            {
+                // Put tradepack in their backpack slot
+                return Owner.Inventory.Equipment.AcquireDefaultItem(taskType, itemId, itemCount, gradeToAdd);
+            }
+            return false;
+        }
+
         public Item GetItemById(ulong id)
         {
             foreach(var c in _itemContainers)

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncPurchase.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncPurchase.cs
@@ -36,10 +36,22 @@ namespace AAEmu.Game.Models.Game.DoodadObj.Funcs
                 return;
             }
 
-            if (character.Inventory.Bag.AcquireDefaultItem(ItemTaskType.DoodadInteraction,ItemId,Count))
+            if (ItemManager.Instance.IsAutoEquipTradePack(ItemId))
             {
-                _log.Error(string.Format("DoodadFuncPurchase: Failed to create item {0} for player {1}",ItemId,character.Name));
-                return;
+                if (!character.Inventory.TryEquipNewBackPack(ItemTaskType.QuestSupplyItems, ItemId, Count))
+                {
+                    _log.Error(string.Format("DoodadFuncPurchase: Failed to auto-equip backpack item {0} for player {1}", ItemId, character.Name));
+                    character.SendErrorMessage(Error.ErrorMessageType.BackpackOccupied);
+                    return;
+                }
+            }
+            else
+            {
+                if (!character.Inventory.Bag.AcquireDefaultItem(ItemTaskType.DoodadInteraction, ItemId, Count))
+                {
+                    _log.Error(string.Format("DoodadFuncPurchase: Failed to create item {0} for player {1}", ItemId, character.Name));
+                    return;
+                }
             }
 
         }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncRatioChange.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncRatioChange.cs
@@ -5,9 +5,7 @@ using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.DoodadObj.Templates;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Units;
-
 using System;
-using System.Runtime.InteropServices.WindowsRuntime;
 
 namespace AAEmu.Game.Models.Game.DoodadObj.Funcs
 {

--- a/AAEmu.Game/Models/Game/Items/Item.cs
+++ b/AAEmu.Game/Models/Game/Items/Item.cs
@@ -21,8 +21,8 @@ namespace AAEmu.Game.Models.Game.Items
     {
         Money = 0,
         Honor = 1,
-        SiegeShop = 2,
-        VocationBadges = 3,
+        VocationBadges = 2,
+        SiegeShop = 3,
     }
 
     public struct ItemLocation

--- a/AAEmu.Game/Models/Game/Items/ItemContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/ItemContainer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;

--- a/AAEmu.Game/Models/Game/Merchant/MerchantGoods.cs
+++ b/AAEmu.Game/Models/Game/Merchant/MerchantGoods.cs
@@ -1,16 +1,42 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace AAEmu.Game.Models.Game.Merchant
 {   
     public class MerchantGoods
     {
         public uint Id { get; set; }
-        public Dictionary<uint, List<byte>> Items { get; set; }
+        public List<MerchantGoodsItem> Items { get; set; }
 
         public MerchantGoods(uint id)
         {
             Id = id;
-            Items = new Dictionary<uint, List<byte>>();
+            Items = new List<MerchantGoodsItem>();
         }
+
+        // NOTE: If there is ever a case where one itemTemplate is sold at multiple grades, then this code needs a rework
+        public bool SellsItem(uint itemTemplateId)
+        {
+            foreach (var i in Items)
+                if (i.ItemTemplateId == itemTemplateId)
+                    return true;
+            return false;
+        }
+
+        public void AddItemToStock(uint itemTemplateId, byte itemGrade)
+        {
+            if (SellsItem(itemTemplateId))
+                return;
+            var newItem = new MerchantGoodsItem();
+            newItem.ItemTemplateId = itemTemplateId;
+            newItem.Grade = itemGrade;
+
+            Items.Add(newItem);
+        }
+    }
+
+    public class MerchantGoodsItem
+    {
+        public uint ItemTemplateId;
+        public byte Grade;
     }
 }

--- a/AAEmu.Game/Models/Game/Quests/Acts/QuestActSupplyItem.cs
+++ b/AAEmu.Game/Models/Game/Quests/Acts/QuestActSupplyItem.cs
@@ -28,6 +28,15 @@ namespace AAEmu.Game.Models.Game.Quests.Acts
                 return true;
             else
             {
+                if (ItemManager.Instance.IsAutoEquipTradePack(ItemId))
+                {
+                    return character.Inventory.TryEquipNewBackPack(ItemTaskType.QuestSupplyItems, ItemId, Count, GradeId);
+                }
+                else
+                {
+                    return character.Inventory.Bag.AcquireDefaultItem(ItemTaskType.QuestSupplyItems, ItemId, Count, GradeId);
+                }
+                /*
                 var template = ItemManager.Instance.GetTemplate(ItemId);
                 if (template is BackpackTemplate backpackTemplate)
                 {
@@ -40,26 +49,8 @@ namespace AAEmu.Game.Models.Game.Quests.Acts
                 {
                     return character.Inventory.Bag.AcquireDefaultItem(ItemTaskType.QuestSupplyItems, ItemId, Count, GradeId);
                 }
-                /*
-                var tasks = new List<ItemTask>();
-                var item = ItemManager.Instance.Create(ItemId, Count, GradeId);
-                if (item == null)
-                    return false;
-                var backpackTemplate = (BackpackTemplate)null;
-                if (item.Template is BackpackTemplate)
-                    backpackTemplate = (BackpackTemplate)item.Template;
-                var res = character.Inventory.AddItem(item);
-                if (res == null)
-                    ItemManager.Instance.ReleaseId(item.Id);
-                if (res.Id != item.Id)
-                    tasks.Add(new ItemCountUpdate(res, item.Count));
-                else
-                    tasks.Add(new ItemAdd(item));
-                character.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.QuestSupplyItems, tasks, new List<ulong>()));
-                if (backpackTemplate != null && backpackTemplate.BackpackType == BackpackType.TradePack )
-                    character.Inventory.Move(item.Id, item.SlotType, (byte)item.Slot, 0, SlotType.Equipment, (byte)EquipmentItemSlot.Backpack);
-                return true;
                 */
+
             }
         }
     }

--- a/AAEmu.Login/AAEmu.Login.csproj
+++ b/AAEmu.Login/AAEmu.Login.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;win7-x86;win8-x64;win8-x86;win81-x64;win81-x86;win10-x64;win10-x86;centos.7-x64;debian.9-x64;ubuntu.18.04-x64;sles-x64;sles.12-x64;sles.12.1-x64;sles.12.2-x64;sles.12.3-x64;alpine-x64;alpine.3.7-x64</RuntimeIdentifiers>
     <VersionPrefix>0.0.2.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>

--- a/AAEmu.Tests/AAEmu.Tests.csproj
+++ b/AAEmu.Tests/AAEmu.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RuntimeIdentifiers>win7-x64;win7-x86;win8-x64;win8-x86;win81-x64;win81-x86;win10-x64;win10-x86;centos.7-x64;debian.9-x64;ubuntu.18.04-x64;sles-x64;sles.12-x64;sles.12.1-x64;sles.12.2-x64;sles.12.3-x64;alpine-x64;alpine.3.7-x64</RuntimeIdentifiers>
     <VersionPrefix>0.0.2.0</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>


### PR DESCRIPTION
Move to .NET Core 3.1 (make sure to move your debug folder content)
Vocation/Honor shop now work correctly
Fixed basic mirage shopping
Reduced SaveManager clutter
Move some INFO logs to DEBUG, and removed save information of things that weren't changed.
Backpack shopping now equips the backpack on buy.