### PR TITLE
[Game] Fixed the faction change for NPCs

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/Buff.cs
+++ b/AAEmu.Game/Models/Game/Skills/Buff.cs
@@ -185,7 +185,11 @@ namespace AAEmu.Game.Models.Game.Skills
                 Owner.Buffs.RemoveEffect(this);
                 Template.Dispel(Caster, Owner, this, replace);
 
-                if (Template.FactionId > 0 && Owner is Unit owner)
+                if (Template.FactionId > 0 && Owner is NPChar.Npc npc)
+                {
+                    npc.SetFaction(npc.Template.FactionId);
+                }
+                else if (Template.FactionId > 0 && Owner is Unit owner)
                 {
                     owner.SetFaction(saveFactions[owner.Id]);
                     saveFactions.Remove(owner.Id);


### PR DESCRIPTION
Fixed the faction change for NPCs. Fix for quest - 2396 and similar quests where the initial faction change is due to NpcControllEffect, and then a buff was applied that should bring the faction back. 

Example: Quest - 2396
Because NpcControllEffect (case NpcControlCategory.AttackUnit) changes the NPC's faction to FactionsEnum.Monstrosity (115), when the buff was applied, faction 115 is passed to the buff, instead of 101, which was the NPC's original faction.