### PR TITLE
#739 [Game] fixed negative LP when crafting materials:

### DIFF
--- a/AAEmu.Game/Core/Packets/G2C/SCCraftFailedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCCraftFailedPacket.cs
@@ -1,0 +1,31 @@
+﻿using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+public class SCCraftFailedPacket : GamePacket
+{
+    private readonly uint _id;
+    private readonly uint _craftId;
+    private readonly int _count;
+
+    // TODO needs fixing
+    public SCCraftFailedPacket(uint id, uint craftId, int count) : base(SCOffsets.SCCraftFailedPacket, 1)
+    {
+        _id = id;
+        _craftId = craftId;
+        _count = count;
+    }
+
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(_id);
+        stream.Write(_count);
+        for (var i = 0; i < _count; i++)
+        {
+            stream.Write(_craftId);
+        }
+
+        return stream;
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -1024,9 +1024,9 @@ public class Skill
 
         if (caster is Character character)
         {
-            if (Template.ConsumeLaborPower > 0 && !Cancelled)
+            if (Template.ConsumeLaborPower > 0 && !Cancelled && character.LaborPower >= Template.ConsumeLaborPower)
             {
-                // Consume labor
+                // Consume labor only if there is enough of it
                 character.ChangeLabor((short)-Template.ConsumeLaborPower, Template.ActabilityGroupId);
             }
 


### PR DESCRIPTION
- When crafting simultaneously a large number of resources on machines, Labor Power goes beyond the minimum permissible values ​​(less than 0). As a result, you can craft an endless amount of resources, even if the player does not have enough Labor Power.

- Nothing I can do better than dummy cycles of the crafting skell so that the crafting doesn't hang. Superfluous cycles can be interrupted.

- Added packet SCCraftFailedPacket (needs fixing);