### PR TITLE
TaskManager improvements

### DIFF
--- a/AAEmu.Game/AAEmu.Game.csproj
+++ b/AAEmu.Game/AAEmu.Game.csproj
@@ -58,7 +58,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Compile Remove="Scripts\**\**" />
       <None Include="Scripts\**\**" CopyToOutputDirectory="PreserveNewest" LinkBase="Scripts\" />
       <None Include="Configs\**\**" CopyToOutputDirectory="PreserveNewest" LinkBase="Configs\" />
       <None Include="Data\**\**" CopyToOutputDirectory="PreserveNewest" LinkBase="Data\" />
@@ -154,5 +153,6 @@
 
     <ItemGroup>
       <Folder Include="Models\ClientData" />
+      <Folder Include="Scripts\SubCommands" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
In a way to reduce the Total CPU cycles over time

- Reduce allocation to one reference during while loop
- Using Threading.Tasks instead of old Thread approach.

![image](https://github.com/AAEmu/AAEmu/assets/19890735/037538ec-b458-43f6-8e43-8c01ac231fb2)
