### PR TITLE
[WebAPI] Update controller for AuctionHouse (Search/Filter)

### DIFF
--- a/AAEmu.Game/Services/WebApi/Controllers/AuctionController.cs
+++ b/AAEmu.Game/Services/WebApi/Controllers/AuctionController.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Models.Game.Auction;
 using NetCoreServer;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using NLog;
+using System.Web;
 
 namespace AAEmu.Game.Services.WebApi.Controllers
 {
@@ -14,8 +18,6 @@ namespace AAEmu.Game.Services.WebApi.Controllers
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         /// Adds an item to the auction house.
-        /// "request" The HTTP request containing the item details.
-        /// "matches" The regex matches from the route.
         /// Returns A JSON response indicating success or failure.
         [WebApiPost("/api/auction/add")]
         public HttpResponse AddAuctionItem(HttpRequest request, MatchCollection matches)
@@ -85,26 +87,75 @@ namespace AAEmu.Game.Services.WebApi.Controllers
                 return BadRequestJson(new { error = "Internal server error", details = ex.Message });
             }
         }
-    }
 
-    /// Represents a request to add an auction item.
-    public class AuctionItemRequest
-    {
-        public uint ItemId { get; set; }
-        public uint Quantity { get; set; }
-        public int Price { get; set; }
-        public int Duration { get; set; }
-        public uint ClientId { get; set; }
-        public string ClientName { get; set; }
+        /// Returns A JSON response with the list of all auction items.
+        [WebApiGet("/api/auction/list")]
+        public HttpResponse GetAllAuctionItems(HttpRequest request, MatchCollection matches)
+        {
+            try
+            {
+                var auctionItems = AuctionManager.Instance._auctionItems;
+                return OkJson(new { items = auctionItems });
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Error retrieving auction items");
+                return BadRequestJson(new { error = "Internal server error", details = ex.Message });
+            }
+        }
+
+
+        /// Returns A JSON response with the filtered list of auction items.
+        [WebApiGet("/api/auction/search")]
+        public HttpResponse SearchAuctionItems(HttpRequest request, MatchCollection matches)
+        {
+            try
+            {
+                var query = AuctionManager.Instance._auctionItems.AsQueryable();
+
+                // Extract query parameters from the URL
+                var queryParams = HttpUtility.ParseQueryString(request.Url.Split('?').Length > 1 ? request.Url.Split('?')[1] : "");
+
+                // Apply filters
+                if (queryParams["itemId"] != null)
+                {
+                    uint itemId = uint.Parse(queryParams["itemId"]);
+                    query = query.Where(item => item.ItemID == itemId);
+                }
+                if (queryParams["clientName"] != null)
+                {
+                    string clientName = queryParams["clientName"];
+                    query = query.Where(item => item.ClientName.Equals(clientName, StringComparison.OrdinalIgnoreCase));
+                }
+                if (queryParams["stackSize"] != null)
+                {
+                    uint stackSize = uint.Parse(queryParams["stackSize"]);
+                    query = query.Where(item => item.StackSize == stackSize);
+                }
+                if (queryParams["directMoney"] != null)
+                {
+                    int directMoney = int.Parse(queryParams["directMoney"]);
+                    query = query.Where(item => item.DirectMoney == directMoney);
+                }
+                if (queryParams["bidMoney"] != null)
+                {
+                    int bidMoney = int.Parse(queryParams["bidMoney"]);
+                    query = query.Where(item => item.BidMoney == bidMoney);
+                }
+                if (queryParams["bidderName"] != null)
+                {
+                    string bidderName = queryParams["bidderName"];
+                    query = query.Where(item => item.BidderName.Equals(bidderName, StringComparison.OrdinalIgnoreCase));
+                }
+
+                var auctionItems = query.ToList();
+                return OkJson(new { items = auctionItems });
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Error retrieving auction items");
+                return BadRequestJson(new { error = "Internal server error", details = ex.Message });
+            }
+        }
     }
 }
-
-/// Example api JSON Payload to POST
-///{
-///    "itemId": 1234,
-///    "quantity": 10,
-///    "price": 5000,
-///    "duration": 3600,
-///    "clientId": 5678,
-///    "clientName": "PlayerName"
-///}

--- a/AAEmu.Game/Services/WebApi/Controllers/AuctionController.cs
+++ b/AAEmu.Game/Services/WebApi/Controllers/AuctionController.cs
@@ -1,0 +1,110 @@
+using System;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.Auction;
+using NetCoreServer;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using NLog;
+
+namespace AAEmu.Game.Services.WebApi.Controllers
+{
+    /// AuctionController handles adding items to the auction house via a web API.
+    internal class AuctionController : BaseController, IController
+    {
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+        /// Adds an item to the auction house.
+        /// "request" The HTTP request containing the item details.
+        /// "matches" The regex matches from the route.
+        /// Returns A JSON response indicating success or failure.
+        [WebApiPost("/api/auction/add")]
+        public HttpResponse AddAuctionItem(HttpRequest request, MatchCollection matches)
+        {
+            // Deserialize the JSON body of the request
+            var jsonBody = JsonSerializer.Deserialize<JsonElement>(request.Body);
+            
+            // Validate and extract required parameters
+            if (!jsonBody.TryGetProperty("itemId", out var itemIdElement) || 
+                !jsonBody.TryGetProperty("quantity", out var quantityElement) || 
+                !jsonBody.TryGetProperty("price", out var priceElement) || 
+                !jsonBody.TryGetProperty("duration", out var durationElement) || 
+                !jsonBody.TryGetProperty("clientId", out var clientIdElement) || 
+                !jsonBody.TryGetProperty("clientName", out var clientNameElement))
+            {
+                return BadRequestJson(new { error = "Invalid parameters" });
+            }
+
+            var itemId = itemIdElement.GetUInt32();
+            var quantity = quantityElement.GetUInt32();
+            var price = priceElement.GetInt32();
+            var duration = durationElement.GetInt32();
+            var clientId = clientIdElement.GetUInt32();
+            var clientName = clientNameElement.GetString();
+
+            try
+            {
+                // Create a new auction item
+                var newAuctionItem = new AuctionItem
+                {
+                    ID = AuctionManager.Instance.GetNextId(),
+                    Duration = (byte)duration,
+                    ItemID = itemId,
+                    ObjectID = 0,
+                    Grade = 0,
+                    Flags = 0,
+                    StackSize = quantity,
+                    DetailType = 0,
+                    CreationTime = DateTime.UtcNow,
+                    EndTime = DateTime.UtcNow.AddSeconds(duration),
+                    LifespanMins = 0,
+                    Type1 = 0,
+                    WorldId = 0,
+                    UnpackDateTIme = DateTime.UtcNow,
+                    UnsecureDateTime = DateTime.UtcNow,
+                    WorldId2 = 0,
+                    ClientId = clientId,
+                    ClientName = clientName,
+                    StartMoney = 0,
+                    DirectMoney = price,
+                    BidWorldID = 0,
+                    BidderId = 0,
+                    BidderName = "",
+                    BidMoney = 0,
+                    Extra = 0,
+                    IsDirty = true
+                };
+
+                // Add the auction item to the auction house
+                AuctionManager.Instance.AddAuctionItem(newAuctionItem);
+                Logger.Info($"Added auction item: {newAuctionItem}");
+                return OkJson(new { message = "Auction item added successfully", item = newAuctionItem });
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Error adding auction item");
+                return BadRequestJson(new { error = "Internal server error", details = ex.Message });
+            }
+        }
+    }
+
+    /// Represents a request to add an auction item.
+    public class AuctionItemRequest
+    {
+        public uint ItemId { get; set; }
+        public uint Quantity { get; set; }
+        public int Price { get; set; }
+        public int Duration { get; set; }
+        public uint ClientId { get; set; }
+        public string ClientName { get; set; }
+    }
+}
+
+/// Example api JSON Payload to POST
+///{
+///    "itemId": 1234,
+///    "quantity": 10,
+///    "price": 5000,
+///    "duration": 3600,
+///    "clientId": 5678,
+///    "clientName": "PlayerName"
+///}


### PR DESCRIPTION
New capability in the AuctionController to handle two GET requests. One returns the entire auction house data (/api/auction/list) and the other can provide a filtered result (/api/auction/search).

Available filters include (but could be extended if needed): itemId, clientName, stackSize, directMoney, bidMoney, bidderName

Example python script for using search via API with filters (filters are optional):
```
import requests

# Replace with the actual URL of your server
base_url = "http://127.0.0.1:1280/api/auction"

# Function to search auction items with filters
def search_auction_items(filters):
    try:
        response = requests.get(f"{base_url}/search", params=filters)
        if response.status_code == 200:
            auction_items = response.json()
            print("Filtered Auction Items:")
            print(auction_items)
        else:
            print(f"Failed to retrieve auction items. Status code: {response.status_code}")
            print(response.text)
    except Exception as e:
        print(f"An error occurred: {e}")

# Define the query parameters for filtering by itemId only
filters = {
    "itemId": "28189"
}

# Search auction items with filters
search_auction_items(filters)
```
