### PR TITLE
[Game] fixing client crash when handing over NPC trade pack:

### DIFF
--- a/AAEmu.Game/Core/Packets/C2G/CSSellBackpackGoodsPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSellBackpackGoodsPacket.cs
@@ -14,8 +14,8 @@ public class CSSellBackpackGoodsPacket : GamePacket
     {
         var objId = stream.ReadBc();
 
-        SpecialtyManager.Instance.SellSpecialty(Connection.ActiveChar, objId);
+        var basePrice = SpecialtyManager.Instance.SellSpecialty(Connection.ActiveChar, objId);
 
-        Logger.Warn("CSSellBackpackGoods, ObjId: {0}. BasePrice: {1}", objId);
+        Logger.Warn($"CSSellBackpackGoods, ObjId: {objId}. BasePrice: {basePrice}");
     }
 }


### PR DESCRIPTION
I tried to return "ID=8665, Relic Collector Camila" for the product "ID=28941, Honey Trade Pack" and got the client disconnected.

It turned out that there is no such Npc in the specialty_npcs table.

As a solution to the problem, we return from the GetBasePriceForSpecialty() method not 0, but 1, and then the product is sold at the minimum price.