### PR TITLE
[Game] Fix: Open Loot Bag

### DIFF
--- a/AAEmu.Game/Core/Packets/G2C/SCLootBagDataPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCLootBagDataPacket.cs
@@ -21,20 +21,7 @@ class SCLootBagDataPacket : GamePacket
         stream.Write((byte)_items.Count);
 
         foreach (var item in _items)
-        {
-            stream.Write(item.TemplateId);
-            stream.Write(item.Id);
-            stream.Write(item.Grade);
-            stream.Write((byte)0);
-            stream.Write(item.Count);
-            stream.Write((byte)item.DetailType);
-            stream.Write(item.CreateTime);
-            stream.Write(item.LifespanMins);
-            stream.Write(item.MadeUnitId);
-            stream.Write(item.WorldId);
-            stream.Write(item.UnsecureTime);
-            stream.Write(item.UnpackTime);
-        }
+            item.Write(stream);
 
         stream.Write(_lootAll);
         return stream;


### PR DESCRIPTION
Fixed a crash and inventory corruption issue that *could* occur whenever you opened a corpse/loot spot using G instead of F to loot all.
