### PR TITLE
/damage GM command is now based on health percentage

### DIFF
--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -1165,7 +1165,17 @@ namespace AAEmu.Game.Models.Game.Char
         [UnitAttribute(UnitAttribute.LungCapacity)]
         public uint LungCapacity
         {
-            get => (uint)CalculateWithBonuses(60000, UnitAttribute.LungCapacity);
+            get
+            {
+                if (Race == Race.Elf)
+                {
+                    return (uint)CalculateWithBonuses(80000, UnitAttribute.LungCapacity); //Elves racial skill Endurance Training gives +20 secs lung capacity
+                }
+                else
+                {
+                    return (uint)CalculateWithBonuses(60000, UnitAttribute.LungCapacity);
+                }
+            }
         }
 
         [UnitAttribute(UnitAttribute.FallDamageMul)]

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -1165,17 +1165,7 @@ namespace AAEmu.Game.Models.Game.Char
         [UnitAttribute(UnitAttribute.LungCapacity)]
         public uint LungCapacity
         {
-            get
-            {
-                if (Race == Race.Elf)
-                {
-                    return (uint)CalculateWithBonuses(80000, UnitAttribute.LungCapacity); //Elves racial skill Endurance Training gives +20 secs lung capacity
-                }
-                else
-                {
-                    return (uint)CalculateWithBonuses(60000, UnitAttribute.LungCapacity);
-                }
-            }
+            get => (uint)CalculateWithBonuses(60000, UnitAttribute.LungCapacity);
         }
 
         [UnitAttribute(UnitAttribute.FallDamageMul)]

--- a/AAEmu.Game/Scripts/Commands/Damage.cs
+++ b/AAEmu.Game/Scripts/Commands/Damage.cs
@@ -17,17 +17,20 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandLineHelp()
         {
-            return "(target) or self";
+            return "(target) or self <health percent>";
         }
 
         public string GetCommandHelpText()
         {
-            return "Damages self";
+            return "Damages self based on health percent";
         }
 
         public void Execute(Character character, string[] args)
         {
-            character.ReduceCurrentHp(character, 100);
+				int healthpercent = int.TryParse(args[0], out healthpercent) ? healthpercent : 1;
+				if(healthpercent > 0 && healthpercent < 100){
+					character.ReduceCurrentHp(character, (character.MaxHp*healthpercent/100));
+				}
         }
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Damage.cs
+++ b/AAEmu.Game/Scripts/Commands/Damage.cs
@@ -49,6 +49,5 @@ namespace AAEmu.Game.Scripts.Commands
                character.ReduceCurrentHp(character, (character.MaxHp * damage / 100));
             }
         }
-               
     }
 }

--- a/AAEmu.Game/Scripts/Commands/Damage.cs
+++ b/AAEmu.Game/Scripts/Commands/Damage.cs
@@ -17,12 +17,12 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandLineHelp()
         {
-            return "(target) or self <health percent>";
+            return "(target) or self <health percentage>";
         }
 
         public string GetCommandHelpText()
         {
-            return "Damages self based on health percent";
+            return "Damages self based on health percentage";
         }
 
         public void Execute(Character character, string[] args)

--- a/AAEmu.Game/Scripts/Commands/Damage.cs
+++ b/AAEmu.Game/Scripts/Commands/Damage.cs
@@ -17,20 +17,38 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandLineHelp()
         {
-            return "(target) or self <health percentage>";
+            return "(target) or self <damage> [%]";
         }
 
         public string GetCommandHelpText()
         {
-            return "Damages self based on health percentage";
+            return "Damages self or target based on raw damage or Hp percentage" +
+                   "Usage: /damage 9999   - Inflicts 9999 damage" +
+                   "or alternatively: /damage 80 %   - Inflicts 80% hp damage" +
+                   "Note: the percentage must be between 1 and 100";
         }
 
         public void Execute(Character character, string[] args)
         {
-				int healthpercent = int.TryParse(args[0], out healthpercent) ? healthpercent : 1;
-				if(healthpercent > 0 && healthpercent < 100){
-					character.ReduceCurrentHp(character, (character.MaxHp*healthpercent/100));
-				}
+            if (args.Length == 0)
+            {
+                character.SendMessage("[Damage] " + CommandManager.CommandPrefix + "damage (self or target) <damage> [%]");
+                return;
+            }
+
+			if (!int.TryParse(args[0], out int damage))
+				damage = 1;
+				
+			if ((args.Length == 1) && (damage > 0))
+			{
+				character.ReduceCurrentHp(character, damage);
+			}
+
+            if ((args.Length == 2) && (args[1] == "%") && (damage > 0 && damage <= 100))
+            {
+               character.ReduceCurrentHp(character, (character.MaxHp * damage / 100));
+            }
         }
+               
     }
 }


### PR DESCRIPTION
I wondered why damage was hardcoded at only 100 HP, so I decided to tweak it

Usage: /damage <health percentage> (between 1 and 99)