### PR TITLE
[Game] Added TargetNpcTagId check for effects

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/Effects/BuffEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/BuffEffect.cs
@@ -4,8 +4,10 @@ using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Packets;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Faction;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects;
 
@@ -82,10 +84,12 @@ public class BuffEffect : EffectTemplate
 
         target.Buffs.AddBuff(new Buff(target, caster, casterObj, Buff, source.Skill, time) { AbLevel = abLevel });
 
-        if (Buff.Kind == BuffKind.Bad && caster.GetRelationStateTo(target) == RelationState.Friendly
-            && caster != target && !target.Buffs.CheckBuff((uint)BuffConstants.Retribution))
+        if (Buff.Kind == BuffKind.Bad && 
+            caster.GetRelationStateTo(target) == RelationState.Friendly && 
+            caster != target && 
+            !target.Buffs.CheckBuff((uint)BuffConstants.Retribution))
         {
-            ((Unit)caster).SetCriminalState(true);
+            ((Unit)caster).SetCriminalState(true, target);
         }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/DamageEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/DamageEffect.cs
@@ -12,6 +12,7 @@ using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects;
 
@@ -369,7 +370,7 @@ public class DamageEffect : EffectTemplate
         {
             if (!trg.Buffs.CheckBuff((uint)BuffConstants.Retribution))
             {
-                ((Unit)caster).SetCriminalState(true);
+                ((Unit)caster).SetCriminalState(true, trg);
             }
         }
 

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -11,6 +11,7 @@ using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.DoodadObj.Static;
@@ -827,6 +828,7 @@ public class Skill
 
             foreach (var target in effectedTargets)
             {
+                var targetNpc = target as Npc;
                 var relationState = caster.GetRelationStateTo(target);
                 if (effect.StartLevel > unit.Level || effect.EndLevel < unit.Level)
                 {
@@ -875,6 +877,14 @@ public class Skill
                 if (effect.TargetNoBuffTagId > 0 && target.Buffs.CheckBuffs(SkillManager.Instance.GetBuffsByTagId(effect.TargetNoBuffTagId)))
                 {
                     continue;
+                }
+
+                if (effect.TargetNpcTagId > 0)
+                {
+                    if (targetNpc == null || !TagsGameData.Instance
+                            .GetIdsByTagId(TagsGameData.TagType.Npcs, effect.TargetNpcTagId)
+                            .Contains(targetNpc.TemplateId))
+                        continue;
                 }
 
                 if (effect.Chance < 100 && Rand.Next(100) > effect.Chance)

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -24,6 +24,7 @@ using AAEmu.Game.Models.Game.Static;
 using AAEmu.Game.Models.Game.Units.Route;
 using AAEmu.Game.Models.Game.Units.Static;
 using AAEmu.Game.Models.Game.World;
+using AAEmu.Game.Models.StaticValues;
 using AAEmu.Game.Models.Tasks;
 using AAEmu.Game.Models.Tasks.Skills;
 using AAEmu.Game.Utils;
@@ -661,10 +662,14 @@ public class Unit : BaseUnit, IUnit
         AppConfiguration.Instance.World.MOTD = value;
     }
 #pragma warning restore CA1822 // Mark members as static
-    public void SetCriminalState(bool criminalState)
+    public void SetCriminalState(bool criminalState, BaseUnit attackedTarget)
     {
         if (criminalState)
         {
+            // Don't trigger Retribution (purple) when target is a Npc (except for player portals)
+            if ((attackedTarget is Npc) && (attackedTarget is not Portal))
+                return;
+
             var buff = SkillManager.Instance.GetBuffTemplate((uint)BuffConstants.Retribution);
             var casterObj = new SkillCasterUnit(ObjId);
             Buffs.AddBuff(new Buff(this, this, casterObj, buff, null, DateTime.UtcNow));


### PR DESCRIPTION
- Effects now correctly targets units when TargetNpcTagId is set
- Added check that prevents players from getting the Retribution buff (purpling) from attacking NPCs
