### PR TITLE
[Game] Fixed missing allow furniture recovery flag

### DIFF
--- a/AAEmu.Game/Models/Game/Housing/House.cs
+++ b/AAEmu.Game/Models/Game/Housing/House.cs
@@ -303,7 +303,7 @@ public sealed class House : Unit
         stream.Write(Helpers.ConvertLongY(Transform.World.Position.Y));
         stream.Write(Transform.World.Position.Z);
         stream.Write(Name); // house // TODO max length 128
-        stream.Write(true); // allowRecover
+        stream.Write(AllowRecover); // allowRecover
         stream.Write(SellPrice); // Sale moneyAmount
         stream.Write(SellToPlayerId); // type(id)
         stream.Write(sellToPlayerName ?? ""); // sellToName


### PR DESCRIPTION
Fixed the issue where the saved recovery state was not applied to the house packet.
