### PR TITLE
Clean docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ publish/
 AAEmu.Tests/TestResults/
 Tools/*/bin/
 Tools/*/obj/
+
+# Docker data
+data/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -64,8 +64,8 @@ services:
         image: aaemu-game:${PROJECT_VERSION_PREFIX}-${PROJECT_VERSION_SUFFIX}
         restart: unless-stopped
         volumes:
-          - "./AAEmu.Game/bin/${BUILD_CONFIGURATION}/${BUILD_FRAMEWORK}/ClientData:/app/ClientData:ro"
-          - "./AAEmu.Game/bin/${BUILD_CONFIGURATION}/${BUILD_FRAMEWORK}/Data:/app/Data:ro"
+          - ./data/game_pak:/app/ClientData/game_pak:ro
+          - ./data/compact.sqlite3:/app/Data/compact.sqlite3:ro
         environment:
             DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: 1
         ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,8 +13,6 @@ services:
             - ./SQL/examples/test-user.sql:/docker-entrypoint-initdb.d/test-user.sql
         environment:
             MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
-        ports:
-            - 3306:3306
 
     adminer:
         image: adminer

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
         restart: unless-stopped
         command: --default_authentication_plugin=mysql_native_password
         volumes:
-            - db-data:/var/lib/mysql
+            - ./data/db:/var/lib/mysql
             - ./SQL/aaemu_login.sql:/docker-entrypoint-initdb.d/aaemu_login.sql
             - ./SQL/aaemu_game.sql:/docker-entrypoint-initdb.d/aaemu_game.sql
             - ./SQL/examples/example-server.sql:/docker-entrypoint-initdb.d/example-server.sql
@@ -73,6 +73,3 @@ services:
             - 1250:1250
         depends_on:
             - login
-
-volumes:
-    db-data:


### PR DESCRIPTION
Removed port 3306 exposure.
Moved db data inside ./data/db instead of using a docker volume.

Moved game_pak and compact.sqlite3 inside the data folder in readonly for setup easiness. Now it's not needed anymore to run `./publish.sh` outside the container in order for it to work. Only `docker compose up` is needed.