### PR TITLE
[DRAFT] NOT TO MERGE - Adding unit tests not using interfaces and inheritance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ AAEmu.Tests/bin/
 AAEmu.Tests/obj/
 AAEmu.Game/Data/compact.sqlite3
 AAEmu.Game/Data/Worlds/*/hmap.dat
+AAEmu.Game/ClientData/game_pak
 AAEmu.Game/Config.json
 AAEmu.Login/Config.json
 publish/

--- a/AAEmu.Game/Core/Managers/TaskManager.cs
+++ b/AAEmu.Game/Core/Managers/TaskManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using ThreadTask = System.Threading.Tasks.Task;

--- a/AAEmu.Game/Core/Packets/G2C/SCCharacterLaborPowerChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCCharacterLaborPowerChangedPacket.cs
@@ -1,4 +1,4 @@
-using AAEmu.Commons.Network;
+﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C
@@ -10,6 +10,7 @@ namespace AAEmu.Game.Core.Packets.G2C
         private readonly int _point;
         private readonly byte _step;
         
+        public int Amount => _amount;
         public SCCharacterLaborPowerChangedPacket(int amount, int action, int point, byte step) 
             : base(SCOffsets.SCCharacterLaborPowerChangedPacket, 1)
         {

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -1362,7 +1362,7 @@ namespace AAEmu.Game.Models.Game.Char
         }
 
 
-        public void ChangeLabor(short change, int actabilityId)
+        public virtual void ChangeLabor(short change, int actabilityId)
         {
             var actabilityChange = 0;
             byte actabilityStep = 0;

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -464,7 +464,7 @@ namespace AAEmu.Game.Models.Game.Units
             return value;
         }
 
-        public void SendPacket(GamePacket packet)
+        public virtual void SendPacket(GamePacket packet)
         {
             Connection?.SendPacket(packet);
         }

--- a/AAEmu.Tests/AAEmu.Tests.csproj
+++ b/AAEmu.Tests/AAEmu.Tests.csproj
@@ -10,6 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="TestConfig.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="TestConfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\AAEmu.Commons\AAEmu.Commons.csproj" />
     <ProjectReference Include="..\AAEmu.Game\AAEmu.Game.csproj" />
   </ItemGroup>

--- a/AAEmu.Tests/LaborPowerManagerTests.cs
+++ b/AAEmu.Tests/LaborPowerManagerTests.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AAEmu.Commons.IO;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Network.Connections;
+using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Units;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace AAEmu.Tests
+{
+    public class LaborPowerManagerTests
+    {
+        [Fact]
+        public void LaborPowerTick_OfflineTooLong_ShouldMaxOut()
+        {
+            SetupPrerequisits();
+
+            var connection = new GameConnection(
+                new Commons.Network.Core.Session(
+                    new Commons.Network.Core.Client(
+                        new System.Net.IPAddress(0x2414188f), 21000, new GameProtocolHandler()
+                    )
+               ));
+
+
+            GameConnectionTable.Instance.AddConnection(connection);
+            var charecter = new MockCharacter(new UnitCustomModelParams(UnitCustomModelType.Hair));
+            charecter.Name = "test";
+            charecter.LaborPower = 0;
+            charecter.IsOnline = true;
+            connection.Characters.Add(0, charecter);
+
+            LaborPowerManager.Instance.LaborPowerTick();
+
+            var sentLaborChangePackets = charecter.SentPackets.OfType<SCCharacterLaborPowerChangedPacket>();
+
+            Assert.Single(sentLaborChangePackets);
+            Assert.Equal(5000, sentLaborChangePackets.Single().Amount);
+        }
+
+        [Fact]
+        public void LaborPowerTick_OfflineTooLong_ShouldNotBeNegative()
+        {
+            SetupPrerequisits();
+
+            var connection = new GameConnection(
+                new Commons.Network.Core.Session(
+                    new Commons.Network.Core.Client(
+                        new System.Net.IPAddress(0x2414188f), 21000, new GameProtocolHandler()
+                    )
+               ));
+
+            GameConnectionTable.Instance.AddConnection(connection);
+            var charecter = new MockCharacter(new UnitCustomModelParams(UnitCustomModelType.Hair));
+            charecter.Name = "test";
+            charecter.LaborPower = 0;
+            charecter.LaborPowerModified = System.DateTime.UtcNow.AddDays(-12);
+            charecter.IsOnline = true;
+            connection.Characters.Add(0, charecter);
+
+            LaborPowerManager.Instance.LaborPowerTick();
+
+            var sentLaborChangePackets = charecter.SentPackets.OfType<SCCharacterLaborPowerChangedPacket>();
+
+            Assert.Single(sentLaborChangePackets);
+            Assert.Equal(5000, sentLaborChangePackets.Single().Amount);
+        }
+
+        private void SetupPrerequisits()
+        {
+            var mainConfig = Path.Combine(FileManager.AppPath, "TestConfig.json");
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddJsonFile(mainConfig);
+            var configurationBuilderResult = configurationBuilder.Build();
+            configurationBuilderResult.Bind(AppConfiguration.Instance);
+
+            FriendMananger.Instance.Load();
+            TaskIdManager.Instance.Initialize();
+            TaskManager.Instance.Initialize();
+            LaborPowerManager.Instance.Initialize();
+        }
+    }
+
+    public class MockCharacter : Character
+    {
+        public List<GamePacket> SentPackets { get; private set; } = new List<GamePacket>();
+        public MockCharacter(UnitCustomModelParams modelParams) : base(modelParams)
+        {
+
+        }
+
+        public override void SendPacket(GamePacket packet)
+        {
+            SentPackets.Add(packet);
+        }
+    }
+}

--- a/AAEmu.Tests/TestConfig.json
+++ b/AAEmu.Tests/TestConfig.json
@@ -4,24 +4,24 @@
     "SecretKey": "test",
     "AutoAccount": true,
     "Network": {
-        "Host": "127.0.0.1",
+        "Host": "*",
         "Port": 1239,
         "NumConnections": 10
     },
     "StreamNetwork": {
-        "Host": "127.0.0.1",
+        "Host": "*",
         "Port": 1250
     },
     "LoginNetwork": {
-        "Host": "127.0.0.1",
-        "Port": "1234"
+        "Host": "%login_host%",
+        "Port": "%login_port%"
     },
     "Connections": {
         "MySQLProvider": {
-            "Host": "localhost",
-            "Port": "3306",
-            "User": "root",
-            "Password": "nml9102!!!",
+            "Host": "%db_host%",
+            "Port": "%db_port%",
+            "User": "%db_user%",
+            "Password": "%db_password%",
             "Database": "aaemu_game"
         }
     },

--- a/AAEmu.Tests/TestConfig.json
+++ b/AAEmu.Tests/TestConfig.json
@@ -1,0 +1,31 @@
+{
+    "Id": 1,
+    "AdditionalesId": [],
+    "SecretKey": "test",
+    "AutoAccount": true,
+    "Network": {
+        "Host": "127.0.0.1",
+        "Port": 1239,
+        "NumConnections": 10
+    },
+    "StreamNetwork": {
+        "Host": "127.0.0.1",
+        "Port": 1250
+    },
+    "LoginNetwork": {
+        "Host": "127.0.0.1",
+        "Port": "1234"
+    },
+    "Connections": {
+        "MySQLProvider": {
+            "Host": "localhost",
+            "Port": "3306",
+            "User": "root",
+            "Password": "nml9102!!!",
+            "Database": "aaemu_game"
+        }
+    },
+    "CharacterNameRegex": "^[a-zA-Z0-9а-яА-Я]{1,18}$",
+    "MaxConcurencyThreadPool": 8,
+    "HeightMapsEnable": true
+}


### PR DESCRIPTION
Not to merge.

This PR is just a DRAFT to show the problem of not using interfaces and following what Gene suggested using inheritance in the current project. 
Basically the environments of one test bubbles up to the other one because they run in the same runtime context as singletons. Additionally, I also had to set some of the base class methods as virtual to be able to override in the FakeCharacter class.
The Managers initializations also gave an error because the second test was initializing again (they are no idempotent). 
Adding a connection on both tests resulted in the ConnectionTable having two connections also, having connections that are not needed for the test and affect the evaluation of each one.
