### PR TITLE
Fixed the wrong coordinates on the Sungold Fields teleport command.

### DIFF
--- a/AAEmu.Game/Scripts/Commands/Teleport.cs
+++ b/AAEmu.Game/Scripts/Commands/Teleport.cs
@@ -366,9 +366,9 @@ public class Teleport : ICommand
             Region = TeleportCommandRegions.Auroria,
             Name = "sungold",
             Info = "Sungold Fields",
-            X = 22349,
-            Y = 24941,
-            Z = 189
+            X = 22122,
+            Y = 26412,
+            Z = 163
         });
         // locations.Add(new TPloc { Region = TeleReg.Origin, Name = "whalesong", Info = "Whalesong Harbor", X = 14436, Y = 26696, Z = 135, altNames = ("whale"} });
         #endregion


### PR DESCRIPTION
Once again a minor thing but it'd seem the current sungold teleport command actually takes you to Exeloch. I've changed the coordinates to match those of Sungold Fields.