### PR TITLE
[Game] Fixed guild house permissions

### DIFF
--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -689,30 +689,13 @@ public class HousingManager : Singleton<HousingManager>
     public void ChangeHousePermission(GameConnection connection, ushort tlId, HousingPermission permission)
     {
         if (!_housesTl.TryGetValue(tlId, out var house))
-            return;
+            return; // invalid house
 
         if (house.OwnerId != connection.ActiveChar.Id)
-            return;
-
-        switch (permission)
-        {
-            case HousingPermission.Guild when connection.ActiveChar.Expedition == null:
-            case HousingPermission.Family when connection.ActiveChar.Family == 0:
-                return;
-            case HousingPermission.Guild:
-                house.CoOwnerId = connection.ActiveChar.Expedition.Id;
-                break;
-            case HousingPermission.Family:
-                house.CoOwnerId = connection.ActiveChar.Family;
-                break;
-            default:
-                house.CoOwnerId = connection.ActiveChar.Id;
-                break;
-        }
-
+            return; // not the owner
+        
         house.Permission = permission;
         house.BroadcastPacket(new SCHousePermissionChangedPacket(tlId, (byte)permission), false);
-        // connection.SendPacket(new SCHousePermissionChangedPacket(tlId, (byte)permission));
     }
 
     /// <summary>
@@ -1549,7 +1532,7 @@ public class HousingManager : Singleton<HousingManager>
         house.SellToPlayerId = 0;
         house.AccountId = character.AccountId;
         house.OwnerId = character.Id;
-        house.CoOwnerId = character.Id;
+        house.CoOwnerId = character.Id; // not entirely sure if this actually needs to change
         house.Permission = house.Template.AlwaysPublic ? HousingPermission.Public : HousingPermission.Private;
         UpdateHouseFaction(house, character.Faction.Id);
         UpdateTaxInfo(house); // send tax due mails etc if needed ...

--- a/AAEmu.Game/Core/Packets/G2C/SCUnitStatePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCUnitStatePacket.cs
@@ -260,6 +260,7 @@ public class SCUnitStatePacket : GamePacket
                 break;
         }
 
+        // ???, ??? and Appellation (Title)
         if (character is not null)
         {
             stream.WritePisc(0, 0, character.Appellations.ActiveAppellation, 0); // pisc
@@ -269,6 +270,7 @@ public class SCUnitStatePacket : GamePacket
             stream.WritePisc(0, 0, 0, 0); // pisc
         }
 
+        // Faction and Guild
         stream.WritePisc(_unit.Faction?.Id ?? 0, _unit.Expedition?.Id ?? 0, 0, 0); // pisc
 
         if (character is not null)
@@ -285,6 +287,7 @@ public class SCUnitStatePacket : GamePacket
                 flags.Set(13);
             }
 
+            // PvP Honor gained and PvP Kills
             stream.WritePisc(character.HonorGainedInCombat, character.HostileFactionKills); // очки чести полученные в PvP, кол-во убийств в PvP
             stream.Write(flags.ToByteArray()); // flags(ushort)
             /*
@@ -299,8 +302,9 @@ public class SCUnitStatePacket : GamePacket
         }
         else
         {
+            // PvP Honor gained and PvP Kills
             stream.WritePisc(0, 0); // pisc
-            stream.Write((ushort)8192); // flags
+            stream.Write((ushort)0x2000); // flags
         }
 
         if (character is not null)

--- a/AAEmu.Game/Models/Game/Housing/House.cs
+++ b/AAEmu.Game/Models/Game/Housing/House.cs
@@ -341,7 +341,7 @@ public sealed class House : Unit
         switch (Permission)
         {
             case HousingPermission.Private:
-                if (player.Id != OwnerId)
+                if (player.Id == OwnerId)
                     return base.AllowedToInteract(player);
                 var ownerAccount = NameManager.Instance.GetCharaterAccount(OwnerId);
                 return (player.AccountId == ownerAccount) && base.AllowedToInteract(player);

--- a/AAEmu.Game/Models/Game/Housing/House.cs
+++ b/AAEmu.Game/Models/Game/Housing/House.cs
@@ -10,6 +10,7 @@ using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.DoodadObj.Static;
+using AAEmu.Game.Models.Game.Expeditions;
 using AAEmu.Game.Models.Game.Units;
 using MySql.Data.MySqlClient;
 
@@ -116,6 +117,21 @@ public sealed class House : Unit
     public uint SellPrice { get => _sellPrice; set { _sellPrice = value; _isDirty = true; } }
     public bool AllowRecover { get => _allowRecover; set { _allowRecover = value; _isDirty = true; } }
 
+    // House always gets its guild from its owner
+    public override Expedition Expedition
+    {
+        get
+        {
+            var guildId = ExpeditionManager.Instance.GetExpeditionOfCharacter(OwnerId);
+            if (guildId == 0)
+                return null;
+            return ExpeditionManager.Instance.GetExpedition(guildId);
+        }
+        set
+        {
+            // Ignored, we always get the guild from its owner
+        }
+    }
 
     public House()
     {
@@ -281,8 +297,8 @@ public sealed class House : Unit
         stream.Write(TemplateId);
         stream.WritePisc(ModelId, 0);
         //stream.Write(ModelId); // ht
-        stream.Write(CoOwnerId); // type(id)
-        stream.Write(OwnerId); // type(id)
+        stream.Write(CoOwnerId); // original owner who placed the building
+        stream.Write(OwnerId); // current owner
         stream.Write(ownerName ?? "");
         stream.Write(AccountId);
         stream.Write((byte)Permission);
@@ -329,9 +345,10 @@ public sealed class House : Unit
                     return base.AllowedToInteract(player);
                 var ownerAccount = NameManager.Instance.GetCharaterAccount(OwnerId);
                 return (player.AccountId == ownerAccount) && base.AllowedToInteract(player);
-            case HousingPermission.Family when (player.Family != CoOwnerId):
-            case HousingPermission.Guild when (player.Expedition.Id != CoOwnerId):
-                return false;
+            case HousingPermission.Family when (player.Family > 0):
+                return FamilyManager.Instance.GetFamily(player.Family).Members.Any(x => x.Id == OwnerId);
+            case HousingPermission.Guild when (player.Expedition?.Id > 0):
+                return player.Expedition.Members.Any(x => x.CharacterId == OwnerId);
             case HousingPermission.Public:
             default:
                 return base.AllowedToInteract(player);

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -218,7 +218,7 @@ public class Unit : BaseUnit, IUnit
     public PlotState ActivePlotState { get; set; }
     public Dictionary<uint, List<Bonus>> Bonuses { get; set; }
     public UnitCooldowns Cooldowns { get; set; }
-    public Expedition Expedition { get; set; }
+    public virtual Expedition Expedition { get; set; }
 
     public bool IsInBattle
     {


### PR DESCRIPTION
- Made Unit's Expedition virtual so it can be overridden in House.
- Added code that always grabs a house's guild from its owner.
- Fixed a small issue where CoOwner was used incorrectly
- Added a few comments to SCUnitStatePacket

This should fix issue #899