### PR TITLE
[Game] Fix: Drowning

### DIFF
--- a/AAEmu.Game/Models/Game/World/Transform/Transform.cs
+++ b/AAEmu.Game/Models/Game/World/Transform/Transform.cs
@@ -465,7 +465,7 @@ namespace AAEmu.Game.Models.Game.World.Transform
             }
             
             ResetFinalizeTransform();            
-            //_owningObject.SetPosition(Local.Position.X,Local.Position.Y,Local.Position.Z,Local.Rotation.X,Local.Rotation.Y,Local.Rotation.Z);
+            _owningObject.SetPosition(Local.Position.X,Local.Position.Y,Local.Position.Z,Local.Rotation.X,Local.Rotation.Y,Local.Rotation.Z);
         }
 
         public void ResetFinalizeTransform()


### PR DESCRIPTION
Uncommented a SetPosition in Transform that was preventing drowning (and likely other things like zone borders) to take effect.
I'm sure there was a reason this was commented in the first place by me, but I can't remember why this was.
So uncommented for now, and let it probably break some other stuff ^_^