### PR TITLE
Repaired GameController.ResolveHostName(),

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![Coverage Status](https://coveralls.io/repos/github/AAEmu/AAEmu/badge.svg?branch=develop)](https://coveralls.io/github/AAEmu/AAEmu?branch=develop)
+# ![AAEmu](https://i.imgur.com/NFDY376.png)
 
-# AAEmu
+[![Coverage Status](https://coveralls.io/repos/github/AAEmu/AAEmu/badge.svg?branch=develop)](https://coveralls.io/github/AAEmu/AAEmu?branch=develop)
+![Discord](https://img.shields.io/discord/479677351618281472?color=%235865F2&label=Discord&logo=Discord&logoColor=%23FFFFFF")
 
 __Open source server software for ArcheAge written in .Net Core__
 


### PR DESCRIPTION
added TestForListeningGameServer(), a gameserver check alive functionality, preserved original "return host if errors or no valid IPs found" logic, kept in line if no listening gameserver was found (which should be almost nonexistant as a use case anyway), modified GameController.Load() to have the port be instantiated first