### PR TITLE
[All] General Code Cleanup

### DIFF
--- a/AAEmu.Commons/Network/Core/Session.cs
+++ b/AAEmu.Commons/Network/Core/Session.cs
@@ -11,7 +11,7 @@ namespace AAEmu.Commons.Network.Core
         public BaseProtocolHandler ProtocolHandler { get; private set; }
         public IPEndPoint RemoteEndPoint { get; set; }
         private readonly Dictionary<string, object> _attributes = new Dictionary<string, object>();
-        public uint Id { get; set; }
+        public uint SessionId { get; set; }
         public IPAddress Ip { get; private set; }
         
         public Client Client { get; set; }
@@ -26,13 +26,13 @@ namespace AAEmu.Commons.Network.Core
             Client = client;
             ProtocolHandler = client.GetHandler();
             Ip = client.Endpoint.Address;
-            Id = (uint) client.Endpoint.GetHashCode();
+            SessionId = (uint) client.Endpoint.GetHashCode();
         }
 
         protected override void OnConnected()
         {
             RemoteEndPoint = (IPEndPoint)Socket.RemoteEndPoint;
-            Id = (uint)RemoteEndPoint.GetHashCode();
+            SessionId = (uint)RemoteEndPoint.GetHashCode();
             Ip = RemoteEndPoint.Address;
             ProtocolHandler?.OnConnect(this);
         }

--- a/AAEmu.Commons/Network/PacketStream.cs
+++ b/AAEmu.Commons/Network/PacketStream.cs
@@ -771,7 +771,7 @@ namespace AAEmu.Commons.Network
                 temp.Write(Convert.ToInt16(values.Y * 32767f));
                 temp.Write(Convert.ToInt16(values.Z * 32767f));
             }
-            catch (Exception e)
+            catch
             {
                 var res = new byte[6];
                 temp.Write(res);

--- a/AAEmu.Game/AAEmu.Game.csproj
+++ b/AAEmu.Game/AAEmu.Game.csproj
@@ -55,12 +55,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Reference Include="DotNet.Config">
-        <HintPath>DotNet.Config.dll</HintPath>
-      </Reference>
-    </ItemGroup>
-
-    <ItemGroup>
       <None Update="Scripts\Commands\ReloadConfigs.cs">
         <LinkBase>$([MSBuild]::EnsureTrailingSlash(%(LinkBase)))</LinkBase>
       </None>

--- a/AAEmu.Game/Core/Managers/AIManager.cs
+++ b/AAEmu.Game/Core/Managers/AIManager.cs
@@ -42,7 +42,7 @@ namespace AAEmu.Game.Core.Managers
                     }
                     catch (Exception e)
                     {
-                        _log.Error("{0}", e);
+                        _log.Error(e,"{0}", e.Message);
                     }
                 }
             }

--- a/AAEmu.Game/Core/Managers/TickManager.cs
+++ b/AAEmu.Game/Core/Managers/TickManager.cs
@@ -36,7 +36,9 @@ namespace AAEmu.Game.Core.Managers
 
         public void Initialize()
         {
-            new Thread(() => TickLoop()).Start();
+            TickThread = new Thread(() => TickLoop());
+            TickThread.Start();
+            // new Thread(() => TickLoop()).Start();
         }
 
         public void Stop()

--- a/AAEmu.Game/Core/Managers/TransferManager.cs
+++ b/AAEmu.Game/Core/Managers/TransferManager.cs
@@ -158,10 +158,10 @@ namespace AAEmu.Game.Core.Managers
                 {
 
                     var doodads = tr.Bounded.AttachedDoodads.ToArray();
-                    for (var i = 0; i < doodads.Length; i += 30)
+                    for (var i = 0; i < doodads.Length; i += SCDoodadsCreatedPacket.MaxCountPerPacket)
                     {
                         var count = doodads.Length - i;
-                        var temp = new Doodad[count <= 30 ? count : 30];
+                        var temp = new Doodad[count <= SCDoodadsCreatedPacket.MaxCountPerPacket ? count : SCDoodadsCreatedPacket.MaxCountPerPacket];
                         Array.Copy(doodads, i, temp, 0, temp.Length);
                         character.SendPacket(new SCDoodadsCreatedPacket(temp));
                     }
@@ -172,10 +172,10 @@ namespace AAEmu.Game.Core.Managers
             if (tr.AttachedDoodads.Count > 0)
             {
                 var doodads = tr.AttachedDoodads.ToArray();
-                for (var i = 0; i < doodads.Length; i += 30)
+                for (var i = 0; i < doodads.Length; i += SCDoodadsCreatedPacket.MaxCountPerPacket)
                 {
                     var count = doodads.Length - i;
-                    var temp = new Doodad[count <= 30 ? count : 30];
+                    var temp = new Doodad[count <= SCDoodadsCreatedPacket.MaxCountPerPacket ? count : SCDoodadsCreatedPacket.MaxCountPerPacket];
                     Array.Copy(doodads, i, temp, 0, temp.Length);
                     character.SendPacket(new SCDoodadsCreatedPacket(temp));
                 }

--- a/AAEmu.Game/Core/Managers/World/WorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/WorldManager.cs
@@ -707,10 +707,10 @@ namespace AAEmu.Game.Core.Managers.World
             }
 
             var doodads = WorldManager.Instance.GetAround<Doodad>(character, 1000f).ToArray();
-            for (var i = 0; i < doodads.Length; i += 30)
+            for (var i = 0; i < doodads.Length; i += SCDoodadsCreatedPacket.MaxCountPerPacket)
             {
                 var count = doodads.Length - i;
-                var temp = new Doodad[count <= 30 ? count : 30];
+                var temp = new Doodad[count <= SCDoodadsCreatedPacket.MaxCountPerPacket ? count : SCDoodadsCreatedPacket.MaxCountPerPacket];
                 Array.Copy(doodads, i, temp, 0, temp.Length);
                 character.SendPacket(new SCDoodadsCreatedPacket(temp));
             }
@@ -721,6 +721,11 @@ namespace AAEmu.Game.Core.Managers.World
             return _characters.Values.ToList();
         }
 
+        public List<Npc> GetAllNpcs()
+        {
+            return _npcs.Values.ToList();
+        }
+        
         public AreaShape GetAreaShapeById(uint id)
         {
             if (_areaShapes.TryGetValue(id, out AreaShape res))

--- a/AAEmu.Game/Core/Network/Connections/GameConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/GameConnection.cs
@@ -27,7 +27,7 @@ namespace AAEmu.Game.Core.Network.Connections
     {
         private Session _session;
 
-        public uint Id => _session.Id;
+        public uint Id => _session.SessionId;
         public uint AccountId { get; set; }
         public IPAddress Ip => _session.Ip;
         public PacketStream LastPacket { get; set; }

--- a/AAEmu.Game/Core/Network/Connections/LoginConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/LoginConnection.cs
@@ -14,7 +14,7 @@ namespace AAEmu.Game.Core.Network.Connections
         private Session _session; 
         private Client _client;
 
-        public uint Id => _session.Id;
+        public uint Id => _session.SessionId;
         public IPAddress Ip => _session.Ip;
 
         public bool Block { get; set; }

--- a/AAEmu.Game/Core/Network/Connections/StreamConnection.cs
+++ b/AAEmu.Game/Core/Network/Connections/StreamConnection.cs
@@ -14,7 +14,7 @@ namespace AAEmu.Game.Core.Network.Connections
         private int _requestId;
         private readonly Dictionary<int, Doodad[]> _requests;
 
-        public uint Id => _session.Id;
+        public uint Id => _session.SessionId;
         public IPAddress Ip => _session.Ip;
         public GameConnection GameConnection { get; set; }
         public PacketStream LastPacket { get; set; }

--- a/AAEmu.Game/Core/Network/Game/GameProtocolHandler.cs
+++ b/AAEmu.Game/Core/Network/Game/GameProtocolHandler.cs
@@ -24,7 +24,7 @@ namespace AAEmu.Game.Core.Network.Game
 
         public override void OnConnect(Session session)
         {
-            _log.Info("Connect from {0} established, session id: {1}", session.Ip.ToString(), session.Id.ToString());
+            _log.Info("Connect from {0} established, session id: {1}", session.Ip.ToString(), session.SessionId.ToString());
             try
             {
                 var con = new GameConnection(session);
@@ -42,7 +42,7 @@ namespace AAEmu.Game.Core.Network.Game
         {
             try
             {
-                var con = GameConnectionTable.Instance.GetConnection(session.Id);
+                var con = GameConnectionTable.Instance.GetConnection(session.SessionId);
                 if (con != null)
                 {
                     if (con.ActiveChar != null)
@@ -53,7 +53,7 @@ namespace AAEmu.Game.Core.Network.Game
                     }
                     con.OnDisconnect();
                     StreamManager.Instance.RemoveToken(con.Id);
-                    GameConnectionTable.Instance.RemoveConnection(session.Id);
+                    GameConnectionTable.Instance.RemoveConnection(session.SessionId);
                 }
             }
             catch (Exception e)
@@ -69,7 +69,7 @@ namespace AAEmu.Game.Core.Network.Game
         {
             try
             {
-                var connection = GameConnectionTable.Instance.GetConnection(session.Id);
+                var connection = GameConnectionTable.Instance.GetConnection(session.SessionId);
                 if(connection == null)
                     return;
                 OnReceive(connection, buf, bytes);

--- a/AAEmu.Game/Core/Network/Login/LoginProtocolHandler.cs
+++ b/AAEmu.Game/Core/Network/Login/LoginProtocolHandler.cs
@@ -23,7 +23,7 @@ namespace AAEmu.Game.Core.Network.Login
 
         public override void OnConnect(Session session)
         {
-            _log.Info("Connect to {0} established, session id: {1}", session.Ip.ToString(), session.Id.ToString(CultureInfo.InvariantCulture));
+            _log.Info("Connect to {0} established, session id: {1}", session.Ip.ToString(), session.SessionId.ToString(CultureInfo.InvariantCulture));
             var con = new LoginConnection(session);
             con.OnConnect();
             LoginNetwork.Instance.SetConnection(con);

--- a/AAEmu.Game/Core/Network/Stream/StreamProtocolHandler.cs
+++ b/AAEmu.Game/Core/Network/Stream/StreamProtocolHandler.cs
@@ -21,7 +21,7 @@ namespace AAEmu.Game.Core.Network.Stream
 
         public override void OnConnect(Session session)
         {
-            _log.Info("Connect from {0} established, session id: {1}", session.Ip.ToString(), session.Id.ToString());
+            _log.Info("Connect from {0} established, session id: {1}", session.Ip.ToString(), session.SessionId.ToString());
             try
             {
                 var con = new StreamConnection(session);
@@ -39,9 +39,9 @@ namespace AAEmu.Game.Core.Network.Stream
         {
             try
             {
-                var con = StreamConnectionTable.Instance.GetConnection(session.Id);
+                var con = StreamConnectionTable.Instance.GetConnection(session.SessionId);
                 if (con != null)
-                    StreamConnectionTable.Instance.RemoveConnection(session.Id);
+                    StreamConnectionTable.Instance.RemoveConnection(session.SessionId);
             }
             catch (Exception e)
             {
@@ -56,7 +56,7 @@ namespace AAEmu.Game.Core.Network.Stream
         {
             try
             {
-                var connection = StreamConnectionTable.Instance.GetConnection(session.Id);
+                var connection = StreamConnectionTable.Instance.GetConnection(session.SessionId);
                 if (connection == null)
                     return;
                 OnReceive(connection, buf, bytes);

--- a/AAEmu.Game/Core/Packets/C2G/CSStartInteractionPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartInteractionPacket.cs
@@ -9,7 +9,6 @@ using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.StaticValues;
 using AAEmu.Game.Models.Tasks.Skills;
-using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Core.Packets.C2G
 {

--- a/AAEmu.Game/Core/Packets/G2C/SCCoolDownPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCCoolDownPacket.cs
@@ -7,7 +7,7 @@ namespace AAEmu.Game.Core.Packets.G2C
     public class SCCooldownsPacket : GamePacket
     {
         private Character _chr;
-        private uint _skillId;
+        //private uint _skillId;
         private int _skillCount;
         private int _tagCount;
 

--- a/AAEmu.Game/Core/Packets/G2C/SCDoodadsCreatedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDoodadsCreatedPacket.cs
@@ -8,6 +8,7 @@ namespace AAEmu.Game.Core.Packets.G2C
     public class SCDoodadsCreatedPacket : GamePacket
     {
         private readonly Doodad[] _doodads;
+        public const int MaxCountPerPacket = 30; // Suggested Maximum Size
 
         public SCDoodadsCreatedPacket(Doodad[] doodads) : base(SCOffsets.SCDoodadsCreatedPacket, 1)
         {
@@ -16,7 +17,7 @@ namespace AAEmu.Game.Core.Packets.G2C
 
         public override PacketStream Write(PacketStream stream)
         {
-            stream.Write((byte)_doodads.Length); // TODO max length 30
+            stream.Write((byte)_doodads.Length);
             foreach (var doodad in _doodads)
                 doodad.Write(stream);
 

--- a/AAEmu.Game/Core/Packets/G2C/SCDoodadsRemovedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDoodadsRemovedPacket.cs
@@ -7,6 +7,7 @@ namespace AAEmu.Game.Core.Packets.G2C
     {
         private readonly bool _last;
         private readonly uint[] _ids;
+        public const int MaxCountPerPacket = 400; // Suggested Maximum Size
 
         public SCDoodadsRemovedPacket(bool last, uint[] ids) : base(SCOffsets.SCDoodadsRemovedPacket, 1)
         {
@@ -16,7 +17,7 @@ namespace AAEmu.Game.Core.Packets.G2C
 
         public override PacketStream Write(PacketStream stream)
         {
-            stream.Write((ushort) _ids.Length); // TODO max 400 elements
+            stream.Write((ushort) _ids.Length);
             stream.Write(_last);
             foreach (var id in _ids)
             {

--- a/AAEmu.Game/Core/Packets/G2C/SCSkillCooldownResetPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCSkillCooldownResetPacket.cs
@@ -19,6 +19,7 @@ namespace AAEmu.Game.Core.Packets.G2C
             _skillId = skillId;
             _tagId = tagId;
             _chr = chr;
+            _gcd = gcd;
         }
 
         public override PacketStream Write(PacketStream stream)

--- a/AAEmu.Game/Core/Packets/G2C/SCSlaveEquipmentChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCSlaveEquipmentChangedPacket.cs
@@ -6,17 +6,18 @@ namespace AAEmu.Game.Core.Packets.G2C
 {
     public class SCSlaveEquipmentChangedPacket : GamePacket
     {
-        private SlaveEquipment slaveEquipment;
-        private bool success;
+        private SlaveEquipment _slaveEquipment;
+        private bool _success;
 
         public SCSlaveEquipmentChangedPacket(SlaveEquipment slaveEquipment, bool success) : base(SCOffsets.SCSlaveEquipmentChangedPacket, 1)
         {
-
+            _slaveEquipment = slaveEquipment;
+            _success = success;
         }
 
         public override PacketStream Write(PacketStream stream)
         {
-            // TODO coming soon!
+            // TODO: Implement SCSlaveEquipmentChangedPacket.Write()
             return stream;
         }
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCUnitsRemovedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCUnitsRemovedPacket.cs
@@ -6,6 +6,7 @@ namespace AAEmu.Game.Core.Packets.G2C
     public class SCUnitsRemovedPacket : GamePacket
     {
         private readonly uint[] _ids;
+        public const int MaxCountPerPacket = 500 ; // Suggested Maximum Size (originally 300)
 
         public SCUnitsRemovedPacket(uint[] ids) : base(SCOffsets.SCUnitsRemovedPacket, 1)
         {
@@ -14,7 +15,7 @@ namespace AAEmu.Game.Core.Packets.G2C
 
         public override PacketStream Write(PacketStream stream)
         {
-            stream.Write((ushort) _ids.Length); // TODO max 300 units
+            stream.Write((ushort) _ids.Length);
             foreach (var id in _ids)
                 stream.WriteBc(id);
 

--- a/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
+++ b/AAEmu.Game/Models/Game/AI/v2/Behaviors/BaseCombatBehavior.cs
@@ -132,7 +132,10 @@ namespace AAEmu.Game.Models.Game.AI.v2.Behaviors
             {
                 _delayEnd = DateTime.Now.AddSeconds(_nextTimeToDelay);
             }
-            catch (Exception e){}
+            catch
+            {
+                
+            }
         }
         
         // Check if can pick a new skill (delay, already casting)

--- a/AAEmu.Game/Models/Game/Char/Inventory.cs
+++ b/AAEmu.Game/Models/Game/Char/Inventory.cs
@@ -336,7 +336,7 @@ namespace AAEmu.Game.Models.Game.Char
                 mainHandWeapon = Equipment.GetItemBySlot((int)EquipmentItemSlot.Mainhand);
                 offHandWeapon = Equipment.GetItemBySlot((int)EquipmentItemSlot.Offhand);
                 // Check for equipping weapons by swapping (and if it's a 2-handed one)
-                var isFromNon2HWeapon = false;
+                //var isFromNon2HWeapon = false;
                 var isFrom2H = false;
                 if ((fromItem != null) && (fromItem.Template is WeaponTemplate weaponFrom))
                 {
@@ -349,14 +349,14 @@ namespace AAEmu.Game.Models.Game.Char
                         case EquipmentItemSlotType.Offhand:
                         case EquipmentItemSlotType.Shield:
                         case EquipmentItemSlotType.OneHanded:
-                            isFromNon2HWeapon = true;
+                            //isFromNon2HWeapon = true;
                             break;
                         default:
                             break;
                     }
                 }
 
-                var isToNon2HWeapon = false;
+                //var isToNon2HWeapon = false;
                 var isTo2H = false;
                 if ((itemInTargetSlot != null) && (itemInTargetSlot.Template is WeaponTemplate weaponTo))
                 {
@@ -369,7 +369,7 @@ namespace AAEmu.Game.Models.Game.Char
                         case EquipmentItemSlotType.Offhand:
                         case EquipmentItemSlotType.Shield:
                         case EquipmentItemSlotType.OneHanded:
-                            isToNon2HWeapon = true;
+                            //isToNon2HWeapon = true;
                             break;
                         default:
                             break;

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadFunc.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadFunc.cs
@@ -22,7 +22,8 @@ namespace AAEmu.Game.Models.Game.DoodadObj
         public int Count { get; set; }
 
         //This acts as an interface/relay for doodad function chain
-        public async void Use(Unit caster, Doodad owner, uint skillId, int nextPhase = 0)
+        //public async void Use(Unit caster, Doodad owner, uint skillId, int nextPhase = 0)
+        public void Use(Unit caster, Doodad owner, uint skillId, int nextPhase = 0)
         {
             owner.ToPhaseAndUse = false;
             var template = DoodadManager.Instance.GetFuncTemplate(FuncId, FuncType);

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncClimateReact.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncClimateReact.cs
@@ -10,7 +10,8 @@ namespace AAEmu.Game.Models.Game.DoodadObj.Funcs
     {
         public uint NextPhase { get; set; }
 
-        public override async void Use(Unit caster, Doodad owner, uint skillId, int nextPhase = 0)
+        //public override async void Use(Unit caster, Doodad owner, uint skillId, int nextPhase = 0)
+        public override void Use(Unit caster, Doodad owner, uint skillId, int nextPhase = 0)
         {
             _log.Debug("DoodadFuncClimateReact");
 

--- a/AAEmu.Game/Models/Game/Housing/House.cs
+++ b/AAEmu.Game/Models/Game/Housing/House.cs
@@ -185,10 +185,10 @@ namespace AAEmu.Game.Models.Game.Housing
             character.SendPacket(new SCHouseStatePacket(this));
 
             var doodads = AttachedDoodads.ToArray();
-            for (var i = 0; i < doodads.Length; i += 30)
+            for (var i = 0; i < doodads.Length; i += SCDoodadsCreatedPacket.MaxCountPerPacket)
             {
                 var count = doodads.Length - i;
-                var temp = new Doodad[count <= 30 ? count : 30];
+                var temp = new Doodad[count <= SCDoodadsCreatedPacket.MaxCountPerPacket ? count : SCDoodadsCreatedPacket.MaxCountPerPacket];
                 Array.Copy(doodads, i, temp, 0, temp.Length);
                 character.SendPacket(new SCDoodadsCreatedPacket(temp));
             }
@@ -208,12 +208,12 @@ namespace AAEmu.Game.Models.Game.Housing
             for (var i = 0; i < AttachedDoodads.Count; i++)
                 doodadIds[i] = AttachedDoodads[i].ObjId;
 
-            for (var i = 0; i < doodadIds.Length; i += 400)
+            for (var i = 0; i < doodadIds.Length; i += SCDoodadsRemovedPacket.MaxCountPerPacket)
             {
-                var offset = i * 400;
+                var offset = i * SCDoodadsRemovedPacket.MaxCountPerPacket;
                 var length = doodadIds.Length - offset;
-                var last = length <= 400;
-                var temp = new uint[last ? length : 400];
+                var last = length <= SCDoodadsRemovedPacket.MaxCountPerPacket;
+                var temp = new uint[last ? length : SCDoodadsRemovedPacket.MaxCountPerPacket];
                 Array.Copy(doodadIds, offset, temp, 0, temp.Length);
                 character.SendPacket(new SCDoodadsRemovedPacket(last, temp));
             }

--- a/AAEmu.Game/Models/Game/Skills/Effects/ManaBurnEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/ManaBurnEffect.cs
@@ -29,8 +29,8 @@ namespace AAEmu.Game.Models.Game.Skills.Effects
             min += BaseMin;
             max += BaseMax;
 
-            var levelMin = 0.0f;
-            var levelMax = 0.0f;
+            //var levelMin = 0.0f;
+            //var levelMax = 0.0f;
             
             var lvlMd = caster.LevelDps * LevelMd;
             // Hack null-check on skill

--- a/AAEmu.Game/Models/Game/Skills/Plots/PlotEventCondition.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/PlotEventCondition.cs
@@ -21,7 +21,7 @@ namespace AAEmu.Game.Models.Game.Skills.Plots
                 return true;
 
             if (NotifyFailure)
-                ;//Maybe do something here?
+                return false;//Maybe do something here?
             
             return false;
 

--- a/AAEmu.Game/Models/Game/Skills/SkillControllers/SkillController.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillControllers/SkillController.cs
@@ -40,17 +40,13 @@ namespace AAEmu.Game.Models.Game.Skills.SkillControllers
             switch ((SkillControllerKind)template.KindId)
             {
                 case SkillControllerKind.Floating:
-                    return null;//Todo
-                    break;
+                    return null; // TODO: Add Floating (telekinesis, bubble ?)
                 case SkillControllerKind.Wandering:
-                    return null;//Todo
-                    break;
+                    return null;// TODO: Add Wandering (Fear ?)
                 case SkillControllerKind.Leap:
                     return new LeapSkillController(template, owner, target);
-                    break;
                 default:
                     return null;
-                    break;
             }
         }
     }

--- a/AAEmu.Game/Models/Game/Units/Route/Simulation.cs
+++ b/AAEmu.Game/Models/Game/Units/Route/Simulation.cs
@@ -45,7 +45,7 @@ namespace AAEmu.Game.Models.Game.Units.Route
         public bool MoveToForward { get; set; }           // направление движения да - вперед, нет - назад
         public bool runningMode { get; set; } = false;    // режим движения да - бежать, нет - идти
         public int MoveStepIndex { get; set; }            // текущ. чекпоинт (куда бежим сейчас)
-        int oldTime, chkTime;
+        //int oldTime, chkTime;
         float oldX, oldY, oldZ;
         //*******************************************************
         public string RecordFilesPath = @"./bin/debug/netcoreapp2.2/Data/Path/";       // путь где хранятся наши файлы
@@ -295,10 +295,10 @@ namespace AAEmu.Game.Models.Game.Units.Route
                 oldX = Position.X;
                 oldY = Position.Y;
                 oldZ = Position.Z;
-                oldTime = 0;
+                //oldTime = 0;
             }
             RepeatMove(this, npc, Position.X, Position.Y, Position.Z);
-            chkTime = 0;
+            //chkTime = 0;
         }
 
         public void MoveTo(Simulation sim, Npc npc, float TargetX, float TargetY, float TargetZ)

--- a/AAEmu.Game/Models/Game/Units/Transfer.cs
+++ b/AAEmu.Game/Models/Game/Units/Transfer.cs
@@ -440,12 +440,12 @@ namespace AAEmu.Game.Models.Game.Units
                 doodadIds[i] = AttachedDoodads[i].ObjId;
             }
 
-            for (var i = 0; i < doodadIds.Length; i += 400)
+            for (var i = 0; i < doodadIds.Length; i += SCDoodadsRemovedPacket.MaxCountPerPacket)
             {
-                var offset = i * 400;
+                var offset = i * SCDoodadsRemovedPacket.MaxCountPerPacket;
                 var length = doodadIds.Length - offset;
-                var last = length <= 400;
-                var temp = new uint[last ? length : 400];
+                var last = length <= SCDoodadsRemovedPacket.MaxCountPerPacket;
+                var temp = new uint[last ? length : SCDoodadsRemovedPacket.MaxCountPerPacket];
                 Array.Copy(doodadIds, offset, temp, 0, temp.Length);
                 character.SendPacket(new SCDoodadsRemovedPacket(last, temp));
             }

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -212,7 +212,7 @@ namespace AAEmu.Game.Models.Game.Units
             Cooldowns = new UnitCooldowns();
         }
 
-        public virtual void SetPosition(float x, float y, float z, sbyte rotationX, sbyte rotationY, sbyte rotationZ)
+        public override void SetPosition(float x, float y, float z, sbyte rotationX, sbyte rotationY, sbyte rotationZ)
         {
             var moved = !Position.X.Equals(x) || !Position.Y.Equals(y) || !Position.Z.Equals(z);
             if (moved)

--- a/AAEmu.Game/Models/Game/World/Region.cs
+++ b/AAEmu.Game/Models/Game/World/Region.cs
@@ -145,10 +145,10 @@ namespace AAEmu.Game.Models.Game.World
                     }
                 }
                 var doodads = GetList(new List<Doodad>(), obj.ObjId).ToArray();
-                for (var i = 0; i < doodads.Length; i += 30)
+                for (var i = 0; i < doodads.Length; i += SCDoodadsCreatedPacket.MaxCountPerPacket)
                 {
                     var count = doodads.Length - i;
-                    var temp = new Doodad[count <= 30 ? count : 30];
+                    var temp = new Doodad[count <= SCDoodadsCreatedPacket.MaxCountPerPacket ? count : SCDoodadsCreatedPacket.MaxCountPerPacket];
                     Array.Copy(doodads, i, temp, 0, temp.Length);
                     character.SendPacket(new SCDoodadsCreatedPacket(temp));
                 }
@@ -179,19 +179,19 @@ namespace AAEmu.Game.Models.Game.World
                     }
                 }
 
-                for (var offset = 0; offset < unitIds.Length; offset += 500)
+                for (var offset = 0; offset < unitIds.Length; offset += SCUnitsRemovedPacket.MaxCountPerPacket)
                 {
                     var length = unitIds.Length - offset;
-                    var temp = new uint[length > 500 ? 500 : length];
+                    var temp = new uint[length > SCUnitsRemovedPacket.MaxCountPerPacket ? SCUnitsRemovedPacket.MaxCountPerPacket : length];
                     Array.Copy(unitIds, offset, temp, 0, temp.Length);
                     character1.SendPacket(new SCUnitsRemovedPacket(temp));
                 }
                 var doodadIds = GetListId<Doodad>(new List<uint>(), character1.ObjId).ToArray();
-                for (var offset = 0; offset < doodadIds.Length; offset += 400)
+                for (var offset = 0; offset < doodadIds.Length; offset += SCDoodadsRemovedPacket.MaxCountPerPacket)
                 {
                     var length = doodadIds.Length - offset;
-                    var last = length <= 400;
-                    var temp = new uint[last ? length : 400];
+                    var last = length <= SCDoodadsRemovedPacket.MaxCountPerPacket;
+                    var temp = new uint[last ? length : SCDoodadsRemovedPacket.MaxCountPerPacket];
                     Array.Copy(doodadIds, offset, temp, 0, temp.Length);
                     character1.SendPacket(new SCDoodadsRemovedPacket(last, temp));
                 }

--- a/AAEmu.Game/Models/Tasks/Doodads/DoodadFuncFinalTask.cs
+++ b/AAEmu.Game/Models/Tasks/Doodads/DoodadFuncFinalTask.cs
@@ -10,7 +10,6 @@ namespace AAEmu.Game.Models.Tasks.Doodads
     public class DoodadFuncFinalTask : DoodadFuncTask
     {
         private bool _respawn;
-        private Doodad _owner;
         private int _delay;
         private DateTime? _respawnTime;
 

--- a/AAEmu.Login/Core/Network/Connections/InternalConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/InternalConnection.cs
@@ -10,7 +10,7 @@ namespace AAEmu.Login.Core.Network.Connections
     {
         private Session _session;
 
-        public uint Id => _session.Id;
+        public uint Id => _session.SessionId;
         public IPAddress Ip => _session.Ip;
         public GameServer GameServer { get; set; }
         public bool Block { get; set; }

--- a/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
@@ -12,7 +12,7 @@ namespace AAEmu.Login.Core.Network.Connections
     {
         private Session _session;
 
-        public uint Id => _session.Id;
+        public uint Id => _session.SessionId;
         public IPAddress Ip => _session.Ip;
         public InternalConnection InternalConnection { get; set; }
         public PacketStream LastPacket { get; set; }

--- a/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Internal/InternalProtocolHandler.cs
@@ -24,7 +24,7 @@ namespace AAEmu.Login.Core.Network.Internal
         public override void OnConnect(Session session)
         {
             _log.Info("GameServer from {0} connected, session id: {1}", session.Ip.ToString(),
-                session.Id.ToString(CultureInfo.InvariantCulture));
+                session.SessionId.ToString(CultureInfo.InvariantCulture));
             var con = new InternalConnection(session);
             con.OnConnect();
             InternalConnectionTable.Instance.AddConnection(con);
@@ -36,12 +36,12 @@ namespace AAEmu.Login.Core.Network.Internal
             var gsId = session.GetAttribute("gsId");
             if (gsId != null)
                 GameController.Instance.Remove((byte) gsId);
-            InternalConnectionTable.Instance.RemoveConnection(session.Id);
+            InternalConnectionTable.Instance.RemoveConnection(session.SessionId);
         }
 
         public override void OnReceive(Session session, byte[] buf, int bytes)
         {
-            var connection = InternalConnectionTable.Instance.GetConnection(session.Id);
+            var connection = InternalConnectionTable.Instance.GetConnection(session.SessionId);
             var stream = new PacketStream();
             if (connection.LastPacket != null)
             {

--- a/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
@@ -21,7 +21,7 @@ namespace AAEmu.Login.Core.Network.Login
 
         public override void OnConnect(Session session)
         {
-            _log.Info("Connect from {0} established, session id: {1}", session.Ip.ToString(), session.Id.ToString());
+            _log.Info("Connect from {0} established, session id: {1}", session.Ip.ToString(), session.SessionId.ToString());
             try
             {
                 var con = new LoginConnection(session);
@@ -39,9 +39,9 @@ namespace AAEmu.Login.Core.Network.Login
         {
             try
             {
-                var con = LoginConnectionTable.Instance.GetConnection(session.Id);
+                var con = LoginConnectionTable.Instance.GetConnection(session.SessionId);
                 if (con != null)
-                    LoginConnectionTable.Instance.RemoveConnection(session.Id);
+                    LoginConnectionTable.Instance.RemoveConnection(session.SessionId);
             }
             catch (Exception e)
             {
@@ -56,7 +56,7 @@ namespace AAEmu.Login.Core.Network.Login
         {
             try
             {
-                var connection = LoginConnectionTable.Instance.GetConnection(session.Id);
+                var connection = LoginConnectionTable.Instance.GetConnection(session.SessionId);
                 if (connection == null)
                     return;
                 OnReceive(connection, buf, bytes);


### PR DESCRIPTION
- Various edits the remove compiler warnings
- Changed Session.Id to Session.SessionId to prevent hiding of base TcpSession.Id
- Added consts for maximum number of items to used for doodads create/remove and units remove packets
- Added missing GetAllNpcs that was required for the recent GM scripts update
- Added missing assignment in SCSkillCooldownResetPacket
- Removed async from DoodadFunc.Use
- Corrected Unit.SetPosition to use override instead of the virtual modifier
- Removed duplicate _owner in DoodadFunc