### PR TITLE
[Game] Boat unsummon

### DIFF
--- a/AAEmu.Game/Core/Managers/World/SpawnManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpawnManager.cs
@@ -441,6 +441,10 @@ namespace AAEmu.Game.Core.Managers.World
                             transfer.Spawner.Despawn(transfer);
                         else if (obj is Gimmick gimmick && gimmick.Spawner != null)
                             gimmick.Spawner.Despawn(gimmick);
+                        else if (obj is Slave slave) // slaves don't have a spawner, but this is used for delayed despawn of un-summoned boats
+                            slave.Delete();
+                        else if (obj is Doodad doodad2)
+                            doodad2.Delete();
                         else
                         {
                             ObjectIdManager.Instance.ReleaseId(obj.ObjId);

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/SpawnSlave.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/SpawnSlave.cs
@@ -23,7 +23,7 @@ namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects
             int value3,
             int value4)
         {
-            _log.Warn("value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
+            _log.Warn("SpawnSlave - value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
 
             var owner = (Character)caster;
             var skillData = (SkillItem)casterObj;

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -44,6 +44,13 @@ namespace AAEmu.Game.Models.Game.Units
         public uint OwnerObjId { get; set; }
         public RigidBody RigidBody { get; set; }
 
+        public Slave()
+        {
+            AttachedDoodads = new List<Doodad>();
+            AttachedSlaves = new List<Slave>();
+            AttachedCharacters = new Dictionary<AttachPointKind, Character>();
+        }
+
         #region Attributes
         [UnitAttribute(UnitAttribute.Str)]
         public int Str

--- a/AAEmu.Game/Models/Game/World/Transform/PositionAndRotation.cs
+++ b/AAEmu.Game/Models/Game/World/Transform/PositionAndRotation.cs
@@ -66,9 +66,10 @@ namespace AAEmu.Game.Models.Game.World.Transform
 
         public (short, short, short) ToRollPitchYawShorts()
         {
-            var q = Quaternion.CreateFromYawPitchRoll(Rotation.X, Rotation.Y, Rotation.Z);
-            return ((short)(q.X * short.MaxValue), (short)(q.Y * short.MaxValue),
-                (short)(q.Z * short.MaxValue));
+            var q = ToQuaternion();
+            // var q = Quaternion.CreateFromYawPitchRoll(Rotation.X, Rotation.Y, Rotation.Z);
+            // q = Quaternion.Normalize(q);
+            return ((short)(q.X * short.MaxValue), (short)(q.Y * short.MaxValue), (short)(q.Z * short.MaxValue));
         }
 
         public (sbyte, sbyte, sbyte) ToRollPitchYawSBytes()

--- a/known_issues.txt
+++ b/known_issues.txt
@@ -18,6 +18,7 @@
 - Boat physics are only working on a very basic level, collision does not really exist
   Boats will always be summoned at ocean level, this means that summoning in lakes or rivers will summon it under the ground!
   This is because of missing water container information on the server-side of things, same as object collisions
+  Also boats have a very minor stutter when they rotated at about 174.5° where they make a very slight "jump"
 
 -  
 


### PR DESCRIPTION
- Changed boat unsummoning so that the boat doesn't immediately disappear when unsummon, but instead are delayed by their summoning time.
- You can now bind to a slave's slave without crashing!
In plain English this means that you can now grab a (harpoon) canon without getting kicked from the game.