### PR TITLE
[Game] and [Data] Fixed Skills and Factions system

### DIFF
--- a/AAEmu.Game/Data/Portal/worldgates.json
+++ b/AAEmu.Game/Data/Portal/worldgates.json
@@ -27,6 +27,16 @@
         "SubZoneId": 196 // 372
     },
     {
+        "Id": 389,
+        "Name": "Villanelle", //for quest 3478
+        "ZoneId": 160,
+        "X": 21206.7,
+        "Y": 10428.8,
+        "Z": 107.7,
+        "Yaw": -68.0,
+        "SubZoneId": 542
+    },
+    {
         "Id": 402,
         "Name": "Respawn: Perinoor Ruins",
         "ZoneId": 139,

--- a/AAEmu.Game/Models/Game/Faction/SystemFaction.cs
+++ b/AAEmu.Game/Models/Game/Faction/SystemFaction.cs
@@ -34,7 +34,7 @@ namespace AAEmu.Game.Models.Game.Faction
             var factionId = MotherId != 0 ? MotherId : Id;
             var otherFactionId = otherFaction.MotherId != 0 ? otherFaction.MotherId : otherFaction.Id;
 
-            if (factionId == otherFactionId)
+            if (factionId == otherFactionId || otherFactionId == 1)
                 return RelationState.Friendly;
 
             //Not sure if we should prioritize mother faction here?

--- a/AAEmu.Game/Models/Tasks/Skills/EndChannelingTask.cs
+++ b/AAEmu.Game/Models/Tasks/Skills/EndChannelingTask.cs
@@ -1,3 +1,4 @@
+﻿using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Units;
@@ -27,6 +28,9 @@ namespace AAEmu.Game.Models.Tasks.Skills
         {
             // Skill.ScheduleEffects(_caster, _casterCaster, _target, _targetCaster, _skillObject);
             Skill.EndChanneling(_caster, _channelDoodad);
+            if (_casterCaster is not SkillItem skillItem) { return; }
+            if (_caster is Unit unit && _caster is Character character && unit.ConditionChance)
+                character.ItemUse(skillItem.ItemId);
         }
     }
 }


### PR DESCRIPTION
Fixed Skills, now if a skill goes into StartChanneling() and is an item, it will be applied (fix tested on quest id - 3469)
Added teleport point for quest id - 3478
Fixed assigning RelationState.Friendly to NPCs. (fix tested on quest id - 3454)
(In db - system_factions - id = 1 (System NPC) has mother_id = 0, but it is friendly to the character. And if we compare character's mother_id to NPC's mother_id, it will never be assigned Friendly status, so we can't use skills that require SkillTargetType.Friendly on it).