### PR TITLE
Fixed small issue, rewrote LootPackEffect

### DIFF
--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -1094,7 +1094,8 @@ namespace AAEmu.Game.Core.Managers
                             template.MaxAmount = reader.GetInt32("max_amount");
                             template.LootPackId = reader.GetUInt32("loot_pack_id");
                             template.GradeId = reader.GetByte("grade_id");
-                            template.AlwaysDrop = reader.GetBoolean("always_drop");
+                            template.AlwaysDrop = reader.GetBoolean("always_drop", true);
+
                             List<LootPacks> lootPacks;
                             if (_lootPacks.ContainsKey(template.LootPackId))
                                 lootPacks = _lootPacks[template.LootPackId];


### PR DESCRIPTION
Fixed issue in a manager defaulting all values to fault. 
Mini rewrite for LootPackEffect. Should be more readable and actually use the the AlwaysDropFlag properly. 

Not 100% how the Grade portion of this works but this works just fine and uses the full loot pool of any given item. 