### PR TITLE
[Game] Fix Quest taking too many item on complete

### DIFF
--- a/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjItemGather.cs
+++ b/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjItemGather.cs
@@ -1,4 +1,5 @@
-﻿using AAEmu.Game.Models.Game.Char;
+﻿using System;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Quests.Templates;
 
@@ -24,6 +25,7 @@ public class QuestActObjItemGather : QuestActTemplate // Сбор предмет
             ItemId, Count, UseAlias, QuestActObjAliasId, HighlightDoodadId, HighlightDoodadPhase, quest.TemplateId, objective, quest.Template.Score);
 
         var res = false;
+        var maxCleanup = quest.Template.LetItDone ? Count * 7 / 5 : Count;
         if (quest.Template.Score > 0) // Check if the quest use Template.Score or Count
         {
             GatherStatus = objective * Count; // Count в данном случае % за единицу
@@ -56,7 +58,7 @@ public class QuestActObjItemGather : QuestActTemplate // Сбор предмет
         }
 
         if (res && Cleanup)
-            quest.QuestCleanupItemsPool.Add(new ItemCreationDefinition(ItemId, objective));
+            quest.QuestCleanupItemsPool.Add(new ItemCreationDefinition(ItemId, Math.Min(maxCleanup, objective)));
 
         return res;
     }


### PR DESCRIPTION
- Fixed QuestActObjItemGather from taking too many items when completing a quest by capping it, rather than taking the objective value. (e.g. Quest Daily quest a Lily Offering from the Nui Priestess)
