### PR TITLE
[Items] CrafterId

### DIFF
--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -189,7 +189,8 @@ namespace AAEmu.Game.Core.Managers
                 CreateTime = DateTime.Now,
                 Id = ++itemId,
                 Count = Rand.Next(unit.Level * 5, unit.Level * 400),
-                MadeUnitId = npcId
+                MadeUnitId = 0
+                // MadeUnitId = npcId
             };
             items.Add(item2);
             _lootDropItems.Add(npcId, items);
@@ -1354,7 +1355,7 @@ namespace AAEmu.Game.Core.Managers
                         command.Parameters.AddWithValue("@id", item.Id);
                         command.Parameters.AddWithValue("@type", item.GetType().ToString());
                         command.Parameters.AddWithValue("@template_id", item.TemplateId);
-                        command.Parameters.AddWithValue("@slot_type", item.SlotType);
+                        command.Parameters.AddWithValue("@slot_type", item.SlotType.ToString());
                         command.Parameters.AddWithValue("@slot", item.Slot);
                         command.Parameters.AddWithValue("@count", item.Count);
                         command.Parameters.AddWithValue("@details", details.GetBytes());

--- a/AAEmu.Game/Core/Managers/World/SpecialtyManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpecialtyManager.cs
@@ -227,7 +227,7 @@ namespace AAEmu.Game.Core.Managers.World
             // Our backpack isn't null, we have the NPC, time to calculate the profits
 
             // TODO: Get crafter ID of tradepack
-            uint crafterId = 0; // leave this at zero if seller is crafter
+            uint crafterId = backpack.MadeUnitId != player.Id ? backpack.MadeUnitId : 0 ;
             var sellerShare = 0.80f; // 80% default, set this to 1f for packs that don't share profit
 
             var interestRate = 5;

--- a/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCraft.cs
@@ -88,11 +88,12 @@ namespace AAEmu.Game.Models.Game.Char
                 // Check if we're crafting a tradepack, if so, try to remove currently equipped backpack slot
                 if (ItemManager.Instance.IsAutoEquipTradePack(product.ItemId) == false)
                 {
-                    Owner.Inventory.Bag.AcquireDefaultItem(Items.Actions.ItemTaskType.CraftPickupProduct, product.ItemId, product.Amount);
+                    Owner.Inventory.Bag.AcquireDefaultItem(Items.Actions.ItemTaskType.CraftPickupProduct,
+                        product.ItemId, product.Amount, -1, Owner.Id);
                 }
                 else
                 {
-                    if (!Owner.Inventory.TryEquipNewBackPack(Items.Actions.ItemTaskType.CraftPickupProduct, product.ItemId, product.Amount))
+                    if (!Owner.Inventory.TryEquipNewBackPack(Items.Actions.ItemTaskType.CraftPickupProduct, product.ItemId, product.Amount,-1,Owner.Id))
                     {
                         CancelCraft();
                         return;

--- a/AAEmu.Game/Models/Game/Char/Inventory.cs
+++ b/AAEmu.Game/Models/Game/Char/Inventory.cs
@@ -30,6 +30,7 @@ namespace AAEmu.Game.Models.Game.Char
         public ItemContainer Bag { get; private set; }
         public ItemContainer Warehouse { get; private set; }
         public ItemContainer MailAttachments { get; private set; }
+        public ItemContainer SystemContainer { get; private set; }
 
         public Inventory(Character owner)
         {
@@ -54,10 +55,12 @@ namespace AAEmu.Game.Models.Game.Char
                 _itemContainers.Add(st, newContainer);
                 switch (st)
                 {
+                    /*
                     case SlotType.Equipment:
                         newContainer.ContainerSize = 28; // 28 equipment slots for 1.2 client
                         Equipment = newContainer;
                         break;
+                    */
                     case SlotType.Inventory:
                         newContainer.ContainerSize = Owner.NumInventorySlots;
                         Bag = newContainer;
@@ -67,7 +70,12 @@ namespace AAEmu.Game.Models.Game.Char
                         Warehouse = newContainer;
                         break;
                     case SlotType.Mail:
+                        newContainer.PartOfPlayerInventory = false;
                         MailAttachments = newContainer;
+                        break;
+                    case SlotType.System:
+                        newContainer.PartOfPlayerInventory = false;
+                        SystemContainer = newContainer;
                         break;
                 }
             }
@@ -576,13 +584,13 @@ namespace AAEmu.Game.Models.Game.Char
             return true;
         }
 
-        public bool TryEquipNewBackPack(ItemTaskType taskType, uint itemId, int itemCount, int gradeToAdd = -1)
+        public bool TryEquipNewBackPack(ItemTaskType taskType, uint itemId, int itemCount, int gradeToAdd = -1, uint crafterId = 0)
         {
             // Remove player backpack
             if (Owner.Inventory.TakeoffBackpack(taskType, true))
             {
                 // Put tradepack in their backpack slot
-                return Owner.Inventory.Equipment.AcquireDefaultItem(taskType, itemId, itemCount, gradeToAdd);
+                return Owner.Inventory.Equipment.AcquireDefaultItem(taskType, itemId, itemCount, gradeToAdd, crafterId);
             }
             return false;
         }

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadSpawner.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadSpawner.cs
@@ -16,10 +16,10 @@ namespace AAEmu.Game.Models.Game.DoodadObj
         
         public Doodad Last { get; set; }
 
-        public override Doodad Spawn(uint objId, ulong itemID, uint charID) //Mostly used for player created spawns
+        public override Doodad Spawn(uint objId, ulong itemId, uint charId) //Mostly used for player created spawns
         {
 
-            Character character = WorldManager.Instance.GetCharacterByObjId(charID);
+            Character character = WorldManager.Instance.GetCharacterByObjId(charId);
             var doodad = DoodadManager.Instance.Create(objId, UnitId, character);
 
             if (doodad == null)
@@ -30,8 +30,8 @@ namespace AAEmu.Game.Models.Game.DoodadObj
 
             doodad.Spawner = this;
             doodad.Position = Position.Clone();
-            doodad.QuestGlow = 0u; //TODO make this OOP
-            doodad.ItemId = itemID;
+            doodad.QuestGlow = 0u; // TODO: make this OOP
+            doodad.ItemId = itemId;
 
             if (Scale > 0)
                 doodad.SetScale(Scale);
@@ -47,7 +47,7 @@ namespace AAEmu.Game.Models.Game.DoodadObj
             return doodad;
         }
 
-        public override Doodad Spawn(uint objId) //TODO clean up each doodad uses the same call
+        public override Doodad Spawn(uint objId) // TODO: clean up each doodad uses the same call
         {  
             var doodad = DoodadManager.Instance.Create(objId, UnitId, null);
             if (doodad == null)

--- a/AAEmu.Game/Models/Game/Items/ItemContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/ItemContainer.cs
@@ -361,9 +361,9 @@ namespace AAEmu.Game.Models.Game.Items
         /// <param name="amountToAdd">Number of item units to add</param>
         /// <param name="gradeToAdd">Overrides default grade if possible</param>
         /// <returns></returns>
-        public bool AcquireDefaultItem(ItemTaskType taskType, uint templateId, int amountToAdd, int gradeToAdd = -1)
+        public bool AcquireDefaultItem(ItemTaskType taskType, uint templateId, int amountToAdd, int gradeToAdd = -1, uint crafterId = 0)
         {
-            return AcquireDefaultItemEx(taskType, templateId, amountToAdd, gradeToAdd, out _, out _);
+            return AcquireDefaultItemEx(taskType, templateId, amountToAdd, gradeToAdd, out _, out _, crafterId);
         }
 
         /// <summary>
@@ -375,7 +375,7 @@ namespace AAEmu.Game.Models.Game.Items
         /// <param name="gradeToAdd">Overrides default grade if possible</param>
         /// <param name="updatedItemsList">A List of the newly added or updated items</param>
         /// <returns></returns>
-        public bool AcquireDefaultItemEx(ItemTaskType taskType, uint templateId, int amountToAdd, int gradeToAdd, out List<Item> newItemsList, out List<Item> updatedItemsList)
+        public bool AcquireDefaultItemEx(ItemTaskType taskType, uint templateId, int amountToAdd, int gradeToAdd, out List<Item> newItemsList, out List<Item> updatedItemsList, uint crafterId)
         {
             newItemsList = new List<Item>();
             updatedItemsList = new List<Item>();
@@ -422,6 +422,12 @@ namespace AAEmu.Game.Models.Game.Items
             {
                 var addAmount = Math.Min(amountToAdd, template.MaxCount);
                 var newItem = ItemManager.Instance.Create(templateId, addAmount, (byte)gradeToAdd, true);
+                // Add name if marked as crafter (single stack items only)
+                if ((crafterId > 0) && (newItem.Template.MaxCount == 1))
+                {
+                    newItem.MadeUnitId = crafterId;
+                    newItem.WorldId = 1; // TODO: proper world id handling
+                }
                 amountToAdd -= addAmount;
                 var prefSlot = -1;
                 if ((newItem.Template is BackpackTemplate) && (ContainerType == SlotType.Equipment))

--- a/AAEmu.Game/Models/Game/Items/SlotType.cs
+++ b/AAEmu.Game/Models/Game/Items/SlotType.cs
@@ -7,6 +7,7 @@ namespace AAEmu.Game.Models.Game.Items
         Inventory = 2,
         Bank = 3,
         Trade = 4,
-        Mail = 5
+        Mail = 5,
+        System = 0xFF 
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/PutDownBackpackEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/PutDownBackpackEffect.cs
@@ -30,13 +30,11 @@ namespace AAEmu.Game.Models.Game.Skills.Effects
             Item item = character.Inventory.Equipment.GetItemByItemId(packItem.ItemId);
             if (item == null) return;
 
-            if (character.Inventory.Equipment.RemoveItem(Items.Actions.ItemTaskType.DropBackpack, item, true))
+            if (character.Inventory.SystemContainer.AddOrMoveExistingItem(Items.Actions.ItemTaskType.DropBackpack, item, (int)EquipmentItemSlot.Backpack))
             {
-                //TODO: save to database and who placed it down and item template shouldn't be used.
-
                 // Spawn doodad
-                _log.Debug("[PutDownPackEffect");
-                var (newX, newY) = MathUtil.AddDistanceToFront(1, character.Position.X, character.Position.Y, character.Position.RotationZ);
+                _log.Debug("PutDownPackEffect");
+                var (newX, newY) = MathUtil.AddDistanceToFront(1f, character.Position.X, character.Position.Y, character.Position.RotationZ);
                 var pos = character.Position.Clone();
 
                 pos.X = newX;
@@ -47,8 +45,7 @@ namespace AAEmu.Game.Models.Game.Skills.Effects
                 doodadSpawner.Id = 0;
                 doodadSpawner.UnitId = BackpackDoodadId;
                 doodadSpawner.Position = pos;
-                var doodad = doodadSpawner.Spawn(0);
-                doodad.ItemId = item.TemplateId;
+                var doodad = doodadSpawner.Spawn(0,item.Id,character.ObjId);
             }
         }
     }

--- a/AAEmu.Game/Models/Game/World/Spawner.cs
+++ b/AAEmu.Game/Models/Game/World/Spawner.cs
@@ -13,7 +13,7 @@
             return null;
         }
 
-        public virtual T Spawn(uint objId, ulong itemID, uint charID)
+        public virtual T Spawn(uint objId, ulong itemId, uint charId)
         {
             return null;
         }

--- a/AAEmu.Game/Scripts/Commands/ShowInventory.cs
+++ b/AAEmu.Game/Scripts/Commands/ShowInventory.cs
@@ -61,7 +61,7 @@ namespace AAEmu.Game.Scripts.Commands
 
                 if ((args.Length > firstarg + 0) && (uint.TryParse(args[firstarg + 0], out uint argcontainerId)))
                 {
-                    if ((argcontainerId >= 0) && (argcontainerId <= (byte)SlotType.Mail))
+                    if (((argcontainerId >= 0) && (argcontainerId <= (byte)SlotType.Mail)) || (argcontainerId == (byte)SlotType.System))
                         containerId = (SlotType)argcontainerId;
                     else
                     {

--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -363,7 +363,7 @@ CREATE TABLE `items` (
   `id` bigint(20) unsigned NOT NULL,
   `type` varchar(100) NOT NULL,
   `template_id` int(11) unsigned NOT NULL,
-  `slot_type` enum('Equipment','Inventory','Bank','Trade','Mail') NOT NULL,
+  `slot_type` enum('Equipment','Inventory','Bank','Trade','Mail','System') NOT NULL,
   `slot` int(11) NOT NULL,
   `count` int(11) NOT NULL,
   `details` blob,

--- a/SQL/updates/2020-12-09_aaemu_game_items.sql
+++ b/SQL/updates/2020-12-09_aaemu_game_items.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `aaemu_game`.`items` 
+CHANGE COLUMN `slot_type` `slot_type` ENUM('Equipment', 'Inventory', 'Bank', 'Trade', 'Mail', 'System') NOT NULL ;


### PR DESCRIPTION
Crafting items now properly sets the CrafterId of the item.
Trade-packs will now retain their crafter information when put down and picked back up.
Time to steal some trade-packs for profit !
Added new item container System that is used for doodad ItemId storage.
Updated /showinv to allow 255 as container id for system
Updated MySQL Items slot_type ENUM()

Note: Dropped trade-packs are not yet persistent between reboots !