### PR TITLE
[Game] (Shipyard) Skill Cancelling (#356)

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/CastAction.cs
+++ b/AAEmu.Game/Models/Game/Skills/CastAction.cs
@@ -28,7 +28,7 @@ namespace AAEmu.Game.Models.Game.Skills
         private ushort _tlId;
         
         public uint SkillId { get => _skillId; }
-        public uint TlId { get => _skillId; }
+        public ushort TlId { get => _tlId; }
         
         public CastSkill(uint skillId, ushort tlId)
         {

--- a/AAEmu.Game/Models/Game/Skills/Effects/CraftEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/CraftEffect.cs
@@ -23,6 +23,12 @@ namespace AAEmu.Game.Models.Game.Skills.Effects
             _log.Debug("CraftEffect, {0}", WorldInteraction);
 
             var wiGroup = WorldManager.Instance.GetWorldInteractionGroup((uint)WorldInteraction);
+            
+            // Check what skill triggered this build
+            uint usedSkill = 0;
+            if (castObj is CastSkill castSkill)
+                usedSkill = castSkill.SkillId;
+            
             if (caster is Character character)
             {
                 switch (wiGroup)
@@ -32,33 +38,47 @@ namespace AAEmu.Game.Models.Game.Skills.Effects
                         {
                             _log.Debug("[Shipyard] ID {0}, objID {1}", shipyard.ShipyardData.TemplateId, shipyard.ObjId);
 
-                            shipyard.AddBuildAction();
-                            //_log.Debug("[Shipyard] BaseAction {0}, NumAction {1}, CurrentAction {2}", shipyard.BaseAction, shipyard.NumAction, shipyard.CurrentAction);
-                            //_log.Debug("[Shipyard] AllAction {0}, CurrentStep {1}, ShipyardSteps.Count {2}", shipyard.AllAction, shipyard.CurrentStep, shipyard.Template.ShipyardSteps.Count);
-                            if (shipyard.CurrentStep == -1)
+                            var shipStep =
+                                (shipyard.CurrentAction >= 0) && (shipyard.CurrentStep < shipyard.Template.ShipyardSteps.Count)
+                                    ? shipyard.Template.ShipyardSteps[shipyard.CurrentStep]
+                                    : null;
+
+                            // Compare if the used skill (correct pack) is still valid when used
+                            if ((shipStep != null) && (usedSkill != shipStep.SkillId))
                             {
-                                shipyard.ShipyardData.Actions = shipyard.AllAction;
-                                shipyard.ShipyardData.Step = shipyard.Template.ShipyardSteps.Count;
-                                _log.Debug("[Shipyard] Actions {0}, Step {1}", shipyard.AllAction, shipyard.Template.ShipyardSteps.Count);
+                                _log.Warn("{0} tried to build a ship using the wrong skill, {1} instead of {2}", caster.Name, usedSkill, shipStep.SkillId);
+                                source.Skill.Cancelled = true;
                             }
                             else
                             {
-                                shipyard.ShipyardData.Actions = shipyard.CurrentAction;
-                                shipyard.ShipyardData.Step = shipyard.CurrentStep;
-                                _log.Debug("[Shipyard] Actions {0}, Step {1}", shipyard.CurrentAction, shipyard.CurrentStep);
+                                shipyard.AddBuildAction();
+                                //_log.Debug("[Shipyard] BaseAction {0}, NumAction {1}, CurrentAction {2}", shipyard.BaseAction, shipyard.NumAction, shipyard.CurrentAction);
+                                //_log.Debug("[Shipyard] AllAction {0}, CurrentStep {1}, ShipyardSteps.Count {2}", shipyard.AllAction, shipyard.CurrentStep, shipyard.Template.ShipyardSteps.Count);
+                                if (shipyard.CurrentStep == -1)
+                                {
+                                    shipyard.ShipyardData.Actions = shipyard.AllAction;
+                                    shipyard.ShipyardData.Step = shipyard.Template.ShipyardSteps.Count;
+                                    _log.Debug("[Shipyard] Actions {0}, Step {1}", shipyard.AllAction, shipyard.Template.ShipyardSteps.Count);
+                                }
+                                else
+                                {
+                                    shipyard.ShipyardData.Actions = shipyard.CurrentAction;
+                                    shipyard.ShipyardData.Step = shipyard.CurrentStep;
+                                    _log.Debug("[Shipyard] Actions {0}, Step {1}", shipyard.CurrentAction, shipyard.CurrentStep);
+                                }
+
+                                character.BroadcastPacket(new SCShipyardStatePacket(shipyard.ShipyardData), true);
+                                character.Craft.EndCraft();
                             }
-                            character.BroadcastPacket(new SCShipyardStatePacket(shipyard.ShipyardData), true);
                         }
-                        character.Craft.EndCraft();
+                        else
+                        {
+                            character.Craft.EndCraft();
+                        }
                         break;
                     case WorldInteractionGroup.Collect:
                         break;
                     case WorldInteractionGroup.Building when target is House house:
-                        // Check what skill triggered this build
-                        uint usedSkill = 0;
-                        if (castObj is CastSkill castSkill)
-                            usedSkill = castSkill.SkillId;
-
                         // Get the house's current build step
                         var currentStep =
                             (house.CurrentAction >= 0) && (house.CurrentStep < house.Template.BuildSteps.Count)
@@ -71,34 +91,34 @@ namespace AAEmu.Game.Models.Game.Skills.Effects
                             _log.Warn("{0} tried to building using the wrong skill, {1} instead of {2}", caster.Name, usedSkill, currentStep.SkillId);
                             character.SkillTask.Skill.Cancelled = true ;
                             character.InterruptSkills();
-                            break;
                         }
-        
-                        // When done, set step to -1
-                        if (house.Template.BuildSteps.Count == 0)
-                            house.CurrentStep = -1;
                         else
-                            house.AddBuildAction();
-
-                        // Send build packet
-                        character.BroadcastPacket(
-                            new SCHouseBuildProgressPacket(
-                                house.TlId,
-                                house.ModelId,
-                                house.AllAction,
-                                house.CurrentStep == -1 ? house.AllAction : house.CurrentAction
-                            ),
-                            true
-                        );
-
-                        // When done, spawn all attached doodads like doors and windows
-                        if (house.CurrentStep == -1)
                         {
-                            var doodads = house.AttachedDoodads.ToArray();
-                            foreach (var doodad in doodads)
-                                doodad.Spawn();
+                            // When done, set step to -1
+                            if (house.Template.BuildSteps.Count == 0)
+                                house.CurrentStep = -1;
+                            else
+                                house.AddBuildAction();
+
+                            // Send build packet
+                            character.BroadcastPacket(
+                                new SCHouseBuildProgressPacket(
+                                    house.TlId,
+                                    house.ModelId,
+                                    house.AllAction,
+                                    house.CurrentStep == -1 ? house.AllAction : house.CurrentAction
+                                ),
+                                true
+                            );
+
+                            // When done, spawn all attached doodads like doors and windows
+                            if (house.CurrentStep == -1)
+                            {
+                                var doodads = house.AttachedDoodads.ToArray();
+                                foreach (var doodad in doodads)
+                                    doodad.Spawn();
+                            }
                         }
-                        
                         break;
                     default:
                         _log.Warn("CraftEffect, {0} not have wi group", WorldInteraction);


### PR DESCRIPTION
Fixed CastSkill.TlId exporting the wrong type
Items no longer get consumed in Skill.ApplyEffect() if the skill got Cancelled
Labor is no longer consumed in EndSkill() is the skill was cancelled
Added code to verify building steps of building a shipyard at the end of a build step in a similar way as done for buildings.