### PR TITLE
[Game] Fix: Add item from loopack

### DIFF
--- a/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
+++ b/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
@@ -192,7 +192,7 @@ public class LootPack
                 continue;
             }
 
-            if (!character.Inventory.Bag.AcquireDefaultItem(taskType, tuple.itemId, tuple.count, tuple.grade))
+            if (!character.Inventory.TryAddNewItem(taskType, tuple.itemId, tuple.count, tuple.grade))
                 Logger.Error($"Unable to give loot to {character.Name} - ItemId: {tuple.itemId} x {tuple.count} at grade {tuple.grade}");
         }
     }


### PR DESCRIPTION
Changed the item add function for adding items from lootpack to use generic ``TryAddNewItem`` instead of adding directly to the bag. This fixes the issues with larders and any other lootpack that would result in a backpack.