### PR TITLE
[Login] Allow hostnames and local connections

### DIFF
--- a/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
+++ b/AAEmu.Login/Core/Network/Connections/LoginConnection.cs
@@ -21,12 +21,20 @@ namespace AAEmu.Login.Core.Network.Connections
         public string AccountName { get; set; }
         public DateTime LastLogin { get; set; }
         public IPAddress LastIp { get; set; }
+        public bool IsLocallyConnected { get; private set; }
 
         public Dictionary<byte, List<LoginCharacterInfo>> Characters;
 
         public LoginConnection(Session session)
         {
             _session = session;
+            
+            // checks if a connection is from the same machine
+            var localIp = session?.Socket?.LocalEndPoint?.ToString() ?? "local:0";
+            var remoteIp = session?.Socket?.RemoteEndPoint?.ToString() ?? "remote:0";
+            localIp = localIp.Substring(0, localIp.IndexOf(':'));
+            remoteIp = remoteIp.Substring(0, remoteIp.IndexOf(':'));
+            IsLocallyConnected = localIp == remoteIp;
 
             Characters = new Dictionary<byte, List<LoginCharacterInfo>>();
         }

--- a/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
+++ b/AAEmu.Login/Core/Network/Login/LoginProtocolHandler.cs
@@ -21,7 +21,7 @@ namespace AAEmu.Login.Core.Network.Login
 
         public override void OnConnect(Session session)
         {
-            _log.Info("Connection from {0} established, session id: {1}", session.Ip.ToString(), session.SessionId.ToString());
+            _log.Debug($"Connection from {session.Ip} established, session id: {session.SessionId}");
             try
             {
                 var con = new LoginConnection(session);
@@ -54,7 +54,7 @@ namespace AAEmu.Login.Core.Network.Login
                 _log.Error(e);
             }
 
-            _log.Info("Client from {0} disconnected", session.Ip.ToString());
+            _log.Debug($"Client from {session.Ip} disconnected");
         }
 
         public override void OnReceive(Session session, byte[] buf, int bytes)

--- a/AAEmu.Login/Core/Packets/C2L/CAListWorldPacket.cs
+++ b/AAEmu.Login/Core/Packets/C2L/CAListWorldPacket.cs
@@ -8,6 +8,7 @@ namespace AAEmu.Login.Core.Packets.C2L
     {
         public CAListWorldPacket() : base(CLOffsets.CAListWorldPacket)
         {
+            // Nothing
         }
 
         public override void Read(PacketStream stream)

--- a/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
+++ b/AAEmu.Login/Core/Packets/G2L/GLRegisterGameServerPacket.cs
@@ -35,7 +35,7 @@ namespace AAEmu.Login.Core.Packets.G2L
             }
             else
             {
-                _log.Error("Connection {0}, bad secret key", Connection.Ip);
+                _log.Error($"Connection {Connection.Ip}, bad secret key");
                 Task.Run(() => SendPacketWithDelay(5000, new LGRegisterGameServerPacket(GSRegisterResult.Error)));
                 // Connection.SendPacket(new LGRegisterGameServerPacket(GSRegisterResult.Error));
             }

--- a/AAEmu.Login/Core/Packets/L2C/ACWorldCookiePacket.cs
+++ b/AAEmu.Login/Core/Packets/L2C/ACWorldCookiePacket.cs
@@ -1,5 +1,6 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Commons.Utils;
+using AAEmu.Login.Core.Network.Connections;
 using AAEmu.Login.Core.Network.Login;
 using AAEmu.Login.Models;
 
@@ -7,21 +8,26 @@ namespace AAEmu.Login.Core.Packets.L2C
 {
     public class ACWorldCookiePacket : LoginPacket
     {
-        private readonly int _cookie;
+        private readonly LoginConnection _connection;
+        private readonly uint _cookie;
         private readonly GameServer _gs;
 
-        public ACWorldCookiePacket(int cookie, GameServer gs) : base(LCOffsets.ACWorldCookiePacket)
+        public ACWorldCookiePacket(LoginConnection connection, GameServer gs) : base(LCOffsets.ACWorldCookiePacket)
         {
-            _cookie = cookie;
+            _connection = connection;
+            _cookie = connection.Id;
             _gs = gs;
         }
 
         public override PacketStream Write(PacketStream stream)
         {
+            var serverIp = _gs.Host;
+            if (_connection.IsLocallyConnected)
+                serverIp = _connection.Ip.ToString();
             stream.Write(_cookie);
             for (var i = 0; i < 4; i++)
             {
-                stream.Write(Helpers.ConvertIp(_gs.Host));
+                stream.Write(Helpers.ConvertIp(serverIp));
                 stream.Write(_gs.Port);
             }
 


### PR DESCRIPTION
Changed the Login server so it can also accept a hostname for the server name field in the DB. It will try to resolve the name using a DNS lookup and then just locally store the IP for use on connections.

Changed ACWorldCookiePacket so it will use the same IP as used to connect with if the client is on the same machine as the login server.
This is a debugging feature that allows you to run a local login + game server using a local client, while still allow others to connect using your external IP provided in the DB.
This requires the port binding is be set to the default asterisk (*), and assumes the game server is running on the same machine as the login server.