### PR TITLE
[Game] Fix: Trade pack Ratio and Overburdened

### DIFF
--- a/AAEmu.Game/AAEmu.Game.csproj
+++ b/AAEmu.Game/AAEmu.Game.csproj
@@ -52,6 +52,9 @@
         <None Update="Configurations\ClientData.json">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Update="Configurations\Specialty.json">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 
     <ItemGroup>

--- a/AAEmu.Game/Configurations/Specialty.json
+++ b/AAEmu.Game/Configurations/Specialty.json
@@ -1,0 +1,10 @@
+{
+	"Specialty": {
+		"MaxSpecialtyRatio": 130,
+		"MinSpecialtyRatio": 70,
+		"RatioDecreasePerPack": 0.5,
+		"RatioDecreaseTickMinutes": 1.0,
+		"RatioIncreasePerTick": 5.0,
+		"RatioRegenTickMinutes": 60.0
+	}
+}

--- a/AAEmu.Game/Models/AppConfiguration.cs
+++ b/AAEmu.Game/Models/AppConfiguration.cs
@@ -25,6 +25,7 @@ namespace AAEmu.Game.Models
         public Dictionary<string, int> AccessLevel { get; set; } = new Dictionary<string, int>();
         public AccountConfig Account { get; set; }
         public ClientDataConfig ClientData { get; set; } = new ClientDataConfig();
+        public SpecialtyConfig Specialty { get; set; } = new SpecialtyConfig();
 
         public class NetworkConfig
         {

--- a/AAEmu.Game/Models/Game/Configurations.cs
+++ b/AAEmu.Game/Models/Game/Configurations.cs
@@ -38,4 +38,14 @@ namespace AAEmu.Game.Models.Game
         public List<AccountDeleteDelayTiming> DeleteTimings { get; set; } = new List<AccountDeleteDelayTiming>();
     }
 
+    public class SpecialtyConfig
+    {
+        public int MaxSpecialtyRatio { get; set; } = 130;
+        public int MinSpecialtyRatio { get; set; } = 70;
+        public double RatioDecreasePerPack { get; set; } = 0.5f;
+        public double RatioIncreasePerTick { get; set; } = 5.0;
+        public double RatioDecreaseTickMinutes { get; set; } = 1f;
+        public double RatioRegenTickMinutes { get; set; } = 60f;
+    }
+
 }

--- a/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
@@ -343,7 +343,7 @@ namespace AAEmu.Game.Models.Game.Items.Containers
                 if (this.ContainerType != SlotType.None)
                     itemTasks.Add(new ItemAdd(item));
                 
-                if ((sourceContainer != null) && (sourceContainer != this))
+                if (sourceContainer != this)
                 {
                     sourceContainer?.OnLeaveContainer(item, this);
                     OnEnterContainer(item, sourceContainer);


### PR DESCRIPTION
Trade pack ratios were not updated as expected. It would keep lowering the % based on the total amount of packs set as the pack counter never got reset.
There was a wrong null check in ItemContainer that would make it so you wouldn't get any buffs or bonuses for new items that where instantiated outside of a item container.