### PR TITLE
[Game] Daily Quest Reset

### DIFF
--- a/AAEmu.Game/Core/Managers/QuestManager.cs
+++ b/AAEmu.Game/Core/Managers/QuestManager.cs
@@ -299,7 +299,7 @@ namespace AAEmu.Game.Core.Managers
                         template.QuestIdx = reader.GetUInt32("quest_idx", 0);
                         template.MilestoneId = reader.GetUInt32("milestone_id", 0);
                         template.LetItDone = reader.GetBoolean("let_it_done", true);
-                        template.DetailId = reader.GetUInt32("detail_id");
+                        template.DetailId = (QuestDetail)reader.GetUInt32("detail_id");
                         template.ZoneId = reader.GetUInt32("zone_id");
                         template.Degree = reader.GetInt32("degree", 0);
                         template.UseQuestCamera = reader.GetBoolean("use_quest_camera", true);

--- a/AAEmu.Game/Core/Managers/QuestManager.cs
+++ b/AAEmu.Game/Core/Managers/QuestManager.cs
@@ -134,6 +134,11 @@ namespace AAEmu.Game.Core.Managers
                 UpdateQuestComponentActs();
             }
             _loaded = true;
+            
+            // Start daily reset task
+            var dailyCron = "0 0 0 ? * * *";
+            // TODO: Make sure it obeys server time settings
+            TaskManager.Instance.CronSchedule(new QuestDailyResetTask(), dailyCron);
         }
 
         private void LoadQuestMonsterNpcs(SqliteConnection connection)

--- a/AAEmu.Game/Core/Packets/G2C/SCQuestContextResetPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCQuestContextResetPacket.cs
@@ -1,0 +1,27 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C
+{
+    public class SCQuestContextResetPacket : GamePacket
+    {
+        private readonly uint _questId;
+        private readonly byte[] _body;
+        private readonly uint _componentId;
+
+        public SCQuestContextResetPacket(uint questId, byte[] body, uint componentId) : base(SCOffsets.SCQuestContextResetPacket, 1)
+        {
+            _questId = questId;
+            _body = body;
+            _componentId = componentId;
+        }
+
+        public override PacketStream Write(PacketStream stream)
+        {
+            stream.Write(_questId);
+            stream.Write(_body); // ulong -> byte[8]
+            stream.Write(_componentId);
+            return stream;
+        }
+    }
+}

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -2143,6 +2143,7 @@ namespace AAEmu.Game.Models.Game.Char
                 Blocked.Load(connection);
                 Quests = new CharacterQuests(this);
                 Quests.Load(connection);
+                Quests.CheckDailyResetAtLogin();
                 Mates = new CharacterMates(this);
                 Mates.Load(connection);
 

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -414,7 +414,6 @@ namespace AAEmu.Game.Models.Game.Char
 
         }
         
-        
         public void Load(MySqlConnection connection)
         {
             using (var command = connection.CreateCommand())
@@ -513,6 +512,27 @@ namespace AAEmu.Game.Models.Game.Char
                     command.Parameters.Clear();
                 }
             }
+        }
+
+        public void CheckDailyResetAtLogin()
+        {
+            // TODO: Put Server timezone offset in configuration file, currently using local machine midnight
+            // var utcDelta = DateTime.Now - DateTime.UtcNow;
+            // var isOld = (DateTime.Today + utcDelta - Owner.LeaveTime.Date) >= TimeSpan.FromDays(1);
+            var isOld = (DateTime.Today - Owner.LeaveTime.Date) >= TimeSpan.FromDays(1);
+            if (isOld)
+                ResetDailyQuests(false);
+        }
+
+        public void ResetDailyQuests(bool sendPacketsIfChanged)
+        {
+            Owner.Quests.ResetQuests(
+                new QuestDetail[]
+                {
+                    QuestDetail.Daily, QuestDetail.DailyGroup, QuestDetail.DailyHunt,
+                    QuestDetail.DailyLivelihood
+                }, true
+            );
         }
     }
 }

--- a/AAEmu.Game/Models/Game/Quests/Static/QuestDetail.cs
+++ b/AAEmu.Game/Models/Game/Quests/Static/QuestDetail.cs
@@ -1,6 +1,6 @@
 ﻿namespace AAEmu.Game.Models.Game.Quests.Static
 {
-    public enum QuestDetail
+    public enum QuestDetail : uint
     {
         Normal = 1,
         Main = 2,

--- a/AAEmu.Game/Models/Game/Quests/Templates/QuestTemplate.cs
+++ b/AAEmu.Game/Models/Game/Quests/Templates/QuestTemplate.cs
@@ -16,7 +16,7 @@ namespace AAEmu.Game.Models.Game.Quests.Templates
         public uint QuestIdx { get; set; }
         public uint MilestoneId { get; set; }
         public bool LetItDone { get; set; }
-        public uint DetailId { get; set; }
+        public QuestDetail DetailId { get; set; }
         public uint ZoneId { get; set; }
         public int Degree { get; set; }
         public bool UseQuestCamera { get; set; }

--- a/AAEmu.Game/Models/Tasks/Quests/QuestDailyResetTask.cs
+++ b/AAEmu.Game/Models/Tasks/Quests/QuestDailyResetTask.cs
@@ -1,0 +1,23 @@
+﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.Game.Models.Tasks.Quests
+{
+    public class QuestDailyResetTask : Task
+    {
+        public QuestDailyResetTask()
+        {
+            
+        }
+
+        public override void Execute()
+        {
+            foreach (var character in WorldManager.Instance.GetAllCharacters())
+            {
+                character.Quests.ResetDailyQuests(true);
+            }
+        }
+    }
+}

--- a/AAEmu.Game/Scripts/Commands/QuestCmd.cs
+++ b/AAEmu.Game/Scripts/Commands/QuestCmd.cs
@@ -17,19 +17,19 @@ namespace AAEmu.Game.Scripts.Commands
 
         public string GetCommandLineHelp()
         {
-            return "<list||add||remove||prog||reward>";
+            return "<list||add||remove||prog||reward||resetdaily>";
         }
 
         public string GetCommandHelpText()
 {
-            return "[Quest] /quest <add/remove/list/prog/reward>\nBefore that, target the Npc you need for the quest";
+            return "[Quest] /quest <add/remove/list/prog/reward/resetdaily>\nBefore that, target the Npc you need for the quest";
         }
 
         public void Execute( Character character, string[] args )
         {
             if ( args.Length < 1 )
             {
-                character.SendMessage( "[Quest] /quest <add/remove/list/prog/reward>\nBefore that, target the Npc you need for the quest" );
+                character.SendMessage( "[Quest] /quest <add/remove/list/prog/reward/resetdaily>\nBefore that, target the Npc you need for the quest" );
                 return;
             }
 

--- a/AAEmu.Game/Utils/QuestCommandUtil.cs
+++ b/AAEmu.Game/Utils/QuestCommandUtil.cs
@@ -140,6 +140,15 @@ namespace AAEmu.Game.Utils
                         character.SendMessage("[Quest] Proper usage: /quest remove <questId>");
                     }
                     break;
+                case "resetdaily":
+                    character.Quests.ResetQuests(
+                        new QuestDetail[]
+                        {
+                            QuestDetail.Daily, QuestDetail.DailyGroup, QuestDetail.DailyHunt,
+                            QuestDetail.DailyLivelihood
+                        }, true
+                    );
+                    break;
                 default:
                     character.SendMessage("[Quest] /quest <add/remove/list/prog/reward>\nBefore that, target the Npc you need for the quest");
                     break;

--- a/AAEmu.Game/Utils/QuestCommandUtil.cs
+++ b/AAEmu.Game/Utils/QuestCommandUtil.cs
@@ -141,13 +141,7 @@ namespace AAEmu.Game.Utils
                     }
                     break;
                 case "resetdaily":
-                    character.Quests.ResetQuests(
-                        new QuestDetail[]
-                        {
-                            QuestDetail.Daily, QuestDetail.DailyGroup, QuestDetail.DailyHunt,
-                            QuestDetail.DailyLivelihood
-                        }, true
-                    );
+                    character.Quests.ResetDailyQuests(true);
                     break;
                 default:
                     character.SendMessage("[Quest] /quest <add/remove/list/prog/reward>\nBefore that, target the Npc you need for the quest");


### PR DESCRIPTION
Added code to handle daily quest resets.
To minimize overhead it only reset current online player's quests at local machine midnight.
It also checks at character login if the last leave time was the day before or not, and triggers resets as needed. 