### PR TITLE
[Game] Fix: action bar, fish-finder

### DIFF
--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -437,7 +437,7 @@ namespace AAEmu.Game.Core.Managers.UnitManagers
                 character.Ability3 = AbilityType.None;
                 character.ReturnDictrictId = template.ReturnDictrictId;
                 character.ResurrectionDictrictId = template.ResurrectionDictrictId;
-                character.Slots = new ActionSlot[85];
+                character.Slots = new ActionSlot[Character.MaxActionSlots];
                 for (var i = 0; i < character.Slots.Length; i++)
                     character.Slots[i] = new ActionSlot();
 

--- a/AAEmu.Game/Core/Network/Game/GamePacket.cs
+++ b/AAEmu.Game/Core/Network/Game/GamePacket.cs
@@ -58,7 +58,8 @@ namespace AAEmu.Game.Core.Network.Game
                 !(TypeId == SCOffsets.SCUnitMovementsPacket && Level == 1) &&
                 !(TypeId == SCOffsets.SCOneUnitMovementPacket && Level == 1) &&
                 !(TypeId == SCOffsets.SCGimmickMovementPacket && Level == 1) &&
-                !(TypeId == SCOffsets.SCTransferTelescopeUnitsPacket && Level == 1))
+                !(TypeId == SCOffsets.SCTransferTelescopeUnitsPacket && Level == 1) &&
+                !(TypeId == SCOffsets.SCTargetChangedPacket && Level == 1))
             {
                 //_log.Debug("GamePacket: S->C type {0:X} {2}\n{1}", TypeId, ps, this.ToString().Substring(23));
                 //_log.Trace("GamePacket: S->C type {0:X3} {1}", TypeId, this.ToString().Substring(23));

--- a/AAEmu.Game/Models/Game/DoodadObj/Static/DoodadConstants.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Static/DoodadConstants.cs
@@ -1,8 +1,0 @@
-﻿namespace AAEmu.Game.Models.Game.DoodadObj.Static
-{
-    public enum DoodadConstants : uint
-    {
-        FreshwaterFishSchool = 6447,
-        SaltwaterFishSchool = 6448
-    }
-}

--- a/AAEmu.Game/Models/Game/Skills/Effects/CraftEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/CraftEffect.cs
@@ -8,6 +8,7 @@ using AAEmu.Game.Models.Game.Housing;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
+using NLog;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects
 {
@@ -31,6 +32,7 @@ namespace AAEmu.Game.Models.Game.Skills.Effects
             
             if (caster is Character character)
             {
+                // _log.Warn($"{character.Name} triggered wiGroup {wiGroup}({(int)wiGroup}) with wi {WorldInteraction}({(int)WorldInteraction})");
                 switch (wiGroup)
                 {
                     case WorldInteractionGroup.Craft:

--- a/AAEmu.Game/Models/StaticValues/DoodadConstants.cs
+++ b/AAEmu.Game/Models/StaticValues/DoodadConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace AAEmu.Game.Models.StaticValues
+{
+    public static class DoodadConstants
+    {
+        public const uint FreshwaterFishSchool = 6447;
+        public const uint SaltwaterFishSchool = 6448;
+    }
+}


### PR DESCRIPTION
- Added a lock to generating the FishFinder doodads list to avoid exceptions.
- Changed how shortcut bars are saved/loaded so they no longer crash the connection if something went wrong with them.