### PR TITLE
Fix mounts skills and buffs

### DIFF
--- a/AAEmu.Game/Core/Managers/MateManager.cs
+++ b/AAEmu.Game/Core/Managers/MateManager.cs
@@ -176,6 +176,7 @@ namespace AAEmu.Game.Core.Managers
 
                 character.Events.OnUnmount(character, new OnUnmountArgs { });
 
+                mateInfo.Buffs.TriggerRemoveOn(BuffRemoveOn.Unmount);
                 character.Buffs.TriggerRemoveOn(BuffRemoveOn.Unmount);
                 _log.Debug("UnMountMate. mountTlId: {0}, targetObjId: {1}, attachPoint: {2}, reason: {3}", mateInfo.TlId,
                     targetObj.ObjId, attachPoint, reason);

--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -18,6 +18,7 @@ using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Items.Templates;
 using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Buffs;
 using AAEmu.Game.Models.Game.Slaves;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World.Transform;
@@ -130,6 +131,9 @@ namespace AAEmu.Game.Core.Managers
                 character.Transform.Parent = null;
                 character.Transform.StickyParent = null;
             }
+
+            character.Buffs.TriggerRemoveOn(BuffRemoveOn.Unmount);
+
             character.BroadcastPacket(new SCUnitDetachedPacket(character.ObjId, reason), true);
         }
 

--- a/AAEmu.Game/Core/Packets/C2G/CSRemoveBuffPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRemoveBuffPacket.cs
@@ -1,4 +1,5 @@
 ﻿using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Effects;
@@ -17,6 +18,16 @@ namespace AAEmu.Game.Core.Packets.C2G
             var objId = stream.ReadBc();
             var buffId = stream.ReadUInt32();
             var reason = stream.ReadByte();
+            var mate = MateManager.Instance.GetActiveMate(Connection.ActiveChar.ObjId);
+
+            if (mate?.ObjId == objId)
+            {
+                var mateEffect = mate.Buffs.GetEffectByIndex(buffId);
+                if (mateEffect == null)
+                    return;
+                if (mateEffect.Template.Kind == BuffKind.Good)
+                    mateEffect.Exit();
+            }
 
             if (Connection.ActiveChar.ObjId != objId)
                 return;

--- a/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
@@ -68,12 +68,13 @@ namespace AAEmu.Game.Core.Packets.C2G
             {
                 var skill = new Skill(SkillManager.Instance.GetSkillTemplate(skillId));
                 var mate = MateManager.Instance.GetActiveMate(Connection.ActiveChar.ObjId);
+                var slave = SlaveManager.Instance.GetActiveSlaveByOwnerObjId(Connection.ActiveChar.ObjId);
                 var mountAttachedSkill = MateManager.Instance.GetMountAttachedSkills(skillId);
 
-                if (mate != null && skill.Template.Plot != null)
+                if (mate != null && Connection.ActiveChar.IsRiding)
                     skill.Use(mate, skillCaster, skillCastTarget, skillObject);
                 else
-                    skill.Use(Connection.ActiveChar, skillCaster, skillCastTarget, skillObject);
+                    skill.Use(slave, skillCaster, skillCastTarget, skillObject);
 
                 if (mountAttachedSkill == 0) { return; }
 

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Blink.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Blink.cs
@@ -1,7 +1,8 @@
 ﻿using System;
-
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.DoodadObj.Static;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects
@@ -32,6 +33,11 @@ namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects
                 newPos.Local.AddDistanceToFront(value1);
                 //var (endX, endY) = MathUtil.AddDistanceToFront(value1, character.Transform.World.Position.X, character.Transform.World.Position.Y, (sbyte)value2);
                 //var endZ = character.Transform.World.Position.Z;
+                if (character.IsRiding)
+                {
+                    var mate = MateManager.Instance.GetActiveMate(character.ObjId);
+                    MateManager.Instance.UnMountMate(character, mate.TlId, AttachPointKind.Driver, AttachUnitReason.None);
+                }
                 character.SendPacket(new SCBlinkUnitPacket(caster.ObjId, value1, value2, newPos.Local.Position.X, newPos.Local.Position.Y, newPos.Local.Position.Z));
                 //character.SendMessage("To: " + newPos.ToString());
                 //character.SendPacket(new SCBlinkUnitPacket(caster.ObjId, value1, value2, endX, endY, endZ));

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/RemoveDoodad.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/RemoveDoodad.cs
@@ -1,6 +1,8 @@
 ﻿using System;
-
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects
@@ -22,6 +24,12 @@ namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects
         {
             // TODO ...
             if (caster is Character) { _log.Debug("Special effects: RemoveDoodad value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+
+            var doodads = WorldManager.Instance.GetAround<Doodad>(caster, 10f);
+            if (doodads != null)
+                foreach (var doodad in doodads)
+                    if (doodad.TemplateId == value1)
+                        doodad.BroadcastPacket(new SCDoodadRemovedPacket(doodad.ObjId), false);
         }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -415,7 +415,23 @@ namespace AAEmu.Game.Models.Game.Skills
                 case SkillTargetType.SourcePos:
                     break;
                 case SkillTargetType.ArtilleryPos:
-                    break;
+                    {
+                        if (targetCaster is SkillCastPosition3Target positionTarget)
+                        {
+                            var positionUnit = new BaseUnit();
+                            positionUnit.ObjId = uint.MaxValue;
+                            positionUnit.Transform = caster.Transform.CloneDetached(positionUnit);
+                            positionUnit.Transform.Local.SetPosition(positionTarget.PosX, positionTarget.PosY, positionTarget.PosZ);
+                            caster.Region ??= WorldManager.Instance.GetRegion(caster.Transform.ZoneId, caster.Transform.World.Position.X, caster.Transform.World.Position.Y);
+                            positionUnit.Region = caster.Region;
+                            target = positionUnit;
+                        }
+                        if (target != null && caster.ObjId == target.ObjId)
+                        {
+                            return null; //TODO отправлять ошибку?
+                        }
+                        break;
+                    }
                 case SkillTargetType.CursorPos:
                     break;
                 default:

--- a/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Templates/BuffTemplate.cs
@@ -233,14 +233,27 @@ namespace AAEmu.Game.Models.Game.Skills.Templates
                 DoAreaTick(caster, owner, buff);
                 return;
             }
+            var mate = MateManager.Instance.GetActiveMate(owner.ObjId);
             foreach (var tickEff in TickEffects)
             {
-                if (tickEff.TargetBuffTagId > 0 &&
-                    !owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetBuffTagId)))
-                    return;
-                if (tickEff.TargetNoBuffTagId > 0 &&
-                    owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetNoBuffTagId)))
-                    return;
+                if (caster is Character character && character.IsRiding)
+                {
+                    if (tickEff.TargetBuffTagId > 0 &&
+                        !mate.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetBuffTagId)))
+                        return;
+                    if (tickEff.TargetNoBuffTagId > 0 &&
+                        mate.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetNoBuffTagId)))
+                        return;
+                }
+                else
+                {
+                    if (tickEff.TargetBuffTagId > 0 &&
+                        !owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetBuffTagId)))
+                        return;
+                    if (tickEff.TargetNoBuffTagId > 0 &&
+                        owner.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(tickEff.TargetNoBuffTagId)))
+                        return;
+                }
                 var eff = SkillManager.Instance.GetEffectTemplate(tickEff.EffectId);
                 if (eff == null)
                 {

--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -322,7 +322,7 @@ namespace AAEmu.Game.Models.Game.Units
                     owner.BuffModifiersCache.AddModifiers(buff.Template.BuffId);
                     owner.CombatBuffs.AddCombatBuffs(buff.Template.BuffId);
 
-                    if (owner is Character character && character.IsRiding && (bufft.Stun || bufft.Silence || bufft.Sleep || bufft.Root))
+                    if (owner is Character character && character.IsRiding && (bufft.Stun || bufft.Sleep || bufft.Root))
                     {
                         var mate = MateManager.Instance.GetActiveMate(character.ObjId);
                         MateManager.Instance.UnMountMate(character, mate.TlId, AttachPointKind.Driver, AttachUnitReason.None);

--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -5,10 +5,12 @@ using System.Linq;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.DoodadObj.Static;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Buffs;
 using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Skills.Templates;
+using NLog.Fluent;
 
 namespace AAEmu.Game.Models.Game.Units
 {
@@ -319,6 +321,12 @@ namespace AAEmu.Game.Models.Game.Units
                     owner.SkillModifiersCache.AddModifiers(buff.Template.BuffId);
                     owner.BuffModifiersCache.AddModifiers(buff.Template.BuffId);
                     owner.CombatBuffs.AddCombatBuffs(buff.Template.BuffId);
+
+                    if (owner is Character character && character.IsRiding && (bufft.Stun || bufft.Silence || bufft.Sleep || bufft.Root))
+                    {
+                        var mate = MateManager.Instance.GetActiveMate(character.ObjId);
+                        MateManager.Instance.UnMountMate(character, mate.TlId, AttachPointKind.Driver, AttachUnitReason.None);
+                    }
 
                     if (bufft.Stun || bufft.Silence || bufft.Sleep)
                         owner.InterruptSkills();

--- a/AAEmu.Game/Models/Game/Units/Mate.cs
+++ b/AAEmu.Game/Models/Game/Units/Mate.cs
@@ -277,6 +277,8 @@ namespace AAEmu.Game.Models.Game.Units
             get
             {
                 var formula = FormulaManager.Instance.GetUnitFormula(FormulaOwnerType.Mate, UnitFormulaKind.MaxMana);
+                var mateKindVariable = FormulaManager.Instance.GetUnitVariable(formula.Id,
+                    UnitFormulaVariableType.MateKind, (uint)Template.MateKindId);
                 var parameters = new Dictionary<string, double>
                 {
                     ["level"] = Level,
@@ -286,7 +288,7 @@ namespace AAEmu.Game.Models.Game.Units
                     ["int"] = Int,
                     ["spi"] = Spi,
                     ["fai"] = Fai,
-                    ["mate_kind"] = Template.MateKindId
+                    ["mate_kind"] = mateKindVariable
                 };
                 var res = (int)formula.Evaluate(parameters);
                 foreach (var bonus in GetBonuses(UnitAttribute.MaxMana))
@@ -378,7 +380,7 @@ namespace AAEmu.Game.Models.Game.Units
                     ["int"] = Int,
                     ["spi"] = Spi,
                     ["fai"] = Fai,
-                    ["mate_kind"] = Template.MateKindId
+                    ["ab_level"] = Level
                 };
 
                 var res = formula.Evaluate(parameters);
@@ -386,6 +388,110 @@ namespace AAEmu.Game.Models.Game.Units
             }
         }
 
+        [UnitAttribute(UnitAttribute.MeleeDpsInc)]
+        public override int DpsInc
+        {
+            get
+            {
+                var formula = FormulaManager.Instance.GetUnitFormula(FormulaOwnerType.Mate, UnitFormulaKind.MeleeDpsInc);
+                var parameters = new Dictionary<string, double>();
+                parameters["level"] = Level;
+                parameters["str"] = Str;
+                parameters["dex"] = Dex;
+                parameters["sta"] = Sta;
+                parameters["int"] = Int;
+                parameters["spi"] = Spi;
+                parameters["fai"] = Fai;
+                var res = formula.Evaluate(parameters);
+                foreach (var bonus in GetBonuses(UnitAttribute.MeleeDpsInc))
+                {
+                    if (bonus.Template.ModifierType == UnitModifierType.Percent)
+                        res += (res * bonus.Value / 100f);
+                    else
+                        res += bonus.Value;
+                }
+                return (int)res;
+            }
+        }
+
+        [UnitAttribute(UnitAttribute.SpellDpsInc)]
+        public override int MDpsInc
+        {
+            get
+            {
+                var formula =
+                    FormulaManager.Instance.GetUnitFormula(FormulaOwnerType.Mate, UnitFormulaKind.SpellDpsInc);
+                var parameters = new Dictionary<string, double>();
+                parameters["level"] = Level;
+                parameters["str"] = Str;
+                parameters["dex"] = Dex;
+                parameters["sta"] = Sta;
+                parameters["int"] = Int;
+                parameters["spi"] = Spi;
+                parameters["fai"] = Fai;
+                var res = formula.Evaluate(parameters);
+                foreach (var bonus in GetBonuses(UnitAttribute.SpellDpsInc))
+                {
+                    if (bonus.Template.ModifierType == UnitModifierType.Percent)
+                        res += (res * bonus.Value / 100f);
+                    else
+                        res += bonus.Value;
+                }
+                return (int)res;
+            }
+        }
+
+        [UnitAttribute(UnitAttribute.Armor)]
+        public override int Armor
+        {
+            get
+            {
+                var formula = FormulaManager.Instance.GetUnitFormula(FormulaOwnerType.Mate, UnitFormulaKind.Armor);
+                var parameters = new Dictionary<string, double>();
+                parameters["level"] = Level;
+                parameters["str"] = Str;
+                parameters["dex"] = Dex;
+                parameters["sta"] = Sta;
+                parameters["int"] = Int;
+                parameters["spi"] = Spi;
+                parameters["fai"] = Fai;
+                var res = (int)formula.Evaluate(parameters);
+                foreach (var bonus in GetBonuses(UnitAttribute.Armor))
+                {
+                    if (bonus.Template.ModifierType == UnitModifierType.Percent)
+                        res += (int)(res * bonus.Value / 100f);
+                    else
+                        res += bonus.Value;
+                }
+                return res;
+            }
+        }
+
+        [UnitAttribute(UnitAttribute.MagicResist)]
+        public override int MagicResistance
+        {
+            get
+            {
+                var formula = FormulaManager.Instance.GetUnitFormula(FormulaOwnerType.Mate, UnitFormulaKind.MagicResist);
+                var parameters = new Dictionary<string, double>();
+                parameters["level"] = Level;
+                parameters["str"] = Str;
+                parameters["dex"] = Dex;
+                parameters["sta"] = Sta;
+                parameters["int"] = Int;
+                parameters["spi"] = Spi;
+                parameters["fai"] = Fai;
+                var res = (int)formula.Evaluate(parameters);
+                foreach (var bonus in GetBonuses(UnitAttribute.MagicResist))
+                {
+                    if (bonus.Template.ModifierType == UnitModifierType.Percent)
+                        res += (int)(res * bonus.Value / 100f);
+                    else
+                        res += bonus.Value;
+                }
+                return res;
+            }
+        }
         #endregion
 
         public Mate()


### PR DESCRIPTION
In SlaveManager Added removal of buffs for a character when he leaves from the Slave
In CSRemoveBuffPacket Added removal of Gliding buffs for flying mounts
In CSStartSkillPacket Modified the use of skills to send Mate and Slave as Caster
In Blink Added check if a character is sitting on a mount, then forced to do UnMount before using the teleport skill
In RemoveDoodad Added removal of Doodads when using certain skils (for example: ID - Jousting Lance Charge)
In BuffTemplate added a check if a main checking buff is on mount (Example: ID - 26138 Lightning Stealth)


In Skills added a check if the character is sitting on the mount, the UseSkill trigger is used to remove the buffs from the mount
Also added a check if the character is on mount and uses allowed skills to use, then forcibly UnMount before using a skill
Also added the ability to fire ship cannons and tanks

In Buffs added a check if the character is on the mount and another character or NPC applies control skills on him, then forcibly UnMount before using the skill

In Mate changed mana formula, now skills that are used on the mount spend mana on the mount
Also added formulas for attacking and defensive skills mounts