### PR TITLE
[Game] Implement racial passives

### DIFF
--- a/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
@@ -1,13 +1,14 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Chat;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Units.Route;
 
@@ -82,10 +83,21 @@ namespace AAEmu.Game.Core.Packets.C2G
                 Connection.ActiveChar.SendOption(1);
                 Connection.ActiveChar.SendOption(2);
                 Connection.ActiveChar.SendOption(5);
-                
+
                 Connection.ActiveChar.Buffs.AddBuff((uint)BuffConstants.LoggedOn, Connection.ActiveChar);
-                
-                Connection.ActiveChar.OnZoneChange(0,Connection.ActiveChar.Transform.ZoneId);
+
+                var template = CharacterManager.Instance.GetTemplate((byte)character.Race, (byte)character.Gender);
+
+                foreach (var buff in template.Buffs)
+                {
+                    var buffTemplate = SkillManager.Instance.GetBuffTemplate(buff);
+                    var casterObj = new SkillCasterUnit(character.ObjId);
+                    character.Buffs.AddBuff(new Buff(character, character, casterObj, buffTemplate, null, DateTime.UtcNow) { Passive = true });
+                }
+
+                character.Breath = character.LungCapacity;
+
+                Connection.ActiveChar.OnZoneChange(0, Connection.ActiveChar.Transform.ZoneId);
             }
             else
             {

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -699,8 +699,11 @@ namespace AAEmu.Game.Models.Game.Units
         public virtual int DoFallDamage(ushort fallVel)
         {
             var fallDmg = Math.Min(MaxHp, (int)(MaxHp * ((fallVel - 8600) / 15000f)));
+            var multiplier = CalculateWithBonuses(0d, UnitAttribute.FallDamageMul) / 100d;
             var minHpLeft = MaxHp / 20; //5% of hp 
             var maxDmgLeft = Hp - minHpLeft; // Max damage one can take 
+
+            fallDmg = (int)(fallDmg + (fallDmg * multiplier));
 
             if (fallVel >= 32000)
             {


### PR DESCRIPTION
Once the buffs are added the passives should generally just work, however I think some are still missing the server side logic. The ones that I've verified are working are:

- Portal Mastery (Reduces the cooldown and cast time of the Recall ability by 30%.)
- Catlike Reflexes (Reduces fall damage by 20%)
- Endurance Training (
Allows Elves to hold their breath 20 seconds longer than other races) https://github.com/AAEmu/AAEmu/issues/447
- Lithe Flow (Increases the swim speed of elves by 5%)