### PR TITLE
[Game] Fix - Ownerless Slaves

### DIFF
--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -586,7 +586,7 @@ public class Slave : Unit
     {
         character.SendPacket(new SCUnitStatePacket(this));
         character.SendPacket(new SCUnitPointsPacket(ObjId, Hp, Mp));
-        character.SendPacket(new SCSlaveStatePacket(ObjId, TlId, Summoner.Name, Summoner.ObjId, Id));
+        character.SendPacket(new SCSlaveStatePacket(ObjId, TlId, Summoner?.Name ?? string.Empty, Summoner?.ObjId ?? 0, Id));
 
         base.AddVisibleObject(character);
 


### PR DESCRIPTION
Fixed a bug where trying to show a ownerless Slave would result in a null exception and disconnect.
This fixes Issue #788