### PR TITLE
Quest 1135 fix

### DIFF
--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -331,13 +331,14 @@ namespace AAEmu.Game.Models.Game.DoodadObj
                 return false; // no phase functions for FuncGroupId
             }
 
-            PhaseRatio = Rand.Next(0, 10000);
             CumulativePhaseRatio = 0;
             var stop = false;
             // perform the phase functions one after the other
             foreach (var phaseFunc in phaseFuncs)
             {
                 if (phaseFunc == null) { continue; }
+
+                PhaseRatio = Rand.Next(0, 10000);
 
                 stop = phaseFunc.Use(caster, this);
                 if (stop)
@@ -349,6 +350,7 @@ namespace AAEmu.Game.Models.Game.DoodadObj
             if (OverridePhase != 0 && stop && FuncGroupId != OverridePhase)
             {
                 nextPhase = OverridePhase;
+                OverridePhase = 0;
                 return DoPhase(caster, nextPhase);
             }
 

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncRatioChange.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncRatioChange.cs
@@ -12,7 +12,7 @@ namespace AAEmu.Game.Models.Game.DoodadObj.Funcs
 
         public override bool Use(Unit caster, Doodad owner)
         {
-            if (owner.PhaseRatio + owner.CumulativePhaseRatio <= Ratio)
+            if (owner.PhaseRatio/* + owner.CumulativePhaseRatio*/ <= Ratio)
             {
                 owner.OverridePhase = NextPhase; // Since phases trigger all at once let the doodad know its okay to stop here if the roll succeeded
                 if (caster is Character)
@@ -26,7 +26,7 @@ namespace AAEmu.Game.Models.Game.DoodadObj.Funcs
             else
                 _log.Trace($"DoodadFuncRatioChange : Ratio {Ratio}, PhaseRatio {owner.PhaseRatio + owner.CumulativePhaseRatio}, NextPhase {NextPhase}", Ratio, owner.FuncGroupId);
 
-            owner.CumulativePhaseRatio += Ratio;
+            //owner.CumulativePhaseRatio += Ratio;
             return false; // let's continue with the phase functions
         }
     }


### PR DESCRIPTION
[Game][Doodad] Fixed DoodadFuncRatioChanges;
[Game][Quest] Now quest 1135 is working correctly:
- chests Id=5171 "Stolen Goods" now counts everything in a row;
- chests Id=5171 "Stolen Goods" can be of two types;