### PR TITLE
[Game] Added Specialty Trade rates panel

### DIFF
--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -1150,7 +1150,7 @@ public class ItemManager : Singleton<ItemManager>
                         var template = _templates.TryGetValue(id, out var templateRes) ? templateRes : new ItemTemplate();
                         template.Id = id;
                         template.Name = reader.IsDBNull("name") ? "" : reader.GetString("name");
-                        template.Category_Id = reader.GetInt32("category_id");
+                        template.CategoryId = reader.GetInt32("category_id");
                         template.Level = reader.GetInt32("level");
                         template.Price = reader.GetInt32("price");
                         template.Refund = reader.GetInt32("refund");
@@ -1169,6 +1169,7 @@ public class ItemManager : Singleton<ItemManager>
                         template.ExpAbsLifetime = reader.GetInt32("exp_abs_lifetime");
                         template.ExpOnlineLifetime = reader.GetInt32("exp_online_lifetime");
                         template.ExpDate = !reader.IsDBNull("exp_date") ? reader.GetDateTime("exp_date") : DateTime.MinValue;
+                        template.SpecialtyZoneId = !reader.IsDBNull("specialty_zone_id") ? reader.GetUInt32("specialty_zone_id") : 0;
                         template.LevelRequirement = reader.GetInt32("level_requirement");
                         template.AuctionCategoryA = reader.IsDBNull("auction_a_category_id") ? 0 : reader.GetInt32("auction_a_category_id");
                         template.AuctionCategoryB = reader.IsDBNull("auction_b_category_id") ? 0 : reader.GetInt32("auction_b_category_id");

--- a/AAEmu.Game/Core/Network/Game/GameNetwork.cs
+++ b/AAEmu.Game/Core/Network/Game/GameNetwork.cs
@@ -283,7 +283,7 @@ public class GameNetwork : Singleton<GameNetwork>
         RegisterPacket(CSOffsets.CSRankCharacterPacket, 1, typeof(CSRankCharacterPacket));
         RegisterPacket(CSOffsets.CSRequestSecondPasswordKeyTablesPacket, 1, typeof(CSRequestSecondPasswordKeyTablesPacket));
         // 0x130 CSRankSnapshotPacket
-        // 0x131 unk packet
+        RegisterPacket(CSOffsets.CSRequestSpecialtyCurrentPacket, 1, typeof(CSRequestSpecialtyCurrentPacket));
         RegisterPacket(CSOffsets.CSIdleStatusPacket, 1, typeof(CSIdleStatusPacket));
         // 0x133 CSChangeAutoUseAAPointPacket
         RegisterPacket(CSOffsets.CSThisTimeUnpackItemPacket, 1, typeof(CSThisTimeUnpackItemPacket));

--- a/AAEmu.Game/Core/Packets/C2G/CSOffsets.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSOffsets.cs
@@ -263,7 +263,7 @@ public static class CSOffsets
     public const ushort CSRankCharacterPacket = 0x12F;
     public const ushort CSRequestSecondPasswordKeyTablesPacket = 0x125;
     // 0x130 CSRankSnapshotPacket
-    // 0x131 unk packet
+    public const ushort CSRequestSpecialtyCurrentPacket = 0x131;
     public const ushort CSIdleStatusPacket = 0x132;
     // 0x133 CSChangeAutoUseAAPointPacket
     public const ushort CSThisTimeUnpackItemPacket = 0x134;

--- a/AAEmu.Game/Core/Packets/C2G/CSRequestSpecialtyCurrentPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRequestSpecialtyCurrentPacket.cs
@@ -1,0 +1,27 @@
+﻿using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Core.Packets.G2C;
+
+namespace AAEmu.Game.Core.Packets.C2G;
+
+public class CSRequestSpecialtyCurrentPacket : GamePacket
+{
+    public CSRequestSpecialtyCurrentPacket() : base(CSOffsets.CSRequestSpecialtyCurrentPacket, 1)
+    {
+        //
+    }
+
+    public override void Read(PacketStream stream)
+    {
+        var fromZoneGroupId = stream.ReadUInt16();
+        var toZoneGroupId = stream.ReadUInt16();
+        Logger.Trace($"RequestSpecialityRates: Player {Connection.ActiveChar.Name}, FromZoneGroup {fromZoneGroupId}, ToZoneGroup {toZoneGroupId}");
+        var items = SpecialtyManager.Instance.GetRatiosForTargetRoute(fromZoneGroupId, toZoneGroupId);
+        /*
+        foreach (var (itemId, rate) in items)
+            Connection.ActiveChar.SendMessage($"@ITEM_NAME({itemId}) => {rate}%");
+        */
+        Connection.ActiveChar.SendPacket(new SCSpecialtyCurrentPacket(fromZoneGroupId, toZoneGroupId, items));
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCSpecialtyCurrentPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCSpecialtyCurrentPacket.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+public class SCSpecialtyCurrentPacket : GamePacket
+{
+    private ushort _fromZoneGroup;
+    private ushort _toZoneGroup;
+    private List<(uint, uint)> _results;
+
+    public SCSpecialtyCurrentPacket(ushort fromZoneGroup, ushort toZoneGroup, List<(uint, uint)> results) : base(SCOffsets.SCSpecialtyCurrentPacket, 1)
+    {
+        _fromZoneGroup = fromZoneGroup;
+        _toZoneGroup = toZoneGroup;
+        _results = results;
+    }
+
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(_results.Count);
+        stream.Write(_fromZoneGroup);
+        stream.Write(_toZoneGroup);
+        foreach (var (itemId, rate) in _results)
+        {
+            stream.Write(itemId);
+            stream.Write(rate);
+        }
+        return stream;
+    }
+}

--- a/AAEmu.Game/Models/Game/Items/Templates/ItemTemplate.cs
+++ b/AAEmu.Game/Models/Game/Items/Templates/ItemTemplate.cs
@@ -9,10 +9,10 @@ public class ItemTemplate
 
     public uint Id { get; set; }
     /// <summary>
-    /// Original Korean name is stored here, use LocalizationManager to get the names for other langauges
+    /// Original Korean name is stored here, use LocalizationManager to get the names for other languages
     /// </summary>
     public string Name { get; set; }
-    public int Category_Id { get; set; }
+    public int CategoryId { get; set; }
     public int Level { get; set; }
     public int Price { get; set; }
     public int Refund { get; set; }
@@ -40,6 +40,7 @@ public class ItemTemplate
     public bool Disenchantable { get; set; }
     public int LivingPointPrice { get; set; }
     public byte CharGender { get; set; }
+    public uint SpecialtyZoneId { get; set; }
 
     // Helpers
     public string searchString { get; set; }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/PlayUserMusic.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/PlayUserMusic.cs
@@ -42,7 +42,7 @@ public class PlayUserMusic : SpecialEffectAction
             {
                 // I'm sure we can get this relation info from the tables somewhere, but can't find it
                 // TODO: It might be that instrument doodads require special handling (not tested)
-                switch ((ItemCategory)instrument.Template.Category_Id)
+                switch ((ItemCategory)instrument.Template.CategoryId)
                 {
                     case ItemCategory.Lute:
                         target.Buffs.AddBuff((uint)BuffConstants.LutePlay, caster);


### PR DESCRIPTION
- Implemented the functionality of the Trade Rate Window where you can see the current rates from and to zones.
- Changed ItemTemplate.Category_Id to ItemTemplate.CategoryId
- Changed SpecialtyManager's implementation of _priceRatios and _soldPackAmountInTack so they now use ZoneGroup instead of ZoneKey (which was technically a potential bug)
