### PR TITLE
[Game] Fix Test Timbre Coupe spawn

### DIFF
--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -621,7 +621,9 @@ public class SlaveManager : Singleton<SlaveManager>
         }
 
         foreach (var slaveBinding in summonedSlave.Template.SlaveBindings)
-        {
+        { 
+            if (slaveBinding.OwnerType != "Slave")
+                continue;
             var childSlaveTemplate = GetSlaveTemplate(slaveBinding.SlaveId);
             var childTlId = (ushort)TlIdManager.Instance.GetNextId();
             var childObjId = ObjectIdManager.Instance.GetNextId();

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnEffect.cs
@@ -54,7 +54,7 @@ public class SpawnEffect : EffectTemplate
                     spawner.Position.X = xx;
                     spawner.Position.Y = yy;
                     spawner.Position.Z = zz;
-                    spawner.Position.Yaw = PosAngle;
+                    spawner.Position.Yaw = PosAngle.DegToRad();
 
                     spawner.RespawnTime = 0; // don't respawn
 
@@ -65,10 +65,11 @@ public class SpawnEffect : EffectTemplate
                 {
                     if (caster is Character player)
                     {
-                        var transform = player.Transform.CloneDetached();
+                        // TODO: Implement OriDirId, PosDirId and MateStateId
+                        using var transform = player.Transform.CloneDetached();
                         if (PosDistance == 0) { PosDistance = 2; }
                         transform.World.AddDistanceToFront(PosDistance);
-                        transform.World.Rotate(transform.World.Rotation with { Z = OriAngle });
+                        transform.World.Rotate(transform.World.Rotation with { Z = OriAngle.DegToRad() });
 
                         var slave = SlaveManager.Instance.Create(SubType, true, transform);
                         if (slave is { Template: null })


### PR DESCRIPTION
- Fixed Slave spawning to properly ignore slave bindings belonging to houses (canon bug was from a tower)
- Fixed spawn rotation by adding missing DegToRad function on the angle arguments in SpawnEffect
