### PR TITLE
[SQL] Fixed default aaemu_game.sql

### DIFF
--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -329,6 +329,10 @@ CREATE TABLE `items` (
   `flags` tinyint unsigned NOT NULL,
   `created_at` datetime NOT NULL DEFAULT '0001-01-01 00:00:00',
   `ucc` int unsigned NOT NULL DEFAULT '0',
+  `expire_time` datetime NULL DEFAULT NULL COMMENT 'Fixed time expire', 
+  `expire_online_minutes` double NOT NULL DEFAULT '0' COMMENT 'Time left when player online',
+  `charge_time` datetime NULL DEFAULT NULL COMMENT 'Time charged items got activated', 
+  `charge_count` int NOT NULL DEFAULT '0' COMMENT 'Number of charges left',
   PRIMARY KEY (`id`) USING BTREE,
   KEY `owner` (`owner`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='All items';


### PR DESCRIPTION
Added the missing update from 28th July 2022 to the main sql for installation
This adds the missing fields for timed items