### PR TITLE
[Game] Fixed persistent Vehicle saving

### DIFF
--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+
+using MySql.Data.MySqlClient;
 
 using AAEmu.Commons.IO;
 using AAEmu.Commons.Utils;
@@ -32,8 +34,6 @@ using AAEmu.Game.Models.Tasks.Slave;
 using AAEmu.Game.Utils;
 using AAEmu.Game.Utils.DB;
 
-#pragma warning disable CA2000 // Dispose objects before losing scope
-
 using NLog;
 
 namespace AAEmu.Game.Core.Managers;
@@ -45,9 +45,9 @@ public class SlaveManager : Singleton<SlaveManager>
     private Dictionary<uint, Slave> _activeSlaves;
     private List<Slave> _testSlaves;
     private Dictionary<uint, Slave> _tlSlaves;
-    public Dictionary<uint, Dictionary<AttachPointKind, WorldSpawnPosition>> _attachPoints;
-    public Dictionary<uint, List<SlaveInitialItems>> _slaveInitialItems; // PackId and List<Slot/ItemData>
-    public Dictionary<uint, SlaveMountSkills> _slaveMountSkills;
+    private Dictionary<uint, Dictionary<AttachPointKind, WorldSpawnPosition>> _attachPoints;
+    private Dictionary<uint, List<SlaveInitialItems>> _slaveInitialItems; // PackId and List<Slot/ItemData>
+    private Dictionary<uint, SlaveMountSkills> _slaveMountSkills;
     public Dictionary<uint, uint> _repairableSlaves; // SlaveId, RepairEffectId
 
     private object _slaveListLock;
@@ -59,13 +59,13 @@ public class SlaveManager : Singleton<SlaveManager>
 
     public SlaveTemplate GetSlaveTemplate(uint id)
     {
-        return _slaveTemplates.TryGetValue(id, out var template) ? template : null;
+        return _slaveTemplates.GetValueOrDefault(id);
     }
 
     public Slave GetActiveSlaveByOwnerObjId(uint objId)
     {
         lock (_slaveListLock)
-            return _activeSlaves.TryGetValue(objId, out var slave) ? slave : null;
+            return _activeSlaves.GetValueOrDefault(objId);
     }
 
     /// <summary>
@@ -116,7 +116,8 @@ public class SlaveManager : Singleton<SlaveManager>
         }
         return null;
     }
-    public Slave GetTestSlaveByObjId(uint objId)
+
+    private Slave GetTestSlaveByObjId(uint objId)
     {
         lock (_slaveListLock)
         {
@@ -138,6 +139,18 @@ public class SlaveManager : Singleton<SlaveManager>
             }
 
             foreach (var slave in _testSlaves.Where(slave => slave.ObjId == objId))
+            {
+                return slave;
+            }
+        }
+        return null;
+    }
+
+    private Slave GetSlaveByDbId(uint dbId)
+    {
+        lock (_slaveListLock)
+        {
+            foreach (var slave in _activeSlaves.Values.Where(slave => slave.Id == dbId))
             {
                 return slave;
             }
@@ -182,6 +195,12 @@ public class SlaveManager : Singleton<SlaveManager>
         return res;
     }
 
+    /// <summary>
+    /// Unmounts a player from a vehicle
+    /// </summary>
+    /// <param name="character"></param>
+    /// <param name="tlId"></param>
+    /// <param name="reason"></param>
     public void UnbindSlave(Character character, uint tlId, AttachUnitReason reason)
     {
         Slave slave;
@@ -201,6 +220,13 @@ public class SlaveManager : Singleton<SlaveManager>
         character.BroadcastPacket(new SCUnitDetachedPacket(character.ObjId, reason), true);
     }
 
+    /// <summary>
+    /// Mounts a player on a vehicle
+    /// </summary>
+    /// <param name="character"></param>
+    /// <param name="objId"></param>
+    /// <param name="attachPoint"></param>
+    /// <param name="bondKind"></param>
     public void BindSlave(Character character, uint objId, AttachPointKind attachPoint, AttachUnitReason bondKind)
     {
         // Check if the target spot is already taken
@@ -226,6 +252,11 @@ public class SlaveManager : Singleton<SlaveManager>
         character.Transform.Local.SetPosition(0, 0, 0, 0, 0, 0);
     }
 
+    /// <summary>
+    /// Mounts a player on a vehicle
+    /// </summary>
+    /// <param name="connection"></param>
+    /// <param name="tlId">Slave TlId</param>
     public void BindSlave(GameConnection connection, uint tlId)
     {
         var unit = connection.ActiveChar;
@@ -236,13 +267,14 @@ public class SlaveManager : Singleton<SlaveManager>
         BindSlave(unit, slave.ObjId, AttachPointKind.Driver, AttachUnitReason.NewMaster);
     }
 
-    // TODO - GameConnection connection
+    // TODO: GameConnection connection
     /// <summary>
     /// Removes a slave from the world
     /// </summary>
     /// <param name="owner"></param>
     /// <param name="objId"></param>
-    public void Delete(Character owner, uint objId)
+    /// <param name="ignoreAttachedItemWarning">If true will not fail if there are attached items</param>
+    public void Delete(Character owner, uint objId, bool ignoreAttachedItemWarning)
     {
         var activeSlaveInfo = GetActiveSlaveByObjId(objId);
         var testSlaveInfo = GetTestSlaveByObjId(objId);
@@ -254,13 +286,16 @@ public class SlaveManager : Singleton<SlaveManager>
         foreach (var character in activeSlaveInfo.AttachedCharacters.Values.ToList())
             UnbindSlave(character, activeSlaveInfo.TlId, AttachUnitReason.SlaveBinding);
 
-        // Check if one of the slave doodads is holding a item
-        foreach (var doodad in activeSlaveInfo.AttachedDoodads)
+        // Check if one of the slave doodads is holding an item
+        if (ignoreAttachedItemWarning == false)
         {
-            if ((doodad.ItemId != 0) || (doodad.ItemTemplateId != 0))
+            foreach (var doodad in activeSlaveInfo.AttachedDoodads)
             {
-                owner?.SendErrorMessage(ErrorMessageType.SlaveEquipmentLoadedItem); // TODO: Do we need this error? Client already mentions it.
-                return; // don't allow un-summon if some it's holding a item (should be a trade-pack)
+                if ((doodad.ItemId != 0) || (doodad.ItemTemplateId != 0))
+                {
+                    owner?.SendErrorMessage(ErrorMessageType.SlaveEquipmentLoadedItem); // TODO: Do we need this error? Client already mentions it.
+                    return; // don't allow un-summon if some it's holding an item (should be a trade-pack)
+                }
             }
         }
 
@@ -294,7 +329,7 @@ public class SlaveManager : Singleton<SlaveManager>
         owner?.BroadcastPacket(new SCSlaveRemovedPacket(owner.ObjId, activeSlaveInfo.TlId), true);
         lock (_slaveListLock)
         {
-            if (testSlaveInfo == null)
+            if ((testSlaveInfo == null) && (owner != null))
                 _activeSlaves.Remove(owner.ObjId); // remove only the ones that we spawn from items
             else
                 _testSlaves.Remove(activeSlaveInfo); // remove only the ones that we spawn from Mirage.
@@ -305,14 +340,14 @@ public class SlaveManager : Singleton<SlaveManager>
     }
 
     /// <summary>
-    /// Slave created from spawn effect since this is a test vehicle from Mirage
+    /// Slave created from spawn effect (e.g. test vehicle from Mirage)
     /// </summary>
-    /// <param name="SubType">TemplateId</param>
+    /// <param name="subType">TemplateId</param>
     /// <param name="hideSpawnEffect"></param>
     /// <param name="positionOverride"></param>
-    public Slave Create(uint SubType, bool hideSpawnEffect = false, Transform positionOverride = null)
+    public Slave Create(uint subType, bool hideSpawnEffect = false, Transform positionOverride = null)
     {
-        var slave = Create(null, null, SubType, null, hideSpawnEffect, positionOverride);
+        var slave = Create(null, null, subType, null, hideSpawnEffect, positionOverride);
         if (slave == null) return null;
         _testSlaves.Add(slave);
 
@@ -333,7 +368,7 @@ public class SlaveManager : Singleton<SlaveManager>
         {
             activeSlaveInfo.Save();
             // TODO: If too far away, don't delete
-            Delete(owner, activeSlaveInfo.ObjId);
+            Delete(owner, activeSlaveInfo.ObjId, false);
             // return;
         }
 
@@ -373,15 +408,19 @@ public class SlaveManager : Singleton<SlaveManager>
         var slaveHp = 1;
         var slaveMp = 1;
         var isLoadedPlayerSlave = false;
+
+        // Check if there's already a slave attached to the summon item (if any)
+        #region load_saved_slave
         if ((owner?.Id > 0) && (item?.Id > 0))
         {
             using var connection = MySQL.CreateConnection();
             using var command = connection.CreateCommand();
-            // Sorting required to make make sure parenting doesn't produce invalid parents (normally)
+            // Sorting required to make sure parenting doesn't produce invalid parents (normally)
 
-            command.CommandText = "SELECT * FROM slaves  WHERE (owner = @playerId) AND (item_id = @itemId) LIMIT 1";
-            command.Parameters.AddWithValue("playerId", owner.Id);
-            command.Parameters.AddWithValue("itemId", item.Id);
+            // owner_type 0 = BaseUnitType.Character
+            command.CommandText = "SELECT * FROM slaves  WHERE (owner_type = 0) AND (owner_id = @playerId) AND (summoner = @playerId) AND (item_id = @itemId) LIMIT 1";
+            command.Parameters.AddWithValue("@playerId", owner.Id);
+            command.Parameters.AddWithValue("@itemId", item.Id);
             command.Prepare();
             using var reader = command.ExecuteReader();
             while (reader.Read())
@@ -403,10 +442,9 @@ public class SlaveManager : Singleton<SlaveManager>
                 break;
             }
         }
-
-        // TODO: Attach Slave's DbId to the Item Details
-        // We currently fake the DbId using TlId instead
-
+        #endregion
+        
+        // Put it at the correct location
         if (spawnPos.Local.IsOrigin())
         {
             if (owner == null && useSpawner == null)
@@ -466,8 +504,8 @@ public class SlaveManager : Singleton<SlaveManager>
                         var delta = surfaceHeight - floorHeight;
                         if (delta > minDepth)
                         {
-                            //owner.SendMessage("Extra inFront = {0}, required Depth = {1}", inFront, minDepth);
-                            spawnPos.Dispose();
+                            // owner.SendMessage("Extra inFront = {0}, required Depth = {1}", inFront, minDepth);
+                            // spawnPos.Dispose();
 
                             spawnPos.ApplyWorldTransformToLocalPosition(depthCheckPos);
                             break;
@@ -490,6 +528,11 @@ public class SlaveManager : Singleton<SlaveManager>
             spawnPos.Local.SetRotation(0f, 0f, owner?.Transform.World.Rotation.Z + MathF.PI / 2 ?? useSpawner.Position.Yaw);
         }
 
+        // Get new Id to save if it has a player as owner
+        if ((owner?.Id > 0) && (dbId <= 0))
+            dbId = CharacterIdManager.Instance.GetNextId(); // CharacterIdManager uses both character and slave IDs to populate
+
+        // Update the summoning item
         if (item is SummonSlave slaveSummonItem)
         {
             slaveSummonItem.SlaveType = 0x02;
@@ -510,12 +553,9 @@ public class SlaveManager : Singleton<SlaveManager>
             owner?.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.UpdateSummonMateItem, new ItemUpdate(item), new List<ulong>()));
         }
 
+        // Create the Slave (packet)
+        #region spawn_base_slave
         owner?.BroadcastPacket(new SCSlaveCreatedPacket(owner.ObjId, tlId, objId, hideSpawnEffect, 0, owner.Name), true);
-
-        // Get new Id to save if it has a player as owner
-        if ((owner?.Id > 0) && (dbId <= 0))
-            dbId = CharacterIdManager.Instance.GetNextId(); // dbId = SlaveIdManager.Instance.GetNextId();
-
         var summonedSlave = new Slave
         {
             TlId = tlId,
@@ -534,16 +574,21 @@ public class SlaveManager : Singleton<SlaveManager>
             SummoningItem = item,
             SpawnTime = DateTime.UtcNow,
             Spawner = useSpawner,
+            OwnerType = owner != null ? BaseUnitType.Character : BaseUnitType.Invalid,
+            OwnerId = owner?.Id ?? 0,
         };
 
         ApplySlaveBonuses(summonedSlave);
 
-        if (!isLoadedPlayerSlave)
+        // If it was loaded from DB, restore previous its HP/MP
+        if (!isLoadedPlayerSlave) 
         {
             summonedSlave.Hp = summonedSlave.MaxHp;
             summonedSlave.Mp = summonedSlave.MaxMp;
         }
 
+        // Equip it's default items
+        // TODO: Implement vehicle customization
         if (_slaveInitialItems.TryGetValue(summonedSlave.Template.SlaveInitialItemPackId, out var itemPack))
         {
             foreach (var initialItem in itemPack)
@@ -554,29 +599,34 @@ public class SlaveManager : Singleton<SlaveManager>
             }
         }
 
+        // Camp HP/MP values as needed 
         summonedSlave.Hp = Math.Min(summonedSlave.Hp, summonedSlave.MaxHp);
         summonedSlave.Mp = Math.Min(summonedSlave.Mp, summonedSlave.MaxMp);
 
-        // Reset HP on "dead" vehicles
+        // Reset HP on "dead" vehicles (can't summon with 0 HP)
         if (summonedSlave.Hp <= 0)
             summonedSlave.Hp = summonedSlave.MaxHp;
 
+        // Move it to target location, and call spawn packet
         summonedSlave.Transform = spawnPos.CloneDetached(summonedSlave);
         summonedSlave.Spawn();
-
-        spawnPos.Dispose();
+        #endregion
 
         // If this was a previously saved slave, load doodads from DB and spawn them
-        var doodadSpawnCount = SpawnManager.Instance.SpawnPersistentDoodads(DoodadOwnerType.Slave, (int)summonedSlave.Id, summonedSlave, true);
-        Logger.Debug($"Loaded {doodadSpawnCount} doodads from DB for Slave {summonedSlave.ObjId} (Db: {summonedSlave.Id}");
+        if (isLoadedPlayerSlave)
+        {
+            var doodadSpawnCount = SpawnManager.Instance.SpawnPersistentDoodads(DoodadOwnerType.Slave, (int)summonedSlave.Id, summonedSlave, true);
+            Logger.Debug($"Loaded {doodadSpawnCount} doodads from DB for Slave {summonedSlave.ObjId} (Db: {summonedSlave.Id}");
+        }
 
         // Create all remaining doodads that where not previously loaded
         foreach (var doodadBinding in summonedSlave.Template.DoodadBindings)
         {
-            // If this AttachPoint has already been spawned, skip it's creation
+            // If this AttachPoint has already been spawned, skip its creation
             if (summonedSlave.AttachedDoodads.Any(d => d.AttachPoint == doodadBinding.AttachPointId))
                 continue;
 
+            // Create attached doodad
             var doodad = new Doodad
             {
                 ObjId = ObjectIdManager.Instance.GetNextId(),
@@ -602,7 +652,7 @@ public class SlaveManager : Singleton<SlaveManager>
             doodad.Transform = summonedSlave.Transform.CloneAttached(doodad);
             doodad.Transform.Parent = summonedSlave.Transform;
 
-            // NOTE: In 1.2 we can't replace slave parts like sail, so just apply it to all of the doodads on spawn)
+            // NOTE: In 1.2 we can't replace slave parts like sail, so just apply it to all the doodads on spawn
             // Should probably have a check somewhere if a doodad can have the UCC applied or not
             if (item != null && item.HasFlag(ItemFlag.HasUCC) && (item.UccId > 0))
                 doodad.UccId = item.UccId;
@@ -610,6 +660,7 @@ public class SlaveManager : Singleton<SlaveManager>
             ApplyAttachPointLocation(summonedSlave, doodad, doodadBinding.AttachPointId);
 
             summonedSlave.AttachedDoodads.Add(doodad);
+            doodad.InitDoodad();
             doodad.Spawn();
 
             // Only set IsPersistent if the binding is defined as such
@@ -620,11 +671,50 @@ public class SlaveManager : Singleton<SlaveManager>
             }
         }
 
+        // Spawn Slave's slaves
         foreach (var slaveBinding in summonedSlave.Template.SlaveBindings)
-        { 
+        {
             if (slaveBinding.OwnerType != "Slave")
                 continue;
-            var childSlaveTemplate = GetSlaveTemplate(slaveBinding.SlaveId);
+            
+            // TODO: When vehicle customization gets added this part needs addition of the related item Ids
+
+            var childDbId = 0u;
+            var childSlaveName = string.Empty;
+            var childSlaveHp = 1;
+            var childSlaveMp = 1;
+            var childSlaveTemplateId = 0u;
+            var isLoadedPlayerChildSlave = false;
+
+            // Only check if the parent was saved as well
+            if (summonedSlave.Id > 0)
+            {
+                using var connection = MySQL.CreateConnection();
+                using var command = connection.CreateCommand();
+
+                // owner_type 2 = BaseUnitType.Slave
+                command.CommandText = "SELECT * FROM slaves  WHERE (owner_type = 2) AND (owner_id = @ownerId) AND (summoner = @summoner) AND (attach_point = @attachPoint) LIMIT 1";
+                command.Parameters.AddWithValue("@ownerId", summonedSlave.Id);
+                command.Parameters.AddWithValue("@summoner", owner?.Id ?? 0);
+                command.Parameters.AddWithValue("@attachPoint", slaveBinding.AttachPointId);
+                command.Prepare();
+                using var reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    childDbId = reader.GetUInt32("id");
+                    childSlaveTemplateId = reader.GetUInt32("template_id");
+                    childSlaveName = reader.GetString("name");
+                    childSlaveHp = reader.GetInt32("hp");
+                    childSlaveMp = reader.GetInt32("mp");
+                    isLoadedPlayerChildSlave = true;
+                    break;
+                }
+            } // Parent Slave has DB Id
+            
+            if ((summonedSlave.Id > 0) && (childDbId <= 0))
+                childDbId = CharacterIdManager.Instance.GetNextId(); // Slaves of Persistent Slaves are always persistent as well
+            
+            var childSlaveTemplate = GetSlaveTemplate(childSlaveTemplateId > 0 ? childSlaveTemplateId : slaveBinding.SlaveId);
             var childTlId = (ushort)TlIdManager.Instance.GetNextId();
             var childObjId = ObjectIdManager.Instance.GetNextId();
             var childSlave = new Slave()
@@ -633,25 +723,34 @@ public class SlaveManager : Singleton<SlaveManager>
                 ObjId = childObjId,
                 ParentObj = summonedSlave,
                 TemplateId = childSlaveTemplate.Id,
-                Name = childSlaveTemplate.Name,
+                Name = string.IsNullOrWhiteSpace(childSlaveName) ? childSlaveTemplate.Name : childSlaveName,
                 Level = (byte)childSlaveTemplate.Level,
                 ModelId = childSlaveTemplate.ModelId,
                 Template = childSlaveTemplate,
-                Hp = 1,
-                Mp = 1,
+                Hp = childSlaveHp,
+                Mp = childSlaveMp,
                 ModelParams = new UnitCustomModelParams(),
-                Faction = owner?.Faction ?? summonedSlave.Faction,
-                Id = 11, // TODO
-                Summoner = owner,
+                Faction = summonedSlave.Faction,
+                Id = childDbId, 
+                Summoner = summonedSlave.Summoner,
                 SpawnTime = DateTime.UtcNow,
                 AttachPointId = (sbyte)slaveBinding.AttachPointId,
-                OwnerObjId = summonedSlave.ObjId
+                OwnerObjId = summonedSlave.ObjId,
+                OwnerType = BaseUnitType.Slave,
+                OwnerId = summonedSlave.Id,
             };
 
             ApplySlaveBonuses(childSlave);
 
-            childSlave.Hp = childSlave.MaxHp;
-            childSlave.Mp = childSlave.MaxMp;
+            // NOTE: Un-comment this if to enable persistent HP for child slaves (e.g. canons), give full HP otherwise
+            // TODO: Re-enable this when vehicle customization is enabled
+            // if (!isLoadedPlayerChildSlave)
+            {
+                childSlave.Hp = childSlave.MaxHp;
+                childSlave.Mp = childSlave.MaxMp;
+            }
+
+            // Child Slaves will always have their location reset
             childSlave.Transform = summonedSlave.Transform.CloneDetached(childSlave);
             childSlave.Transform.Parent = summonedSlave.Transform;
 
@@ -662,6 +761,10 @@ public class SlaveManager : Singleton<SlaveManager>
                 _tlSlaves.Add(childSlave.TlId, childSlave);
             childSlave.Spawn();
             childSlave.PostUpdateCurrentHp(childSlave, 0, childSlave.Hp, KillReason.Unknown);
+
+            // NOTE: This Save is not needed, actual saving will be done by being forwarded from the parent below
+            // if (childSlave.Id > 0)
+            //     childSlave.Save();
         }
 
         lock (_slaveListLock)
@@ -716,10 +819,8 @@ public class SlaveManager : Singleton<SlaveManager>
                 Logger.Debug($"Model id: {slave.ModelId} attachment {attachPoint} => pos {_attachPoints[slave.ModelId][attachPoint]} = {baseUnit.Transform}");
                 return;
             }
-            else
-            {
-                Logger.Warn($"Model id: {slave.ModelId} incomplete attach point information");
-            }
+
+            Logger.Warn($"Model id: {slave.ModelId} incomplete attach point information");
         }
         else
         {
@@ -728,7 +829,7 @@ public class SlaveManager : Singleton<SlaveManager>
     }
 
     /// <summary>
-    /// Applies buff ans bonuses to Slave
+    /// Applies buff and bonuses to Slave
     /// </summary>
     /// <param name="summonedSlave"></param>
     private static void ApplySlaveBonuses(Slave summonedSlave)
@@ -747,13 +848,18 @@ public class SlaveManager : Singleton<SlaveManager>
         // Apply bonuses
         foreach (var bonusTemplate in summonedSlave.Template.Bonuses)
         {
-            var bonus = new Bonus();
-            bonus.Template = bonusTemplate;
-            bonus.Value = bonusTemplate.Value; // TODO using LinearLevelBonus
+            var bonus = new Bonus { 
+                Template = bonusTemplate, 
+                Value = bonusTemplate.Value // TODO using LinearLevelBonus
+            };
             summonedSlave.AddBonus(0, bonus);
         }
     }
 
+    /// <summary>
+    /// Loads attachment points from slave_attach_points.json 
+    /// </summary>
+    /// <exception cref="IOException"></exception>
     public void LoadSlaveAttachmentPointLocations()
     {
         Logger.Info("Loading Slave Model Attach Points...");
@@ -761,8 +867,7 @@ public class SlaveManager : Singleton<SlaveManager>
         var filePath = Path.Combine(FileManager.AppPath, "Data", "slave_attach_points.json");
         var contents = FileManager.GetFileContents(filePath);
         if (string.IsNullOrWhiteSpace(contents))
-            throw new IOException(
-                $"File {filePath} doesn't exists or is empty.");
+            throw new IOException($"File {filePath} doesn't exists or is empty.");
 
         if (JsonHelper.TryDeserializeObject(contents, out List<SlaveModelAttachPoint> attachPoints, out _))
             Logger.Info("Slave model attach points loaded...");
@@ -787,6 +892,9 @@ public class SlaveManager : Singleton<SlaveManager>
         }
     }
 
+    /// <summary>
+    /// Load slave data
+    /// </summary>
     public void Load()
     {
         _slaveListLock = new object();
@@ -853,11 +961,13 @@ public class SlaveManager : Singleton<SlaveManager>
                         var slaveId = reader.GetUInt32("owner_id");
                         if (!_slaveTemplates.TryGetValue(slaveId, out var slaveTemplate))
                             continue;
-                        var template = new BonusTemplate();
-                        template.Attribute = (UnitAttribute)reader.GetByte("unit_attribute_id");
-                        template.ModifierType = (UnitModifierType)reader.GetByte("unit_modifier_type_id");
-                        template.Value = reader.GetInt32("value");
-                        template.LinearLevelBonus = reader.GetInt32("linear_level_bonus");
+                        var template = new BonusTemplate
+                        {
+                            Attribute = (UnitAttribute)reader.GetByte("unit_attribute_id"),
+                            ModifierType = (UnitModifierType)reader.GetByte("unit_modifier_type_id"),
+                            Value = reader.GetInt32("value"),
+                            LinearLevelBonus = reader.GetInt32("linear_level_bonus")
+                        };
                         slaveTemplate.Bonuses.Add(template);
                     }
                 }
@@ -872,26 +982,26 @@ public class SlaveManager : Singleton<SlaveManager>
                 {
                     while (reader.Read())
                     {
-                        var ItemPackId = reader.GetUInt32("slave_initial_item_pack_id");
-                        var SlotId = reader.GetByte("equip_slot_id");
+                        var itemPackId = reader.GetUInt32("slave_initial_item_pack_id");
+                        var slotId = reader.GetByte("equip_slot_id");
                         var item = reader.GetUInt32("item_id");
 
-                        if (_slaveInitialItems.TryGetValue(ItemPackId, out var key))
+                        if (_slaveInitialItems.TryGetValue(itemPackId, out var key))
                         {
-                            key.Add(new SlaveInitialItems() { slaveInitialItemPackId = ItemPackId, equipSlotId = SlotId, itemId = item });
+                            key.Add(new SlaveInitialItems() { slaveInitialItemPackId = itemPackId, equipSlotId = slotId, itemId = item });
                         }
                         else
                         {
                             var newPack = new List<SlaveInitialItems>();
                             var newKey = new SlaveInitialItems
                             {
-                                slaveInitialItemPackId = ItemPackId,
-                                equipSlotId = SlotId,
+                                slaveInitialItemPackId = itemPackId,
+                                equipSlotId = slotId,
                                 itemId = item
                             };
                             newPack.Add(newKey);
 
-                            _slaveInitialItems.Add(ItemPackId, newPack);
+                            _slaveInitialItems.Add(itemPackId, newPack);
                         }
                     }
                 }
@@ -1101,15 +1211,21 @@ public class SlaveManager : Singleton<SlaveManager>
         LoadSlaveAttachmentPointLocations();
     }
 
+    /// <summary>
+    /// Starts task that sends the MySlave packets to players (updates markers on the map)
+    /// </summary>
     public static void Initialize()
     {
         var sendMySlaveTask = new SendMySlaveTask();
         TaskManager.Instance.Schedule(sendMySlaveTask, TimeSpan.Zero, TimeSpan.FromSeconds(5));
     }
 
+    /// <summary>
+    /// Used by SendMySlaveTask
+    /// </summary>
     public void SendMySlavePacketToAllOwners()
     {
-        Dictionary<uint, Slave> slaveList = null;
+        Dictionary<uint, Slave> slaveList;
         lock (_slaveListLock)
             slaveList = _activeSlaves;
 
@@ -1124,6 +1240,12 @@ public class SlaveManager : Singleton<SlaveManager>
         }
     }
 
+    /// <summary>
+    /// Checks if a specified object is mounted on a slave, and returns it's position
+    /// </summary>
+    /// <param name="objId"></param>
+    /// <param name="attachPoint">Attach point the object is on</param>
+    /// <returns>Slave the object is on or null of none</returns>
     public Slave GetIsMounted(uint objId, out AttachPointKind attachPoint)
     {
         attachPoint = AttachPointKind.None;
@@ -1143,7 +1265,13 @@ public class SlaveManager : Singleton<SlaveManager>
         return null;
     }
 
-    public void RemoveActiveSlave(Character character, ushort slaveTlId)
+    /// <summary>
+    /// Un-summons a vehicle
+    /// </summary>
+    /// <param name="character"></param>
+    /// <param name="slaveTlId"></param>
+    /// <param name="forceDelete">If true, will force delete attached items</param>
+    public void RemoveActiveSlave(Character character, ushort slaveTlId, bool forceDelete)
     {
         if (_tlSlaves.TryGetValue(slaveTlId, out var slave))
         {
@@ -1158,10 +1286,15 @@ public class SlaveManager : Singleton<SlaveManager>
             return;
         }
 
-        Delete(character, slave.ObjId);
+        Delete(character, slave.ObjId, forceDelete);
         // slave.Delete();
     }
 
+    /// <summary>
+    /// Performs the Rider's Escape action
+    /// </summary>
+    /// <param name="player"></param>
+    /// <param name="skillCastPositionTarget"></param>
     public void RidersEscape(Character player, SkillCastPositionTarget skillCastPositionTarget)
     {
         var mySlave = GetActiveSlaveByOwnerObjId(player.ObjId);
@@ -1192,6 +1325,10 @@ public class SlaveManager : Singleton<SlaveManager>
         //mySlave.SendPacket(new SCSlaveStatePacket(mySlave.ObjId, mySlave.TlId, mySlave.Summoner.Name, mySlave.Summoner.ObjId, mySlave.Id));
     }
 
+    /// <summary>
+    /// Spawns or de-spawns repairs points on the vehicle based on it's HP
+    /// </summary>
+    /// <param name="slave"></param>
     public void UpdateSlaveRepairPoints(Slave slave)
     {
         var hpPercent = slave.Hp * 100 / slave.MaxHp;
@@ -1288,23 +1425,120 @@ public class SlaveManager : Singleton<SlaveManager>
         }
     }
 
+    /// <summary>
+    /// De-spawns all vehicles owned by the specified player 
+    /// </summary>
+    /// <param name="owner"></param>
     public void RemoveAndDespawnAllActiveOwnedSlaves(Character owner)
     {
         var activeSlaveInfo = GetActiveSlaveByOwnerObjId(owner.ObjId);
         if (activeSlaveInfo != null)
         {
             activeSlaveInfo.Save();
-            Delete(owner, activeSlaveInfo.ObjId);
+            Delete(owner, activeSlaveInfo.ObjId, false);
         }
     }
 
     /// <summary>
     /// RemoveAndDespawnTestSlave - deleting Mirage's test transport
     /// </summary>
-    /// <param name="ObjId"></param>
+    /// <param name="owner"></param>
+    /// <param name="slaveObjId"></param>
     /// <returns></returns>
     public void RemoveAndDespawnTestSlave(Character owner, uint slaveObjId)
     {
-        Delete(owner, slaveObjId);
+        Delete(owner, slaveObjId, false);
+    }
+
+    /// <summary>
+    /// Deleted the slave attached to an Item, deletes it's stored doodads and slaves, and removed them from the DB 
+    /// </summary>
+    /// <param name="summonSlaveItem"></param>
+    /// <returns></returns>
+    public bool OnDeleteSlaveItem(SummonSlave summonSlaveItem)
+    {
+        if (summonSlaveItem.SlaveDbId <= 0)
+            return false;
+
+        if (!summonSlaveItem.CanDestroy())
+            return false;
+
+        var slaveIdToDelete = summonSlaveItem.SlaveDbId;
+
+        // Despawn the slave if it's currently active
+        var currentActiveSlave = GetSlaveByDbId(slaveIdToDelete);
+        if (currentActiveSlave != null)
+            RemoveActiveSlave(currentActiveSlave.Summoner, currentActiveSlave.TlId, true);
+
+        // Remove the slave from DB
+        using var connection = MySQL.CreateConnection();
+        if (!DeleteSlaveById(connection, null, slaveIdToDelete))
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Deletes a Vehicle from the DB (entry only) 
+    /// </summary>
+    /// <param name="connection">DB Connection</param>
+    /// <param name="transaction">optional transaction</param>
+    /// <param name="dbId">Slave DB Id</param>
+    /// <returns></returns>
+    private bool DeleteSlaveById(MySqlConnection connection, MySqlTransaction transaction, uint dbId)
+    {
+        using var command = connection.CreateCommand();
+        command.Connection = connection;
+        if (transaction != null)
+            command.Transaction = transaction;
+        var deleteCount = 0;
+
+        using (var deleteCommand = connection.CreateCommand())
+        {
+            deleteCommand.CommandText = $"DELETE FROM slaves WHERE `id` = @removeId";
+            deleteCommand.Parameters.AddWithValue("@removeId", dbId);
+            deleteCommand.Prepare();
+            deleteCount += deleteCommand.ExecuteNonQuery();
+        }
+
+        var childDoodadsToRemove = new List<uint>();
+        var childSlavesToRemove = new List<uint>();
+        
+        // Get list of child doodads to remove
+        command.CommandText = "SELECT * FROM doodads WHERE (owner_type = 2) AND (house_id = @ownerId)";
+        command.Parameters.AddWithValue("@ownerId", dbId);
+        command.Prepare();
+        using(var reader = command.ExecuteReader())
+        {
+            while (reader.Read())
+                childDoodadsToRemove.Add(reader.GetUInt32("id"));
+        }
+
+        // Get a list of child slaves to remove
+        command.CommandText = "SELECT * FROM slaves  WHERE (owner_type = 2) AND (owner_id = @ownerId)";
+        // command.Parameters.AddWithValue("@ownerId", dbId); // we're recycling the one above
+        command.Prepare();
+        using (var reader = command.ExecuteReader())
+        {
+            while (reader.Read())
+                childSlavesToRemove.Add(reader.GetUInt32("id"));
+        }
+
+        // Actually call function to remove
+        foreach (var childDoodad in childDoodadsToRemove)
+            DoodadManager.Instance.DeleteDoodadById(connection, transaction, childDoodad);
+
+        // Actually call function to remove
+        foreach (var childSlaveId in childSlavesToRemove)
+            DeleteSlaveById(connection, transaction, childSlaveId);
+
+        if (deleteCount <= 0)
+        {
+            Logger.Error($"Slave could not be deleted or did not exist, Id {dbId}");
+            return false;
+        }
+        CharacterIdManager.Instance.ReleaseId(dbId);
+
+        return true;
     }
 }

--- a/AAEmu.Game/Core/Managers/World/BoatPhysicsManager.cs
+++ b/AAEmu.Game/Core/Managers/World/BoatPhysicsManager.cs
@@ -257,7 +257,7 @@ public class BoatPhysicsManager//: Singleton<BoatPhysicsManager>
             var damage = _random.Next(500, 750); // damage randomly 500-750
             if (damage > 0)
             {
-                slave.DoDamage(damage, false, KillReason.Collide);
+                slave.DoFloorCollisionDamage(damage, false, KillReason.Collide);
             }
 
             Logger.Debug($"Slave: {slave.ObjId}, speed: {slave.Speed}, rotSpeed: {slave.RotSpeed}, floor: {floor}, Z: {slave.Transform.World.Position.Z}, damage: {damage}");

--- a/AAEmu.Game/Core/Managers/World/SpawnManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpawnManager.cs
@@ -415,7 +415,7 @@ public class SpawnManager : Singleton<SpawnManager>
         using var connection = MySQL.CreateConnection();
         using (var command = connection.CreateCommand())
         {
-            // Sorting required to make make sure parenting doesn't produce invalid parents (normally)
+            // Sorting required to make sure parenting doesn't produce invalid parents (normally)
 
             command.CommandText = "SELECT * FROM doodads  WHERE owner_type = @OwnerType";
             if (ownerToSpawnId >= 0)
@@ -472,7 +472,7 @@ public class SpawnManager : Singleton<SpawnManager>
                     // Try to grab info from the actual item if it still exists
                     var sourceItem = ItemManager.Instance.GetItemByItemId(itemId);
                     doodad.ItemTemplateId = sourceItem?.TemplateId ?? itemTemplateId;
-                    // Grab Ucc from it's old source item
+                    // Grab Ucc from its old source item
                     doodad.UccId = sourceItem?.UccId ?? 0;
                     doodad.SetData(data); // Directly assigning to Data property would trigger a .Save()
 

--- a/AAEmu.Game/Core/Packets/C2G/CSDespawnSlavePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSDespawnSlavePacket.cs
@@ -8,13 +8,14 @@ public class CSDespawnSlavePacket : GamePacket
 {
     public CSDespawnSlavePacket() : base(CSOffsets.CSDespawnSlavePacket, 1)
     {
+        //
     }
 
     public override void Read(PacketStream stream)
     {
         var slaveObjId = stream.ReadBc();
 
-        //Logger.Debug("DespawnSlave, SlaveObjId: {0}", slaveObjId);
-        SlaveManager.Instance.Delete(Connection.ActiveChar, slaveObjId);
+        // Logger.Debug($"DespawnSlave, SlaveObjId: {slaveObjId}");
+        SlaveManager.Instance.Delete(Connection.ActiveChar, slaveObjId, false);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSDestroyItemPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSDestroyItemPacket.cs
@@ -12,6 +12,7 @@ public class CSDestroyItemPacket : GamePacket
 {
     public CSDestroyItemPacket() : base(CSOffsets.CSDestroyItemPacket, 1)
     {
+        //
     }
 
     public override void Read(PacketStream stream)
@@ -46,6 +47,7 @@ public class CSDestroyItemPacket : GamePacket
             if (!item._holdingContainer.RemoveItem(ItemTaskType.Destroy, item, true))
             {
                 Logger.Warn("DestroyItem: Failed to destroy item...");
+                return;
             }
             // Connection.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.Destroy, new List<ItemTask> { new ItemRemove(item) }, new List<ulong>()));
         }

--- a/AAEmu.Game/Core/Packets/C2G/CSDestroySlavePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSDestroySlavePacket.cs
@@ -8,13 +8,14 @@ public class CSDestroySlavePacket : GamePacket
 {
     public CSDestroySlavePacket() : base(CSOffsets.CSDestroySlavePacket, 1)
     {
+        //
     }
 
     public override void Read(PacketStream stream)
     {
         var tl = stream.ReadUInt16();
 
-        Logger.Debug("DestroySlave, Tl: {0}", tl);
-        SlaveManager.Instance.RemoveActiveSlave(Connection.ActiveChar, tl);
+        Logger.Debug($"DestroySlave, Tl: {tl}");
+        SlaveManager.Instance.RemoveActiveSlave(Connection.ActiveChar, tl, false);
     }
 }

--- a/AAEmu.Game/Models/Game/Char/Inventory.cs
+++ b/AAEmu.Game/Models/Game/Char/Inventory.cs
@@ -948,6 +948,7 @@ public class Inventory
 
     public void OnItemManuallyDestroyed(Item item, int count)
     {
+        item?.OnManuallyDestroyingItem();
         if (item?.Template.LootQuestId > 0)
             if (Owner.Quests.HasQuest(item.Template.LootQuestId))
                 Owner.Quests.Drop(item.Template.LootQuestId, true);

--- a/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
+++ b/AAEmu.Game/Models/Game/Items/Containers/ItemContainer.cs
@@ -415,41 +415,6 @@ public class ItemContainer
         return ((itemTasks.Count + sourceItemTasks.Count) > 0);
     }
 
-    private bool CanDestroy(Item item)
-    {
-        // TODO: Check if item is expired, then always allow destruction
-        if (item is SummonSlave summonSlaveItem)
-        {
-            var owner = WorldManager.Instance.GetCharacterById(summonSlaveItem._holdingContainer.OwnerId);
-            if (owner != null)
-            {
-                var checkSlave = SlaveManager.Instance.GetActiveSlaveByOwnerObjId(owner.ObjId);
-                if (checkSlave?.Id == summonSlaveItem.SlaveDbId)
-                {
-                    owner.SendErrorMessage(ErrorMessageType.SlaveSpawnItemLocked);
-                    return false;
-                }
-            }
-        }
-        /*
-        else if (item is SummonMate summonMateItem)
-        {
-            var owner = WorldManager.Instance.GetCharacterById(summonMateItem._holdingContainer.OwnerId);
-            if (owner != null)
-            {
-                var checkSlave = MateManager.Instance.GetActiveMate(owner.ObjId);
-                if (checkSlave.Id == summonMateItem.MateDbId)
-                {
-                    owner.SendErrorMessage(ErrorMessageType.SlaveSpawnItemLocked);
-                    return false;
-                }
-            }
-        }
-        */
-
-        return true;
-    }
-
     /// <summary>
     /// Removes (and Destroys if needed) a item from the container
     /// </summary>
@@ -459,7 +424,7 @@ public class ItemContainer
     /// <returns></returns>
     public bool RemoveItem(ItemTaskType task, Item item, bool releaseIdAsWell)
     {
-        if (!CanDestroy(item))
+        if (!item.CanDestroy())
             return false;
 
         Owner?.Inventory.OnConsumedItem(item, item.Count);

--- a/AAEmu.Game/Models/Game/Items/Item.cs
+++ b/AAEmu.Game/Models/Game/Items/Item.cs
@@ -294,4 +294,17 @@ public class Item : PacketMarshaler, IComparable<Item>
     {
         ItemFlags &= ~flag;
     }
+
+    /// <summary>
+    /// Called just before a item is getting destroyed
+    /// </summary>
+    public virtual void OnManuallyDestroyingItem()
+    {
+        
+    }
+
+    public virtual bool CanDestroy()
+    {
+        return true;
+    }
 }

--- a/AAEmu.Game/Models/Game/Items/SummonMate.cs
+++ b/AAEmu.Game/Models/Game/Items/SummonMate.cs
@@ -1,4 +1,6 @@
 ﻿using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Items.Templates;
 
 namespace AAEmu.Game.Models.Game.Items;
@@ -33,5 +35,18 @@ public class SummonMate : Item
         stream.Write(DetailMateExp); // exp
         stream.Write((byte)0);
         stream.Write(DetailLevel); // level
+    }
+    
+    public override void OnManuallyDestroyingItem()
+    {
+        base.OnManuallyDestroyingItem();
+        // TODO: Call function to remove mate entries from DB
+    }
+
+    public override bool CanDestroy()
+    {
+        // Mounts should always be able to be destroyed as they cannot carry any persistent items anyway
+        // It should just un-summon it while the item is getting deleted
+        return true;
     }
 }

--- a/AAEmu.Game/Models/Game/Items/SummonSlave.cs
+++ b/AAEmu.Game/Models/Game/Items/SummonSlave.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Numerics;
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Items.Templates;
 
 namespace AAEmu.Game.Models.Game.Items;
@@ -31,10 +33,12 @@ public class SummonSlave : Item
 
     public SummonSlave()
     {
+        //
     }
 
     public SummonSlave(ulong id, ItemTemplate template, int count) : base(id, template, count)
     {
+        //
     }
 
     public override void ReadDetails(PacketStream stream)
@@ -48,10 +52,7 @@ public class SummonSlave : Item
         {
             // Read time of something else than 0
             var timeBytes = stream.ReadBytes(4);
-            if (Convert.ToInt32(timeBytes) != 0)
-                RepairStartTime = Convert.ToDateTime(timeBytes);
-            else
-                RepairStartTime = DateTime.MinValue;
+            RepairStartTime = Convert.ToInt32(timeBytes) != 0 ? Convert.ToDateTime(timeBytes) : DateTime.MinValue;
 
             // Read remaining bytes
             _ = stream.ReadBytes((int)DetailBytesLength-1-4-4); // Filler, Equipment?
@@ -82,5 +83,28 @@ public class SummonSlave : Item
         stream.Write(0);
         stream.Write(0);
         stream.Write(0);
+    }
+
+    public override void OnManuallyDestroyingItem()
+    {
+        if (!SlaveManager.Instance.OnDeleteSlaveItem(this))
+            Logger.Warn($"Failed to delete Slave attached to Item Id: {Id}, Type: {TemplateId}");
+    }
+
+    public override bool CanDestroy()
+    {
+        // TODO: Always allow expired items to be removed regardless if summoned or not 
+        var owner = WorldManager.Instance.GetCharacterById((uint)OwnerId);
+        if (owner != null)
+        {
+            var checkSlave = SlaveManager.Instance.GetActiveSlaveByOwnerObjId(owner.ObjId);
+            if (checkSlave?.Id == SlaveDbId)
+            {
+                owner.SendErrorMessage(ErrorMessageType.SlaveSpawnItemLocked);
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/AAEmu.Game/Models/Game/Units/BaseUnitType.cs
+++ b/AAEmu.Game/Models/Game/Units/BaseUnitType.cs
@@ -8,5 +8,6 @@ public enum BaseUnitType : byte
     Housing = 3,
     Transfer = 4,
     Mate = 5,
-    Shipyard = 6
+    Shipyard = 6,
+    Invalid = 255,
 }

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -37,6 +37,8 @@ public class Slave : Unit
     public SlaveTemplate Template { get; set; }
     // public Character Driver { get; set; }
     public Character Summoner { get; set; }
+    public BaseUnitType OwnerType { get; set; }
+    
     public Item SummoningItem { get; set; }
     public List<Doodad> AttachedDoodads { get; set; }
     public List<Slave> AttachedSlaves { get; set; }
@@ -615,9 +617,15 @@ public class Slave : Unit
         character.SendPacket(new SCUnitsRemovedPacket(new[] { ObjId }));
     }
 
-    public void DoDamage(int damage, bool isPercent = true, KillReason killReason = KillReason.Damage)
+    /// <summary>
+    /// Damage handler used by BoatPhysics
+    /// </summary>
+    /// <param name="damage"></param>
+    /// <param name="isPercent"></param>
+    /// <param name="killReason"></param>
+    public void DoFloorCollisionDamage(int damage, bool isPercent = true, KillReason killReason = KillReason.Damage)
     {
-        // If % based, calculate it's damage
+        // If % based, calculate its damage
         if (isPercent)
         {
             damage = MaxHp * damage / 100;
@@ -652,12 +660,15 @@ public class Slave : Unit
         Summoner?.SendPacket(new SCSlaveRemovedPacket(ObjId, TlId));
     }
 
+    /// <summary>
+    /// Destroys (de-spawns) any child doodads and slaves and drops trade packs if present in a random 1m range to the center of the vehicle
+    /// </summary>
     private void DestroyAttachedItems()
     {
         // Destroy Doodads
         foreach (var doodad in AttachedDoodads)
         {
-            // Check if the doodad held a item
+            // Check if the doodad held an item
             if (doodad.ItemId > 0)
             {
                 var droppedItem = ItemManager.Instance.GetItemByItemId(doodad.ItemId);
@@ -740,6 +751,9 @@ public class Slave : Unit
         }
     }
 
+    /// <summary>
+    /// Creates the random debris created by destroying some of the vehicles (mostly ships)
+    /// </summary>
     private void DistributeSlaveDropDoodads()
     {
         foreach (var dropDoodad in Template.SlaveDropDoodads)
@@ -768,6 +782,9 @@ public class Slave : Unit
         }
     }
 
+    /// <summary>
+    /// Updates the summon item data as being destroyed
+    /// </summary>
     private void MarkSummoningItemAsDestroyed()
     {
         if (SummoningItem is not SummonSlave item)
@@ -779,6 +796,10 @@ public class Slave : Unit
         Summoner.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.MateDeath, new ItemUpdate(item), new List<ulong>()));
     }
 
+    /// <summary>
+    /// Creates a new DB connection and calls the Save function
+    /// </summary>
+    /// <returns></returns>
     public bool Save()
     {
         if (Id <= 0 || SummoningItem == null)
@@ -788,12 +809,18 @@ public class Slave : Unit
         return Save(connection, null);
     }
 
+    /// <summary>
+    /// Saves vehicle data to DB
+    /// </summary>
+    /// <param name="connection"></param>
+    /// <param name="transaction"></param>
+    /// <returns></returns>
     public bool Save(MySqlConnection connection, MySqlTransaction transaction)
     {
-        if (Id <= 0 || SummoningItem == null)
+        if (Id <= 0)
             return false;
 
-        var result = false;
+        bool result;
         try
         {
             using var command = connection.CreateCommand();
@@ -802,11 +829,15 @@ public class Slave : Unit
                 command.Transaction = transaction;
 
             command.CommandText =
-                "REPLACE INTO slaves(`id`,`item_id`,`name`,`owner`,`updated_at`,`hp`,`mp`,`x`,`y`,`z`) " +
-                "VALUES (@id, @item_id, @name, @owner, @updated_at, @hp, @mp, @x, @y, @z)";
+                "REPLACE INTO slaves(`id`,`item_id`,`template_id`,`attach_point`,`name`,`owner_type`,`owner_id`,`summoner`,`updated_at`,`hp`,`mp`,`x`,`y`,`z`) " +
+                "VALUES (@id, @item_id, @templateId, @attachPoint, @name, @ownerType, @ownerId, @owner, @updated_at, @hp, @mp, @x, @y, @z)";
             command.Parameters.AddWithValue("@id", Id);
             command.Parameters.AddWithValue("@item_id", SummoningItem?.Id ?? 0);
-            command.Parameters.AddWithValue("@owner", Summoner?.Id ?? OwnerId);
+            command.Parameters.AddWithValue("@templateId", Template.Id);
+            command.Parameters.AddWithValue("@attachPoint", AttachPointId);
+            command.Parameters.AddWithValue("@ownerType", (byte)OwnerType);
+            command.Parameters.AddWithValue("@ownerId", OwnerId);
+            command.Parameters.AddWithValue("@owner", Summoner?.Id ?? 0);
             command.Parameters.AddWithValue("@name", Name);
             command.Parameters.AddWithValue("@hp", Hp);
             command.Parameters.AddWithValue("@mp", Mp);
@@ -822,6 +853,11 @@ public class Slave : Unit
             Logger.Error(ex);
             result = false;
         }
+
+        // Also save its children if needed
+        foreach(var child in AttachedSlaves)
+            if (child.Id > 0)
+                child.Save(connection, transaction);
 
         return result;
     }
@@ -857,5 +893,4 @@ public class Slave : Unit
         BroadcastPacket(new SCUnitPointsPacket(ObjId, Hp, Mp), false);
         PostUpdateCurrentHp(this, oldHp, Hp, KillReason.Unknown);
     }
-
 }

--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -475,8 +475,12 @@ DROP TABLE IF EXISTS `slaves`;
 CREATE TABLE `slaves` (
 	`id` INT(10) UNSIGNED NOT NULL,
 	`item_id` INT(10) UNSIGNED NULL DEFAULT NULL COMMENT 'Item that is used to summon this vehicle',
+	`template_id` INT(10) UNSIGNED NULL DEFAULT NULL COMMENT 'Slave template Id of this vehicle',
+	`attach_point` INT(10) NULL DEFAULT NULL COMMENT 'Binding point Id',
 	`name` TEXT NULL DEFAULT NULL COLLATE 'utf8mb4_general_ci',
-	`owner` INT(10) UNSIGNED NULL DEFAULT NULL,
+	`owner_type` INT(10) UNSIGNED NULL DEFAULT '0' COMMENT 'Parent unit type',
+	`owner_id` INT(10) UNSIGNED NULL DEFAULT '0' COMMENT 'Parent unit DB Id',
+	`summoner` INT(10) UNSIGNED NULL DEFAULT NULL COMMENT 'Owning player',
 	`created_at` DATETIME NULL DEFAULT CURRENT_TIMESTAMP,
 	`updated_at` DATETIME NULL DEFAULT CURRENT_TIMESTAMP,
 	`hp` INT(11) NULL DEFAULT NULL,

--- a/SQL/updates/2024-05-04_aaemu_game_slaves_update.sql
+++ b/SQL/updates/2024-05-04_aaemu_game_slaves_update.sql
@@ -1,0 +1,11 @@
+-- --------------------------------------------
+-- Add owner type support to persistent slaves
+-- --------------------------------------------
+ALTER TABLE `slaves`
+	ADD COLUMN `template_id` INT(10) UNSIGNED NULL DEFAULT '0' AFTER `item_id` COMMENT 'Slave template Id of this vehicle',
+	ADD COLUMN `attach_point` INT(10) NULL DEFAULT '0' COMMENT 'Binding point Id' AFTER `template_id`
+	ADD COLUMN `owner_type` INT(10) UNSIGNED NULL DEFAULT '0' COMMENT 'Parent unit type' AFTER `name`,
+	ADD COLUMN `owner_id` INT(10) UNSIGNED NULL DEFAULT '0' COMMENT 'Parent unit DB Id' AFTER `owner_type`,
+	CHANGE COLUMN `owner` `summoner` INT(10) UNSIGNED NULL DEFAULT NULL COMMENT 'Owning player' AFTER `owner_id`;
+	
+UPDATE `slaves` SET `owner_id` = `owner`

--- a/SQL/updates/2024-05-04_aaemu_game_slaves_update.sql
+++ b/SQL/updates/2024-05-04_aaemu_game_slaves_update.sql
@@ -2,10 +2,10 @@
 -- Add owner type support to persistent slaves
 -- --------------------------------------------
 ALTER TABLE `slaves`
-	ADD COLUMN `template_id` INT(10) UNSIGNED NULL DEFAULT '0' AFTER `item_id` COMMENT 'Slave template Id of this vehicle',
-	ADD COLUMN `attach_point` INT(10) NULL DEFAULT '0' COMMENT 'Binding point Id' AFTER `template_id`
+	ADD COLUMN `template_id` INT(10) UNSIGNED NULL DEFAULT '0' COMMENT 'Slave template Id of this vehicle' AFTER `item_id`,
+	ADD COLUMN `attach_point` INT(10) NULL DEFAULT '0' COMMENT 'Binding point Id' AFTER `template_id` ,
 	ADD COLUMN `owner_type` INT(10) UNSIGNED NULL DEFAULT '0' COMMENT 'Parent unit type' AFTER `name`,
 	ADD COLUMN `owner_id` INT(10) UNSIGNED NULL DEFAULT '0' COMMENT 'Parent unit DB Id' AFTER `owner_type`,
 	CHANGE COLUMN `owner` `summoner` INT(10) UNSIGNED NULL DEFAULT NULL COMMENT 'Owning player' AFTER `owner_id`;
 	
-UPDATE `slaves` SET `owner_id` = `owner`
+UPDATE `slaves` SET `owner_id` = `summoner`


### PR DESCRIPTION
- Added various fields to the ``slaves`` table to allow saving of child slaves like canons.
- Added unused function to delete vehicles
- Fixed the issue where child doodads from slave that are not persistent (or newly created) would not be missing their InitDoodad function, resulting in timer functions to not work server-side.
- Replaced ItemContainer.CanDestroy with Item.CanDestroy
- Added Item.OnManuallyDestroyingItem that is called just before a item gets destroyed from tossing it
- RemoveActiveSlave now has a added argument to allow unsummoning even when the vehicle is carrying items.

Note: if you have previously bugged vehicles, you can run the following MySQL query to remove all of the vehicle doodads so they will get regenerated on their next summon
```SQL
DELETE FROM `doodads` WHERE `owner_type` = 2
```