### PR TITLE
[Game] Tagging added for kill credit, XP, and Loot (with Rotate Winner and Free For All)

### DIFF
--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -177,14 +177,13 @@ public class ItemManager : Singleton<ItemManager>
         var lootDropRate = 1f;
         var lootGoldRate = 1f;
 
-        // Check all people with with a claim on the NPC
+        // Check all people with a claim on the NPC
 
         HashSet<Character> eligiblePlayers = new HashSet<Character>();
         if ( unit.CharacterTagging.TagTeam != 0)
         {
-           
-                //A team has tagging rights
-                var team = TeamManager.Instance.GetActiveTeam(unit.CharacterTagging.TagTeam);
+            //A team has tagging rights
+            var team = TeamManager.Instance.GetActiveTeam(unit.CharacterTagging.TagTeam);
             if (team != null)
             {
                 foreach (var member in team.Members)

--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -176,55 +176,77 @@ public class ItemManager : Singleton<ItemManager>
         // Calculate loot rates
         var lootDropRate = 1f;
         var lootGoldRate = 1f;
-        var validAggroCount = 0;
 
-        // Check all people in the aggro list, and use the highest stat
-        // TODO: Only consider players in the party/raid with a claim on the NPC
-        if (!unit.AggroTable.IsEmpty)
+        // Check all people with with a claim on the NPC
+
+        HashSet<Character> eligiblePlayers = new HashSet<Character>();
+        if ( unit.CharacterTagging.TagTeam != 0)
+        {
+           
+                //A team has tagging rights
+                var team = TeamManager.Instance.GetActiveTeam(unit.CharacterTagging.TagTeam);
+            if (team != null)
+            {
+                foreach (var member in team.Members)
+                {
+                    if (member != null && member.Character != null)
+                    {
+                        if (member.Character is Character tm)
+                        {
+                            var distance = tm.Transform.World.Position - unit.Transform.World.Position;
+                            if (distance.Length() <= 200)
+                            {
+                                //This player is in range of the mob and in a group with tagging rights.
+                                eligiblePlayers.Add(tm);
+                            }
+                        }
+                    }
+                }
+            }
+            else if (unit.CharacterTagging.Tagger != null)
+            {
+                //A player has tag rights
+                eligiblePlayers.Add(unit.CharacterTagging.Tagger);
+            }
+
+        }
+        else if (unit.CharacterTagging.Tagger != null)
+        {
+            //A player has tag rights
+            eligiblePlayers.Add(unit.CharacterTagging.Tagger);
+        }
+        if (eligiblePlayers.Count > 0)
         {
             var maxDropRateMul = -100f;
             var maxLootGoldMul = -100f;
 
-            foreach (var aggroInfo in unit.AggroTable)
+            foreach (var pl in eligiblePlayers)
             {
-                // Ingnore stats from people more than 200m away. 
-                var distance = aggroInfo.Value.Owner.Transform.World.Position - unit.Transform.World.Position;
-                if (distance.Length() > 200)
-                    continue;
 
-                // If a pet is on there, use it's owner
-                var checkUnit = aggroInfo.Value.Owner;
-                if (checkUnit is Mate mate)
-                    checkUnit = WorldManager.Instance.GetCharacterByObjId(mate.OwnerObjId) ?? aggroInfo.Value.Owner;
+                var aggroDropMul = (100f + pl.DropRateMul) / 100f;
+                var aggroGoldMul = (100f + pl.LootGoldMul) / 100f;
+                if (aggroDropMul > maxDropRateMul)
+                    maxDropRateMul = aggroDropMul;
+                if (aggroGoldMul > maxLootGoldMul)
+                    maxLootGoldMul = aggroGoldMul;
 
-                // Get player loot stats
-                if (checkUnit is Character pl)
-                {
-                    var aggroDropMul = (100f + pl.DropRateMul) / 100f;
-                    var aggroGoldMul = (100f + pl.LootGoldMul) / 100f;
-                    if (aggroDropMul > maxDropRateMul)
-                        maxDropRateMul = aggroDropMul;
-                    if (aggroGoldMul > maxLootGoldMul)
-                        maxLootGoldMul = aggroGoldMul;
-                    validAggroCount++;
-                }
+
+
             }
 
-            if (validAggroCount > 0)
-            {
-                lootDropRate = maxDropRateMul;
-                lootGoldRate = maxLootGoldMul;
-            }
+            lootDropRate = maxDropRateMul;
+            lootGoldRate = maxLootGoldMul;
+
+
+
         }
-
-        // Fallback to killer's stats if aggro list failed
-        if ((validAggroCount <= 0) && (killer is Character player))
+        else if (killer is Character player)
         {
             lootDropRate *= (100f + player.DropRateMul) / 100f;
             lootGoldRate *= (100f + player.LootGoldMul) / 100f;
             Logger.Info($"Unit killed without aggro: {unit.ObjId} ({unit.TemplateId}) by {player.Name}");
         }
-
+      
         // Base ID used for identifying the loot
         var baseId = ((ulong)unit.ObjId << 32) + 65536;
 
@@ -1627,7 +1649,7 @@ public class ItemManager : Singleton<ItemManager>
             }
         }
 
-        // Update dirty items
+
         using (var command = connection.CreateCommand())
         {
             command.Connection = connection;
@@ -1646,7 +1668,25 @@ public class ItemManager : Singleton<ItemManager>
                     {
                         // Only give a error if it has no owner, otherwise it's likely a BuyBack item
                         if (item.OwnerId <= 0)
-                            Logger.Warn(string.Format("Found SlotType.None in itemslist, skipping ID:{0} - Template:{1}", item.Id, item.TemplateId));
+                            continue;
+
+                        //Debug to get slot by data
+
+                        if (item._holdingContainer != null)
+                        {
+                            item.SlotType = GetContainerSlotTypeByContainerID(item._holdingContainer.ContainerId);
+                        }
+
+                        Logger.Warn($"Slot type for {item.Id}  was None, changing to {item.SlotType}");
+
+                        if (item.SlotType == SlotType.None && item.OwnerId <= 0)
+                        {
+                            continue;
+                        }
+                    }
+                    if (!Enum.IsDefined(typeof(SlotType), item.SlotType))
+                    {
+                        Logger.Warn($"Found SlotType.{item.SlotType} in itemslist, skipping ID:{item.Id} - Template:{item.TemplateId}");
                         continue;
                     }
 
@@ -1688,14 +1728,24 @@ public class ItemManager : Singleton<ItemManager>
                     command.Parameters.AddWithValue("@charge_time", item.ChargeStartTime);
                     command.Parameters.AddWithValue("@charge_count", item.ChargeCount);
 
-                    if (command.ExecuteNonQuery() < 1)
+                    try
                     {
-                        Logger.Error($"Error updating items {item.Id} ({item.TemplateId}) !");
+                        if (command.ExecuteNonQuery() < 1)
+                        {
+                            Logger.Error($"Error updating items {item.Id} ({item.TemplateId}) !");
+                        }
+                        else
+                        {
+                            item.IsDirty = false;
+                            updateCount++;
+                        }
                     }
-                    else
+                    catch (Exception ex)
                     {
-                        item.IsDirty = false;
-                        updateCount++;
+                        // Create a manual SQL string with the data provided
+                        var sqlString = $"REPLACE INTO items (id, type, template_id, container_id, slot_type, slot, count, details, lifespan_mins, made_unit_id, unsecure_time, unpack_time, owner, created_at, grade, flags, ucc, expire_time, expire_online_minutes, charge_time, charge_count) VALUES ({item.Id}, {item.GetType().ToString()}, {item.TemplateId}, {item._holdingContainer?.ContainerId ?? 0}, {item.SlotType.ToString()}, {item.Slot}, {item.Count}, {details.GetBytes()}, {item.LifespanMins}, {item.MadeUnitId}, {item.UnsecureTime}, {item.UnpackTime}, {item.CreateTime}, {item.OwnerId}, {item.Grade}, {(byte)item.ItemFlags}, {item.UccId}, {item.ExpirationTime}, {item.ExpirationOnlineMinutesLeft}, {item.ChargeStartTime}, {item.ChargeCount})";
+
+                        Logger.Error($"Error: {ex.Message}\nSQL Query: {sqlString}\n");
                     }
                     command.Parameters.Clear();
                 }
@@ -1704,6 +1754,19 @@ public class ItemManager : Singleton<ItemManager>
 
         return (updateCount, deleteCount, containerUpdateCount);
     }
+
+    public SlotType GetContainerSlotTypeByContainerID(ulong dbId)
+    {
+        _allPersistantContainers.TryGetValue(dbId, out var container);
+
+        if (container != null)
+        {
+            return container.ContainerType;
+        }
+
+        return SlotType.None;
+    }
+
 
     public ItemContainer GetItemContainerForCharacter(uint characterId, SlotType slotType, uint mateId = 0)
     {

--- a/AAEmu.Game/Core/Managers/TeamManager.cs
+++ b/AAEmu.Game/Core/Managers/TeamManager.cs
@@ -5,6 +5,7 @@ using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Team;
 using AAEmu.Game.Models.Game.World.Transform;
@@ -54,7 +55,7 @@ public class TeamManager : Singleton<TeamManager>
         return null;
     }
 
-    private Team GetActiveTeam(uint teamId)
+    public Team GetActiveTeam(uint teamId)
     {
         if (teamId == 0) return null;
         return _activeTeams.TryGetValue(teamId, out var team) ? team : null;
@@ -207,6 +208,44 @@ public class TeamManager : Singleton<TeamManager>
                 ChatManager.Instance.GetPartyChat(activeTeam, t2).JoinChannel(t2);
         }
     }
+
+    public Character GetNextEligibleLooter(uint teamId, Unit owner)
+    {
+        var activeTeam = GetActiveTeam(teamId);
+        if (activeTeam == null) return null;
+       
+        //Round Robin vs FFA
+        //if(activeTeam.LootingRule==)
+        foreach (var member in activeTeam.Members)
+        {
+            if (member?.Character == null)
+                continue;
+            if (member.HasGoneRoundRobin)
+                continue;
+            //Need to check if player is in range, and skip if not.
+            var distance = member.Character.Transform.World.Position - owner.Transform.World.Position;
+            if (distance.Length() >= 200)
+                continue;
+
+            member.HasGoneRoundRobin = true;
+            return member.Character;
+        }
+
+        // Reset round robin and get the first eligible member
+        Character returnMember = null;
+        foreach (var member in activeTeam.Members)
+        {
+            if (member?.Character == null)
+                continue;
+
+            member.HasGoneRoundRobin = returnMember == null;
+            if (returnMember == null)
+                returnMember = member.Character;
+        }
+
+        return returnMember;
+    }
+
 
     public void CreateNewTeam(InvitationTemplate activeInvitation)
     {

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -17,6 +17,7 @@ using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Models;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.SkillControllers;
+using AAEmu.Game.Models.Game.Team;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Units.Movements;
 using AAEmu.Game.Models.Game.Units.Static;
@@ -43,6 +44,9 @@ public class Npc : Unit
     public ConcurrentDictionary<uint, Aggro> AggroTable { get; }
     public uint CurrentAggroTarget { get; set; }
     public bool CanFly { get; set; } // TODO mark Npc's that can fly so that they don't land on the ground when calculating the Z height
+    //Tagging works differently to Aggro.:
+    public Tagging CharacterTagging { get; set; }
+
 
     public override float BaseMoveSpeed
     {
@@ -756,27 +760,175 @@ public class Npc : Unit
     {
         Name = "";
         AggroTable = new ConcurrentDictionary<uint, Aggro>();
+        CharacterTagging = new Tagging(this);//Adding because Tagging works differently than Aggro
         //Equip = new Item[28];
     }
 
     public override void DoDie(BaseUnit killer, KillReason killReason)
     {
-        base.DoDie(killer, killReason);
-        AggroTable.Clear();
-        if (killer is Character character)
+       
+        HashSet<Character> eligiblePlayers = new HashSet<Character>();
+        if (CharacterTagging.TagTeam != 0)
         {
-            character.AddExp(KillExp, true);
-            var mate = MateManager.Instance.GetActiveMate(character.ObjId);
+            //A team has tagging rights
+            var team = TeamManager.Instance.GetActiveTeam(CharacterTagging.TagTeam);
+            if (team != null)
+            {
+
+                //Just to check the team is still a valid team.
+                foreach (var member in team.Members)
+                {
+                    if (member != null && member.Character != null)
+                    {
+                        if (member.Character is Character tm)
+                        {
+                            var distance = tm.Transform.World.Position - this.Transform.World.Position;
+                            if (distance.Length() <= 200)
+                            {
+                                eligiblePlayers.Add(tm);
+                            }
+                        }
+                    }
+                }
+            }
+            else if (CharacterTagging.Tagger != null)
+            {
+                //A player has tag rights, but the team is not valid.
+                eligiblePlayers.Add(CharacterTagging.Tagger);
+            }
+        }
+        else if (CharacterTagging.Tagger != null)
+        {
+            //A player has tag rights
+            eligiblePlayers.Add(CharacterTagging.Tagger);
+        }
+
+
+
+        //Logger.Warn($"Eligible killers count is {eligiblePlayers.Count }");
+
+        if (eligiblePlayers.Count == 0 && killer is Character characterKiller)
+        {
+            QuestManager.Instance.DoOnMonsterHuntEvents(characterKiller, this);//No eligible owner, but the killer is a character.
+            characterKiller.AddExp(KillExp, true);
+            var mate = MateManager.Instance.GetActiveMate(characterKiller.ObjId);
             if (mate != null)
             {
                 mate.AddExp(KillExp);
-                character.SendMessage($"Pet gained {KillExp} XP");
+                characterKiller.SendMessage($"Pet gained {KillExp} XP");
             }
-            //character.Quests.OnKill(this);
-            // инициируем событие
-            //Task.Run(() => QuestManager.Instance.DoOnMonsterHuntEvents(character, this));
-            QuestManager.Instance.DoOnMonsterHuntEvents(character, this);
         }
+        else
+        {
+            var isFullTeam = false;
+            var isRaid = false;
+            if (CharacterTagging.TagTeam != 0)
+            {
+                //A team has tagging rights
+                var team = TeamManager.Instance.GetActiveTeam(CharacterTagging.TagTeam);
+                if (team != null)
+                {
+                    if(!team.IsParty)
+                    {
+                        isRaid = true;
+                        //Team is a raid.
+                    }
+                    else if(team.MembersCount()>3)
+                    {
+                        isFullTeam = true;
+                    }
+                }
+            }
+                    foreach (Character pl in eligiblePlayers)
+            {
+                int plKillXP = 0;
+                int mateKillXP = 0;
+                float plMod = 1f;
+                float mateMod = 1f;
+
+
+                if (isRaid)
+                {
+                    //Player is in a raid. 1.2, pet XP is capped a full team value, but player gets raid XP regardless of how many raiders are present.
+                   plMod =  0.33f;
+                   mateMod = 0.66f;
+                }
+                else if (isFullTeam)
+                {
+                    //Player is in a team of more than 3 people. Player gets full party XP regardless of how many party members are present.
+                    plMod = 0.66f;
+                    mateMod = 0.66f;
+                }
+                
+                else if(eligiblePlayers.Count > 1 && eligiblePlayers.Count <= 3)
+                {
+                    //If players are between 2 and 3, we scale. At this point, the party doesn't matter, just nearby players. 
+                    if (eligiblePlayers.Count == 2)
+                    {
+                        plMod = 0.90f;
+                        mateMod = 0.90f;
+                    }
+                    else if (eligiblePlayers.Count == 3)
+                    {
+                        plMod = 0.875f;
+                        mateMod = 0.875f;
+                    }
+                }
+                else 
+                {
+                    //Player is solo, or at least only 1 player is close enough to get rights
+                    plMod = 1f;
+                    mateMod = 1f;
+                }
+
+                //Now we need to scale XP based on level difference, which gets a bit more complex.
+               
+
+                if (pl.Level >= this.Level + 10 || pl.Level <= this.Level - 10)
+                {
+                   //No XP for you or your pet. Will check on the +10
+                }
+                else
+                {
+                    float LevDif = 1.0f;
+                    int levelDifference = pl.Level - this.Level;
+
+                    if (levelDifference > 0)
+                    {
+                        // pl.Level is above this.Level
+                        LevDif = 1.0f - (0.1f * levelDifference);
+                    }
+                    else if (levelDifference < 0)
+                    {
+                        // pl.Level is below this.Level
+                        LevDif = 1.0f + (0.1f * -levelDifference);
+                    }
+                    
+                    plKillXP = (int)((KillExp * plMod) * LevDif);
+                    mateKillXP = (int)((KillExp * mateMod) * LevDif);
+
+                    pl.AddExp(plKillXP, true);
+                    var mate = MateManager.Instance.GetActiveMate(pl.ObjId);
+                    if (mate != null)
+                    {
+                        mate.AddExp(mateKillXP);
+                        pl.SendMessage($"Pet gained {mateKillXP} XP");
+                    }
+                }
+
+
+
+             
+                //character.Quests.OnKill(this);
+                // инициируем событие
+                //Task.Run(() => QuestManager.Instance.DoOnMonsterHuntEvents(character, this));
+                QuestManager.Instance.DoOnMonsterHuntEvents(pl, this);
+            }
+        }
+        base.DoDie(killer, killReason);
+        AggroTable.Clear();
+        CharacterTagging.ClearAllTaggers();
+
 
         Spawner?.DecreaseCount(this);
         Ai?.GoToDead();
@@ -821,6 +973,11 @@ public class Npc : Unit
             ClearAggroOfUnit(unit);
             return;
         }
+
+        //Add Tagging if it was damage aggro
+        if (kind == AggroKind.Damage)
+            CharacterTagging.AddTagger(unit, amount);
+
 
         amount = (int)(amount * (unit.AggroMul / 100.0f));
         amount = (int)(amount * (IncomingAggroMul / 100.0f));
@@ -883,6 +1040,9 @@ public class Npc : Unit
             CheckIfEmptyAggroToReturn(unit);
     }
 
+    //Tagging!
+
+
     private static void CheckIfEmptyAggroToReturn(IBaseUnit unit)
     {
         if (unit is not Npc npc)
@@ -920,6 +1080,9 @@ public class Npc : Unit
 
     public void ClearAllAggro()
     {
+        ///Adding for tagging
+        CharacterTagging.ClearAllTaggers();
+
         foreach (var table in AggroTable)
         {
             var unit = WorldManager.Instance.GetUnit(table.Key);

--- a/AAEmu.Game/Models/Game/NPChar/Tagging.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Tagging.cs
@@ -1,0 +1,136 @@
+﻿using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Team;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using System.Collections.Generic;
+using System.Numerics;
+
+
+
+namespace AAEmu.Game.Models.Game.NPChar
+{
+    public class Tagging
+    {
+        private object _lock = new();
+        private Dictionary<Character, int> _taggers = new();
+        private Character _tagger;
+        private uint _tagTeam;
+        private int _totalDamage;
+
+        public Unit Owner { get; }
+
+        public Tagging(Unit owner)
+        {
+            Owner = owner;
+        }
+
+        public Character Tagger
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _tagger;
+                }
+            }
+        }
+        public uint TagTeam
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _tagTeam;
+                }
+            }
+        }
+        public void ClearAllTaggers()
+        {
+            _taggers = new Dictionary<Character, int>();
+            _tagger = null;
+            _tagTeam = 0;
+            _totalDamage = 0;
+        }
+                public void AddTagger(Unit checkUnit, int damage)
+        {
+            lock (_lock)
+            {
+                // Check if the character is a pet
+                
+                if (checkUnit is Units.Mate pm)
+                {
+                    checkUnit = WorldManager.Instance.GetCharacterByObjId(pm.OwnerObjId) ?? checkUnit;
+                }
+
+
+              
+
+              
+                if (checkUnit is Character pl)
+                {
+
+                    if (!_taggers.ContainsKey(pl))
+                    {
+                        _taggers[pl] = damage;
+                        if (_tagger == null)
+                        {
+                            _tagger = pl;
+                        }
+                    }
+                    else
+                    {
+                        _taggers[pl] += damage;
+                    }
+
+                    _totalDamage += damage;
+                    // Check if the character is in a party
+                    if (pl.InParty)
+                    {
+                        var checkTeam = TeamManager.Instance.GetTeamByObjId(pl.ObjId);
+                        var partyDamage = 0;
+                        foreach (var member in checkTeam.Members)
+                        {
+                            if (member != null && member.Character != null)
+                            {
+                                if (member.Character is Character tm)
+                                {
+                                    var distance = tm.Transform.World.Position - Owner.Transform.World.Position;
+                                    if (distance.Length() <= 200)
+                                    {
+                                        //tm is an eligible party member
+                                        if (_taggers.ContainsKey(tm))
+                                        {
+                                            //Tagger is already in the list
+                                            partyDamage+=_taggers[tm];
+                                          
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        //Did the party do more than 50% of the total HP in damage?
+                        if (partyDamage > Owner.MaxHp * 0.5)
+                        {
+                           
+                                _tagTeam = checkTeam.Id;
+                            
+                            
+                        }
+                    }
+                    else
+                    {
+                        if (_taggers[pl] > Owner.MaxHp * 0.5)
+                        {
+
+                            _tagger = pl;
+                        }
+                    }
+                }
+                //TODO: packet to set red-but-not-aggro HP bar for taggers, "dull red" HP bar for not-taggers
+
+                
+            }
+        }
+    }
+}

--- a/AAEmu.Game/Models/Game/Team/TeamMember.cs
+++ b/AAEmu.Game/Models/Game/Team/TeamMember.cs
@@ -8,11 +8,13 @@ public class TeamMember : PacketMarshaler
 {
     public Character Character { get; set; }
     public MemberRole Role { get; set; }
+    public bool HasGoneRoundRobin { get; set; }
 
     public TeamMember(Character character = null)
     {
         Character = character;
         Role = MemberRole.Undecided;
+        HasGoneRoundRobin = false;
     }
 
     public override PacketStream Write(PacketStream stream)

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -447,10 +447,87 @@ public class Unit : BaseUnit, IUnit
         }
 
         var lootDropItems = ItemManager.Instance.CreateLootDropItems(ObjId, killer);
+        // Without moving the tagging into the root of unit, we need to do some work for loot distribution:
         if (lootDropItems.Count > 0)
         {
-            killer.BroadcastPacket(new SCLootableStatePacket(ObjId, true), true);
+           // Logger.Info($"Loot item count is {lootDropItems.Count}");
+            var unit = WorldManager.Instance.GetNpc(ObjId);
+            if (unit == null)
+            {
+                //Defaulting to the original code if this isn't an NPC
+              //  Logger.Info($"Not an NPC for {ObjId}");
+
+                killer.BroadcastPacket(new SCLootableStatePacket(ObjId, true), true);
+
+            }
+            else
+            {
+                //it's an NPC, and we have a thing for this!
+                HashSet<Character> eligiblePlayers = new HashSet<Character>();
+                if (unit.CharacterTagging.TagTeam != 0)
+                {
+                    //A team has tagging rights. TODO: Master Looter
+                    var activeTeam = TeamManager.Instance.GetActiveTeam(unit.CharacterTagging.TagTeam);
+                    if(activeTeam.LootingRule.LootMethod==0)
+                    {
+                        //FFA Loot
+                        foreach (var member in activeTeam.Members)
+                        {
+                            if (member != null && member.Character != null)
+                            {
+                                if (member.Character is Character tm)
+                                {
+                                    var distance = tm.Transform.World.Position - this.Transform.World.Position;
+                                    if (distance.Length() <= 200)
+                                    {
+                                        eligiblePlayers.Add(tm);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+
+                        //RoundRobin, TODO: Master Looter
+                        var nextEligibleLooter = TeamManager.Instance.GetNextEligibleLooter(unit.CharacterTagging.TagTeam, unit);
+                        if (nextEligibleLooter != null)
+                        {
+                            eligiblePlayers.Add(nextEligibleLooter);
+                            Logger.Warn($"Eligible team, adding {nextEligibleLooter}");
+                        }
+                        else
+                        {
+                            Logger.Warn("Next eligible looter was null");
+                        }
+                    }
+                  
+                }
+                else if (unit.CharacterTagging.Tagger != null)
+                {
+                    //A player has tag rights
+                    eligiblePlayers.Add(unit.CharacterTagging.Tagger);
+                    Logger.Warn($"Added tagger {unit.CharacterTagging.Tagger}");
+                }
+                if (eligiblePlayers.Count > 0)
+                {
+                    foreach (var eligible in eligiblePlayers)
+                    {
+                        if (eligible != null)
+                        {
+                            eligible.SendPacket(new SCLootableStatePacket(ObjId, true));
+                        }
+                        else
+                        {
+                            Logger.Warn($"Eligible player was null, eligible player count was {eligiblePlayers.Count}");
+                        }
+                    }
+                }
+            }
+
         }
+
+
 
         if (CurrentTarget != null)
         {


### PR DESCRIPTION

- Added Tagging.cs to control tagging system.

- Hitting an enemy for the first time now tags it to the player (or mate/pet owner) and any party/raid members in range.

- Per 1.2 ArcheAge, dealing more than 50% mob health in damage from a single player or a party/raid will steal the tag on that enemy.

- Modified GetActiveTeam() in TeamManager.cs to be public, for the tagging system to access.

- Rewrote DoDie() in NPC.cs to correctly process kill rights for looting and XP distribution: -- The owning tagger or party are processed.
-- XP scaling is in place for levels. Before the Party reduction, individual XP award is calculated based on player level vs enemy level. At 1:1, it is 100% of XP. It decreases by 10% for every level below the player the enemy is, until it caps at 0 XP at -10 levels. It increases by 10% for every level above the player the enemy is. Currently, it becomes 0 when the enemy is more than 10 levels above the player. -- If the player who tagged is solo or in a party of less than 4 players, the tagging players in range are considered eligible. XP is provided to all eligible players and pets at 100% for a single player, 90% for 2, and 87.5 for 3 players. -- If the eligible taggers are party of 4 or 5 players, range stops mattering. XP is awarded to all eligible players and pets at 66% of the original value. -- If the eligible taggers are in a raid of any size, XP is awarded to all eligible players at 33% of the original value. Per a 1.2 feature, pets still get 66% XP.

- Added GetNextEligibleLooter() to TeamManager.cs to process loot rules.

- Added HasGoneRoundRobin to TeamMember.cs to track Rotate Winner

- Rewrote loot elements of DoDie() in Unit.cs to control looting: If the eligible taggers are in a party/raid (including solo party) with Free For All loot set, the loot packet is sent to all eligible taggers. If the loot type is Rotate Winner (or Master Looter, which is NYI), the loot packet is sent to valid party/raid members in order. Party/raid members are skipped for this if there is no loot. Once every party/raid member has received loot rights, the rotation starts over.

- Modified saving of items in ItemManager.cs with a try/catch to ensure that if an item cannot be saved, it does not break the saving of the rest of the items. Also added a catch that if an item type is None, and it has a parent container, to convert the type to the type of that container.