### PR TITLE
[Game] Created config file for labor, premium/fremium now recognized, not hard coded anymore

### DIFF
--- a/AAEmu.Game/Core/Managers/LaborPowerManager.cs
+++ b/AAEmu.Game/Core/Managers/LaborPowerManager.cs
@@ -1,8 +1,12 @@
 ﻿using System;
 using AAEmu.Commons.Utils;
+using System.Collections.Generic;
 using AAEmu.Game.Core.Network.Connections;
 using AAEmu.Game.Models.Tasks.LaborPower;
+using AAEmu.Game.Models;
+using Newtonsoft.Json;
 using NLog;
+using System.IO;
 
 namespace AAEmu.Game.Core.Managers
 {
@@ -12,10 +16,8 @@ namespace AAEmu.Game.Core.Managers
 
         //private List<LaborPower> _onlineChar;
         //private List<LaborPower> _offlineChar;
-        private const short LpChangePremium = 10; // TODO in config
-        private const short LpChange = 5;
-        private const short UpLimit = 2000;
-        private const double Delay = 5; // min
+
+        private Dictionary<string, short> _labor;
 
         public LaborPowerManager()
         {
@@ -26,6 +28,29 @@ namespace AAEmu.Game.Core.Managers
         public void Initialize()
         {
             _log.Info("Initialising Labor Power Manager...");
+            
+            #region FileManager
+            _labor = new Dictionary<string, short>();
+            Dictionary<string, short> d = new Dictionary<string, short>();
+            try
+            {
+                string data = File.ReadAllText("Data/labor.json");
+                d = JsonConvert.DeserializeObject<Dictionary<string, short>>(data);
+                foreach (var entry in d)
+                    _labor.Add(entry.Key,entry.Value);
+            }
+            catch (Exception e ){
+                _log.Error(e.Message);
+            }
+            #endregion
+
+            _log.Info("Fremium max labor: {0}", _labor["fremium_labor_maximum"]);
+            _log.Info("Premium max labor: {0}", _labor["premium_labor_maximum"]);
+            _log.Info("Fremium labor gain: {0}", _labor["fremium_labor_change"]);
+            _log.Info("Premium labor gain: {0}", _labor["premium_labor_change"]);
+            _log.Info("Fremium offline gain: {0}", _labor["fremium_offline_tick"]);
+            _log.Info("Premium offline gain: {0}", _labor["premium_offline_tick"]);
+
             LaborPowerTickStart();
         }
 
@@ -34,34 +59,56 @@ namespace AAEmu.Game.Core.Managers
             _log.Warn("LaborPowerTickStart: Started");
 
             var lpTickStartTask = new LaborPowerTickStartTask();
-            TaskManager.Instance.Schedule(lpTickStartTask, TimeSpan.FromMinutes(Delay), TimeSpan.FromMinutes(Delay));
+            TaskManager.Instance.Schedule(lpTickStartTask, TimeSpan.FromMinutes(_labor["minute_tick"]), TimeSpan.FromMinutes(_labor["minute_tick"]));
         }
+
         public void LaborPowerTick()
         {
+            _log.Info("Labor tick in progress.");
             var connections = GameConnectionTable.Instance.GetConnections();
             foreach (var connection in connections)
             {
                 foreach (var character in connection.Characters)
                 {
-                    if (!character.Value.IsOnline)
+                    var payment = connection.Payment.Method;
+                    short up_limit = 0;
+                    short lp_change = 0;
+                    if (payment == PaymentMethodType.None) {
+                        if (!character.Value.IsOnline)
+                        {
+                            if (_labor["fremium_offline_tick"] == 0)
+                                continue;
+                        }
+                        up_limit = _labor["fremium_labor_maximum"];
+                        lp_change = _labor["fremium_labor_change"];
+                    }
+                    else if (payment == PaymentMethodType.Premium)
                     {
+                        if (!character.Value.IsOnline)
+                        {
+                            if (_labor["premium_offline_tick"] == 0)
+                                continue;
+                        }
+                        up_limit = _labor["premium_labor_maximum"];
+                        lp_change = _labor["premium_labor_change"];
+                    }
+
+                    if (character.Value.LaborPower >= up_limit)
+                    {
+                        _log.Info("No need to increase Labor Points for {0} as they reached the limit {1}", character.Value.Name, up_limit);
                         continue;
                     }
-                    if (character.Value.LaborPower >= UpLimit)
+					
+                    var change = (short)(up_limit - character.Value.LaborPower);
+                    if (change >= lp_change)
                     {
-                        _log.Warn("No need to increase Labor Point, since they reached the limit {0} for Char: {1}", UpLimit, character.Value.Name);
-                        continue;
-                    }
-                    var change = (short)(UpLimit - character.Value.LaborPower);
-                    if (change >= LpChange)
-                    {
-                        _log.Warn("Added {0} Labor Point for Char: {1}", LpChange, character.Value.Name);
+                        _log.Info("Added {0} Labor Points for {1}", lp_change, character.Value.Name);
                         character.Value.LaborPowerModified = DateTime.Now;
-                        character.Value.ChangeLabor(LpChange, 0);
+                        character.Value.ChangeLabor(lp_change, 0);
                     }
                     else if (change != 0)
                     {
-                        _log.Warn("Added {0} Labor Point for Char: {1}", change, character.Value.Name);
+                        _log.Info("Added {0} Labor Points for {1}", change, character.Value.Name);
                         character.Value.LaborPowerModified = DateTime.Now;
                         character.Value.ChangeLabor(change, 0);
                     }

--- a/AAEmu.Game/Data/labor.json
+++ b/AAEmu.Game/Data/labor.json
@@ -1,0 +1,9 @@
+{
+    "minute_tick": 1,
+    "premium_offline_tick": 1,
+    "fremium_offline_tick": 0,
+    "fremium_labor_change": 5,
+    "premium_labor_change": 10,
+    "fremium_labor_maximum": 2000,
+    "premium_labor_maximum": 5000
+}


### PR DESCRIPTION
- Edited AAEmu.Game/Core/Managers/LaborPowerManager.cs
- Added AAEmu.Game/Data/labor.json

Awards fremium default 5 labor
Awards premium default 10 labor
Fremium labor cap is 2000
Premium labor cap is 5000 (probably need the buff in order to change the tooltip)
Ready for an offline user list to award premium users offline
Premium and fremium can be disallowed offline labor gains
