### PR TITLE
[Game] Fix faction check and AoE related hits

### DIFF
--- a/AAEmu.Game/Models/Game/Faction/SystemFaction.cs
+++ b/AAEmu.Game/Models/Game/Faction/SystemFaction.cs
@@ -37,22 +37,21 @@ public class SystemFaction : PacketMarshaler
         if (factionId == otherFactionId)
             return RelationState.Friendly;
 
-        //Not sure if we should prioritize mother faction here?
+        // Not sure if we should prioritize mother faction here?
         if (MotherId != 0)
         {
             var motherFaction = FactionManager.Instance.GetFaction(MotherId);
             if (motherFaction != null)
             {
-                var motherRelations = motherFaction.Relations;
-                if (motherRelations.ContainsKey(otherFactionId))
-                    return motherRelations[otherFactionId].State;
+                if (motherFaction.Relations.TryGetValue(otherFactionId, out var motherRelation))
+                    return motherRelation.State;
 
-                // TODO not found, so enemy (id = [1, 2, 3])
-                return RelationState.Hostile;
+                // TODO not found, so enemy (id = [1, 2, 3])?
+                return RelationState.Friendly;
             }
         }
 
-        return Relations.ContainsKey(otherFactionId) ? Relations[otherFactionId].State : RelationState.Neutral;
+        return Relations.TryGetValue(otherFactionId, out var relation) ? relation.State : RelationState.Neutral;
     }
 
     public override PacketStream Write(PacketStream stream)

--- a/AAEmu.Game/Models/Game/Skills/Effects/BuffEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/BuffEffect.cs
@@ -76,9 +76,10 @@ public class BuffEffect : EffectTemplate
         }
 
         // TODO Doesn't let the quest work Id=2488 "A Mother's Tale", 13, "Lilyut Hills", "Nuian Main"
-        ////Safeguard to prevent accidental flagging
-        //if (Buff.Kind == BuffKind.Bad && !caster.CanAttack(target) && caster != target)
-        //    return;
+        // Safeguard to prevent accidental flagging
+        if (Buff.Kind == BuffKind.Bad && !caster.CanAttack(target) && caster != target)
+            return;
+
         target.Buffs.AddBuff(new Buff(target, caster, casterObj, Buff, source.Skill, time) { AbLevel = abLevel });
 
         if (Buff.Kind == BuffKind.Bad && caster.GetRelationStateTo(target) == RelationState.Friendly

--- a/AAEmu.Game/Models/Game/Skills/Effects/DamageEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/DamageEffect.cs
@@ -302,11 +302,11 @@ public class DamageEffect : EffectTemplate
             finalDamage *= TargetBuffBonusMul;
         }
 
-        //toughness reduction (PVP Only)
+        // Toughness reduction (PVP Only)
         if (caster is Character && trg is Character)
             finalDamage *= 1 - trg.BattleResist / (8000f + trg.BattleResist);
 
-        //Do Critical Dmgs
+        // Do Critical Dmgs
         switch (hitType)
         {
             case SkillHitType.MeleeCritical:
@@ -355,9 +355,10 @@ public class DamageEffect : EffectTemplate
         var healthStolen = (int)(value * (HealthStealRatio / 100.0f));
         var manaStolen = (int)(value * (ManaStealRatio / 100.0f));
 
-        //Safeguard to prevent accidental flagging
+        // Safeguard to prevent accidental flagging
         if (!caster.CanAttack(trg))
             return;
+
         trg.ReduceCurrentHp(caster, value);
         ((Unit)caster).SummarizeDamage += value;
 

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -685,12 +685,8 @@ public class Skill
         if (Template.TargetAreaRadius > 0)
         {
             var units = WorldManager.GetAround<BaseUnit>(targetSelf, Template.TargetAreaRadius, true);
-            // TODO Fixed the work doodad ID=5090, "Stacked Lumber" and skill ID=18312, "Throw Torch" in Howling abyss.
-            if (units.Count == 1 && units[0] is not Doodad)
-            {
-                units.Add(targetSelf);
-                units = FilterAoeUnits(caster, units).ToList();
-            }
+            units.Add(targetSelf); // Add main target as well
+            units = FilterAoeUnits(caster, units).ToList();
 
             targets.AddRange(units);
             // TODO : Need to this if this is needed
@@ -705,7 +701,33 @@ public class Skill
         {
             if (target is Unit trg && Template.TargetType == SkillTargetType.Hostile)
             {
-                HitTypes.TryAdd(trg.ObjId, RollCombatDice(caster, trg));
+                var diceResult = RollCombatDice(caster, trg);
+                if (Template.LevelRuleNoConsideration)
+                {
+                    var damageType = (DamageType)Template.DamageTypeId;
+                    switch (damageType)
+                    {
+                        case DamageType.Melee:
+                            diceResult = SkillHitType.MeleeHit;
+                            break;
+                        case DamageType.Magic:
+                            diceResult = SkillHitType.SpellHit;
+                            break;
+                        case DamageType.Siege:
+                            diceResult = SkillHitType.RangedHit; // no siege version?
+                            break;
+                        case DamageType.Ranged:
+                            diceResult = SkillHitType.RangedHit;
+                            break;
+                        case DamageType.Heal:
+                            diceResult = SkillHitType.SpellHit;
+                            break;
+                        default:
+                            diceResult = SkillHitType.Invalid;
+                            break;
+                    }
+                }
+                HitTypes.TryAdd(trg.ObjId, diceResult);
             }
             if (target is Doodad doodad)
             {

--- a/AAEmu.Game/Models/Game/Units/BaseUnit.cs
+++ b/AAEmu.Game/Models/Game/Units/BaseUnit.cs
@@ -1,8 +1,11 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Chat;
 using AAEmu.Game.Models.Game.Faction;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Skills.Templates;
@@ -56,23 +59,34 @@ public class BaseUnit : GameObject, IBaseUnit
     public bool CanAttack(BaseUnit target)
     {
         if (this.Faction == null || target.Faction == null)
-            return false;
+            return true;
         if (this.ObjId == target.ObjId)
             return false;
         var relation = GetRelationStateTo(target);
+
         var zone = ZoneManager.Instance.GetZoneByKey(target.Transform.ZoneId);
+        var zoneFaction = FactionManager.Instance.GetFaction(zone.FactionId);
+        var targetMotherFaction = target.Faction?.MotherId ?? 0;
+        if (targetMotherFaction != 0 && ((targetMotherFaction == zoneFaction.MotherId) || (targetMotherFaction == zoneFaction.Id)))
+        {
+            // Target is protected by mother zone, can't attack it
+            return false;
+        }
+
         if (this is Character me && target is Character other)
         {
             var trgIsFlagged = other.Buffs.CheckBuff((uint)BuffConstants.Retribution);
 
-            //check safezone
-            if (other.Faction.MotherId != 0 && other.Faction.MotherId == zone.FactionId
-                && !me.IsActivelyHostile(other) && !trgIsFlagged)
+            // Check Safe-zone
+            if (other.Faction.MotherId != 0 &&
+                other.Faction.MotherId == zone.FactionId
+                && !me.IsActivelyHostile(other) &&
+                !trgIsFlagged)
             {
                 return false;
             }
 
-            bool isTeam = TeamManager.Instance.AreTeamMembers(me.Id, other.Id);
+            var isTeam = TeamManager.Instance.AreTeamMembers(me.Id, other.Id);
             if (trgIsFlagged && !isTeam && relation == RelationState.Friendly)
             {
                 return true;
@@ -84,14 +98,24 @@ public class BaseUnit : GameObject, IBaseUnit
         }
         else
         {
-            //handle non-players. Do we need to check target is Npc?
+            // Handle non-players. Do we need to check target is Npc?
 
-            //Check if npc is protected by safe zone
-            //TODO fix npc safety
-            //if (zone.FactionId != 0 && target.Faction.MotherId == zone.FactionId)
-            //return false;
+            // Check if npc is protected by safe zone
+            // TODO: fix npc safety
+            // if (zone.FactionId != 0 && target.Faction.MotherId == zone.FactionId)
+            //     return false;
         }
 
+        /*
+        // Debug info for player on attacking
+        if (this is Character player)
+        {
+            var targetName = target.Name;
+            if (target is Npc npc)
+                targetName = "@NPC_NAME(" + npc.TemplateId.ToString() + ")";
+            player.SendMessage(ChatType.Shout, $"CanAttack? in Zone:{zoneFaction.Name} => {player.Name} {player.Faction?.Name} => {targetName} ({target.ObjId}) {target.Faction?.Name} = {relation}");
+        }
+        */
 
         return relation == RelationState.Hostile;
     }


### PR DESCRIPTION
This PR fixes issues with AoE skills like ``Concussive Arrow (Archery)`` that would fail to properly AoE, could miss and could trigger Bloodlust as well (multiple bugs)

- Default undefined factions to Friendly instead of Hostile
- Re-enable the auto-purpling prevention check
- Code cleaning
- Fixed AoE targetting
- Added support for always-hit skills
- Added support for zone protection to ``CanAttack`` to protect NPCs and Players that are in their faction zones. (can no longer use AoEs to force-hit them)