### PR TITLE
[Game] Fix tradepack unequip bug

### DIFF
--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -1757,7 +1757,7 @@ namespace AAEmu.Game.Core.Managers
                                 }
                                 else
                                 {
-                                    _log.Fatal($"Failed to add owned item {item} to new container!");
+                                    _log.Fatal($"Failed to add owned item ({item.Id}){item} to new container (Id:{cContainer.ContainerId}) !");
                                     item.Slot = thisItemSlot;
                                     item.IsDirty = false;
                                 }

--- a/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
@@ -729,6 +729,11 @@ namespace AAEmu.Game.Models.Game.Items.Containers
 
         public virtual bool CanAccept(Item item, int targetSlot)
         {
+            if (item == null)
+                return true;
+            // When it's a backpack, allow only gliders by default
+            if (PartOfPlayerInventory && (item.Template is BackpackTemplate backpackTemplate))
+                return (backpackTemplate.BackpackType == BackpackType.Glider) || (backpackTemplate.BackpackType == BackpackType.ToyFlag);
             return true;
         }
 

--- a/AAEmu.Game/Models/Game/Items/Templates/BackpackTemplate.cs
+++ b/AAEmu.Game/Models/Game/Items/Templates/BackpackTemplate.cs
@@ -9,7 +9,7 @@ namespace AAEmu.Game.Models.Game.Items.Templates
         SiegeDeclare = 4,
         NationFlag = 5,
         Fish = 6,
-        Unk7 = 7
+        ToyFlag = 7
     }
 
     public class BackpackTemplate : ItemTemplate


### PR DESCRIPTION
Fixes a bug where you could drag a equipped trade-pack back to your inventory making it stuck there as you are not allowed to re-equip it.