### PR TITLE
[Game] InvalidCastException error fix:

### DIFF
--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -801,7 +801,7 @@ public class Npc : Unit
     {
         //var player = unit as Character; // TODO player.Region становится равным null | player.Region becomes null
         Character player = null;
-        if (unit is not Npc and not Units.Mate)
+        if (unit is not Npc and not Units.Mate and not Slave)
         {
             player = (Character)unit;
         }


### PR DESCRIPTION
- if a character fires a cannon at an Npc, the error InvalidCastException: Unable to cast object of type 'Slave' to type 'Character' appears;