### PR TITLE
[Game] Implement PosDirId and OriDirId for NPC-based SpawnEffect

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnEffect.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Numerics;
+
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets;
@@ -45,16 +45,41 @@ public class SpawnEffect : EffectTemplate
                         Logger.Info($"SpawnEffect: SubType={SubType} not found in spawners.");
                         return;
                     }
-                    var (xx, yy) = MathUtil.AddDistanceToFrontDeg(PosDistance, target.Transform.World.Position.X, target.Transform.World.Position.Y, PosAngle);
-                    var zz = WorldManager.Instance.GetHeight(target.Transform.ZoneId, xx, yy);
-                    if (zz == 0)
+
+                    // dir id 1 = relative to target/spawner.
+                    // dir id 2 = relative to caster.
+                    var positionRelativeToUnit = PosDirId switch
                     {
-                        zz = target.Transform.World.Position.Z;
+                        1 => target,
+                        2 => caster,
+                        _ => null
+                    };
+                    var orientationRelativeToUnit = OriDirId switch
+                    {
+                        1 => target,
+                        2 => caster,
+                        _ => null
+                    };
+
+                    if (positionRelativeToUnit == null || orientationRelativeToUnit == null)
+                    {
+                        Logger.Warn($"SpawnEffect: Unhandled PosDirId {PosDirId} or OriDirId {OriDirId}");
+                        return;
                     }
+
+                    var (xx, yy) = MathUtil.AddDistanceToFrontDeg(PosDistance, positionRelativeToUnit.Transform.World.Position.X, positionRelativeToUnit.Transform.World.Position.Y, PosAngle);
+
+                    // TODO: Not sure if this is needed.
+                    //var zz = WorldManager.Instance.GetHeight(target.Transform.ZoneId, xx, yy);
+                    //if (zz == 0) {
+                    //	zz = target.Transform.World.Position.Z;
+                    //}
+
                     spawner.Position.X = xx;
                     spawner.Position.Y = yy;
-                    spawner.Position.Z = zz;
-                    spawner.Position.Yaw = PosAngle.DegToRad();
+                    spawner.Position.Z = positionRelativeToUnit.Transform.World.Position.Z;
+
+                    spawner.Position.Yaw = orientationRelativeToUnit.Transform.World.Rotation.Z + OriAngle.DegToRad();
 
                     spawner.RespawnTime = 0; // don't respawn
 


### PR DESCRIPTION
Adds `PosDirId` and `OriDirId` support for NPC-based SpawnEffects, which fixes the General Merchant's Cushion (28440), Warehouse Manager's Cushion (28441), and Elite Merchant's Cushion (28386), spawning them in the correct position and rotating them to face the player.

It would be good to check the code still works as intended in other cases, but I'm not sure what else to test with. Same for supporting `BaseUnitType.Slave`, I'm also not sure what to test with.

Should fix https://github.com/AAEmu/AAEmu/issues/903

![image](https://github.com/AAEmu/AAEmu/assets/32184718/9d872828-821e-4580-beda-c60f34d45e9f)
