### PR TITLE
[Game] Added null check in PopulateDistrictPortals

### DIFF
--- a/AAEmu.Game/Models/Game/Char/CharacterPortals.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterPortals.cs
@@ -248,7 +248,7 @@ public class CharacterPortals
 
             //var returnPointsId = PortalManager.Instance.GetDistrictReturnPoint(subZone.Value.Id, Owner.Faction.Id);
 
-            if (portals.Count == 0) { continue; }
+            if ((portals == null) || (portals.Count == 0)) { continue; }
 
             foreach (var portal in portals)
             {


### PR DESCRIPTION
Added a additional null-check in ``CharacterPortals.PopulateDistrictPortals`` to help mitigate invalid subzone entries preventing player from logging in is there were errors with the DB or configuration settings.
