### PR TITLE
[All] Fix: MySqlDatabseUpdater warning

### DIFF
--- a/AAEmu.Commons/Utils/Updater/MySqlDatabaseUpdater.cs
+++ b/AAEmu.Commons/Utils/Updater/MySqlDatabaseUpdater.cs
@@ -297,7 +297,7 @@ namespace AAEmu.Commons.Utils.Updater
 
                 try
                 {
-                    currentDir = Directory.GetParent(currentDir).FullName;
+                    currentDir = Directory.GetParent(currentDir)?.FullName ?? string.Empty;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
Made it so the MySQL Auto Updater does not toss a useless exception anymore when it doesn't find files.