### PR TITLE
[Game] Fixed display of sitting character on pets or slaves

### DIFF
--- a/AAEmu.Game/Models/Game/Units/Mate.cs
+++ b/AAEmu.Game/Models/Game/Units/Mate.cs
@@ -543,6 +543,8 @@ namespace AAEmu.Game.Models.Game.Units
 
         public override void AddVisibleObject(Character character)
         {
+            base.AddVisibleObject(character);
+
             character.SendPacket(new SCUnitStatePacket(this));
             character.SendPacket(new SCMateStatePacket(ObjId));
             character.SendPacket(new SCUnitPointsPacket(ObjId, Hp, Mp));
@@ -556,7 +558,6 @@ namespace AAEmu.Game.Models.Game.Units
                         character.SendPacket(new SCUnitAttachedPacket(player.ObjId, ati.Key, ati.Value._reason, ObjId));
                 }
             }
-            base.AddVisibleObject(character);
         }
 
         public override void RemoveVisibleObject(Character character)

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -11,6 +11,7 @@ using AAEmu.Game.Models.Game.Formulas;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Units.Static;
 using Jitter.Dynamics;
+using AAEmu.Game.Core.Managers.World;
 
 namespace AAEmu.Game.Models.Game.Units
 {
@@ -578,11 +579,21 @@ namespace AAEmu.Game.Models.Game.Units
         
         public override void AddVisibleObject(Character character)
         {
+            base.AddVisibleObject(character);
+
             character.SendPacket(new SCUnitStatePacket(this));
             character.SendPacket(new SCUnitPointsPacket(ObjId, Hp, Mp));
             character.SendPacket(new SCSlaveStatePacket(ObjId, TlId, Summoner.Name, Summoner.ObjId, Template.Id));
-            
-            base.AddVisibleObject(character);
+
+            foreach (var ati in AttachedCharacters)
+            {
+                if (ati.Value.ObjId > 0)
+                {
+                    var player = WorldManager.Instance.GetCharacterByObjId(ati.Value.ObjId);
+                    if (player != null)
+                        character.SendPacket(new SCUnitAttachedPacket(player.ObjId, ati.Key, AttachUnitReason.None, ObjId));
+                }
+            }
         }
 
         public override void RemoveVisibleObject(Character character)


### PR DESCRIPTION
Fixed the display of a character sitting on pets or slaves when the character comes from another region

How it works now: 
If a character is sitting on a mate or slave and comes from another region, only the mate or slave will be displayed for the other character, and the character will be "invisible" and will be displayed at 5000 meters away