### PR TITLE
[Login] Added option to skip the host resolving

### DIFF
--- a/AAEmu.Login/Core/Controllers/GameController.cs
+++ b/AAEmu.Login/Core/Controllers/GameController.cs
@@ -83,12 +83,13 @@ public class GameController : Singleton<GameController>
                         var id = reader.GetByte("id");
                         var name = reader.GetString("name");
                         var loadedHost = reader.GetString("host");
-                        var host = ResolveHostName(loadedHost);
+                        var host = AppConfiguration.Instance.SkipHostResolve ? loadedHost : ResolveHostName(loadedHost);
                         var port = reader.GetUInt16("port");
                         var gameServer = new GameServer(id, name, host, port);
                         _gameServers.Add(gameServer.Id, gameServer);
 
-                        var extraInfo = host != loadedHost ? "from " + loadedHost : "";
+                        var extraInfo = host != loadedHost ? "from " + loadedHost :
+                            AppConfiguration.Instance.SkipHostResolve ? " (unresolved)" : "";
                         Logger.Info($"Game Server {id}: {name} -> {host}:{port} {extraInfo}");
                     }
                 }

--- a/AAEmu.Login/ExampleConfig.json
+++ b/AAEmu.Login/ExampleConfig.json
@@ -1,22 +1,23 @@
 {
-  "SecretKey": "test",
-  "AutoAccount": true,
-  "InternalNetwork": {
-    "Host": "*",
-    "Port": 1234
-  },
-  "Network": {
-    "Host": "*",
-    "Port": 1237,
-    "NumConnections": 10
-  },
-  "Connections": {
-    "MySQLProvider": {
-      "Host": "%db_host%",
-      "Port": "%db_port%",
-      "User": "%db_user%",
-      "Password": "%db_password%",
-      "Database": "aaemu_login"
-    }
-  }
+	"SecretKey": "test",
+	"AutoAccount": true,
+	"SkipHostResolve": false,
+	"InternalNetwork": {
+		"Host": "*",
+		"Port": 1234
+	},
+	"Network": {
+		"Host": "*",
+		"NumConnections": 10,
+		"Port": 1237
+	},
+	"Connections": {
+		"MySQLProvider": {
+			"Database": "aaemu_login",
+			"Host": "%db_host%",
+			"Password": "%db_password%",
+			"Port": "%db_port%",
+			"User": "%db_user%"
+		}
+	}
 }

--- a/AAEmu.Login/Models/AppConfiguration.cs
+++ b/AAEmu.Login/Models/AppConfiguration.cs
@@ -7,6 +7,7 @@ public class AppConfiguration : Singleton<AppConfiguration>
 {
     public string SecretKey { get; set; }
     public bool AutoAccount { get; set; }
+    public bool SkipHostResolve { get; set; }
     public DBConnections Connections { get; set; }
     public NetworkConfig InternalNetwork { get; set; }
     public NetworkConfig Network { get; set; }


### PR DESCRIPTION
Added a ``SkipHostResolve`` option to ``Config.json`` to allow the login server to skip host name resolving and simply processing the raw IP used in the ``game_servers`` table.
This can be useful for making specific setups work correctly. Recommended to keep this setting ``false`` unless it is consistently resolving to the wrong IP when starting.
