### PR TITLE
[Game] Removed culture specific settings

### DIFF
--- a/AAEmu.Game/Core/Managers/World/SphereQuestManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SphereQuestManager.cs
@@ -151,7 +151,7 @@ namespace AAEmu.Game.Core.Managers.World
         {
             _log.Info("Loading SphereQuest...");
             var worlds = WorldManager.Instance.GetWorlds();
-            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+            Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
 
             var sphereQuests = new Dictionary<uint, List<SphereQuest>>();
             foreach (var world in worlds)

--- a/AAEmu.Game/Models/Game/Units/Route/Simulation.cs
+++ b/AAEmu.Game/Models/Game/Units/Route/Simulation.cs
@@ -126,7 +126,7 @@ namespace AAEmu.Game.Models.Game.Units.Route
         //***************************************************************
         public float ExtractValue(string sData, int nIndex)
         {
-            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("en-US");
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
             int i;
             var j = 0;
             var s = sData;


### PR DESCRIPTION
Replace en-US with culture invariant for some of the functions.
This should be functionally the same.
This change was needed to try and fix a issue where people are having problems running the server on platforms that don't have that culture installed (usually inside docker)