### PR TITLE
Update aaemu_game.sql to fix syntax err.

### DIFF
--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -32,8 +32,13 @@ CREATE TABLE `accounts` (
   PRIMARY KEY (`account_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Account specific values not related to login';
 
-CREATE TRIGGER update_timestamps BEFORE UPDATE ON accounts FOR EACH ROW BEGIN SET NEW.last_updated = UTC_TIMESTAMP(); END;
-
+DELIMITER //
+CREATE TRIGGER update_timestamps BEFORE UPDATE ON accounts
+FOR EACH ROW
+BEGIN
+   SET NEW.last_updated = UTC_TIMESTAMP();
+END;//
+DELIMITER ;
 
 DROP TABLE IF EXISTS `actabilities`;
 CREATE TABLE `actabilities` (


### PR DESCRIPTION
Before err says:
```
ERROR 1064 (42000) at line 35: 
You have an error in your SQL syntax; 
check the manual that corresponds to your MySQL server version
 for the right syntax to use near '' at line 1
```
Previously, the trigger definition was causing a ERROR 1064 (42000) due to incorrect usage of semicolons within the BEGIN ... END block.

Changes made:

Updated the trigger definition to use a custom delimiter (//) allowing the use of semicolons within the BEGIN ... END block.
Reverted back to the default delimiter (;) after the trigger definition.
With these changes, the trigger update_timestamps should now be created without any syntax errors.