### PR TITLE
[Game] Fix - Doodad Area Trigger OnDelete

### DIFF
--- a/AAEmu.Game/Core/Managers/World/AreaTriggerManager.cs
+++ b/AAEmu.Game/Core/Managers/World/AreaTriggerManager.cs
@@ -31,6 +31,7 @@ public class AreaTriggerManager : Singleton<AreaTriggerManager>
 
     public void AddAreaTrigger(AreaTrigger trigger)
     {
+        trigger.Owner?.AttachAreaTriggers.Add(trigger);
         lock (_addLock)
         {
             _addQueue.Add(trigger);

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -18,6 +18,7 @@ using AAEmu.Game.Models.Game.DoodadObj.Templates;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Models.Tasks.Doodads;
 
 /*
@@ -189,6 +190,7 @@ public class Doodad : BaseUnit
     private bool _deleted = false;
     public VehicleSeat Seat { get; set; }
     private List<uint> ListGroupId { get; set; }
+    public List<AreaTrigger> AttachAreaTriggers { get; set; } = new List<AreaTrigger>();
 
     public Doodad()
     {
@@ -612,6 +614,11 @@ public class Doodad : BaseUnit
     {
         base.Delete();
         _deleted = true;
+        foreach (var areaTrigger in AttachAreaTriggers)
+        {
+            AreaTriggerManager.Instance.RemoveAreaTrigger(areaTrigger);
+        }
+        AttachAreaTriggers.Clear();
 
         // Delete associated item if expired
         if (ItemId > 0)

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/RemoveDoodad.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/RemoveDoodad.cs
@@ -29,6 +29,9 @@ public class RemoveDoodad : SpecialEffectAction
         if (doodads != null)
             foreach (var doodad in doodads)
                 if (doodad.TemplateId == value1)
+                {
+                    doodad.Delete();
                     doodad.BroadcastPacket(new SCDoodadRemovedPacket(doodad.ObjId), false);
+                }
     }
 }

--- a/AAEmu.Game/Models/Tasks/Doodads/DoodadFuncCloutTask.cs
+++ b/AAEmu.Game/Models/Tasks/Doodads/DoodadFuncCloutTask.cs
@@ -15,16 +15,17 @@ public class DoodadFuncCloutTask : DoodadFuncTask
     private Doodad _owner;
     private uint _skillId;
     private int _nextPhase;
-    private AreaTrigger _araAreaTrigger;
+    private AreaTrigger _areaTrigger;
 
-    public DoodadFuncCloutTask(BaseUnit caster, Doodad owner, uint skillId, int nextPhase, AreaTrigger araAreaTrigger) : base(caster, owner, skillId)
+    public DoodadFuncCloutTask(BaseUnit caster, Doodad owner, uint skillId, int nextPhase, AreaTrigger areaTrigger) : base(caster, owner, skillId)
     {
         _caster = caster;
         _owner = owner;
         _skillId = skillId;
         _nextPhase = nextPhase;
-        _araAreaTrigger = araAreaTrigger;
+        _areaTrigger = areaTrigger;
     }
+
     public override void Execute()
     {
         if (_caster is Character)
@@ -37,7 +38,7 @@ public class DoodadFuncCloutTask : DoodadFuncTask
         if (_nextPhase == -1)
             _owner.Delete();
 
-        AreaTriggerManager.Instance.RemoveAreaTrigger(_araAreaTrigger);
+        AreaTriggerManager.Instance.RemoveAreaTrigger(_areaTrigger);
         _owner.DoChangePhase(_caster, _nextPhase);
     }
 }


### PR DESCRIPTION
- Some changes to make skills like Vitalism - **Twilight** to work correctly.
- Added some code, so that when a ``AreaTrigger`` gets removed the Units inside it get a proper ``OnLeave()`` event.
- Added some code to ``Doodad``, that when removed, they also remove the related AreaTrigger to this doodad
