### PR TITLE
[Game] Moved NPC events out of dungeons and onto all NPCs

### DIFF
--- a/AAEmu.Game/Core/Managers/IndunManager.cs
+++ b/AAEmu.Game/Core/Managers/IndunManager.cs
@@ -43,17 +43,17 @@ namespace AAEmu.Game.Core.Managers
 
         private void IndunInfoTick(TimeSpan delta)
         {
-            if (_teamDungeons is { Count: 0 })
+            if (_teamDungeons is { Count: > 0 })
             {
-                Logger.Info($"Team dungeons: 0");
+                Logger.Info($"Team dungeons: {_teamDungeons.Count}");
             }
-            if (_soloDungeons is { Count: 0 })
+            if (_soloDungeons is { Count: > 0 })
             {
-                Logger.Info($"Solo dungeons: 0");
+                Logger.Info($"Solo dungeons: {_soloDungeons.Count}");
             }
-            if (_sysDungeons is { Count: 0 })
+            if (_sysDungeons is { Count: > 0 })
             {
-                Logger.Info($"Sys dungeons: 0");
+                Logger.Info($"Sys dungeons: {_sysDungeons.Count}");
             }
             foreach (var td in _teamDungeons)
             {
@@ -665,11 +665,7 @@ namespace AAEmu.Game.Core.Managers
         {
             lock (_lock)
             {
-                if (_attempts is { Count: 0 })
-                {
-                    Logger.Info("Attempts: 0");
-                }
-                else
+                if (_attempts is { Count: > 0 })
                 {
                     foreach (var attempt in _attempts)
                     {

--- a/AAEmu.Game/Core/Managers/SkillManager.cs
+++ b/AAEmu.Game/Core/Managers/SkillManager.cs
@@ -250,7 +250,7 @@ public class SkillManager : Singleton<SkillManager>, ISkillManager
             }
         }
 
-        return new Skill(skillTemplate);
+        return skillTemplate != null ? new Skill(skillTemplate) : null;
     }
 
     public void Load()

--- a/AAEmu.Game/GameData/NpcGameData.cs
+++ b/AAEmu.Game/GameData/NpcGameData.cs
@@ -189,7 +189,7 @@ public class NpcGameData : Singleton<NpcGameData>, IGameDataLoader
         return _npcSpawnerTemplateNpcs.Values.FirstOrDefault(nsn => nsn.NpcSpawnerTemplateId == spawnerId);
     }
 
-    public List<NpcSkill> GetNpSkill(uint npcId, SkillUseConditionKind skillCondition = SkillUseConditionKind.None)
+    public List<NpcSkill> GetNpSkills(uint npcId, SkillUseConditionKind skillCondition = SkillUseConditionKind.None)
     {
         if (_skillsForNpc.ContainsKey(npcId))
         {

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncRequireQuest.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncRequireQuest.cs
@@ -18,10 +18,9 @@ public class DoodadFuncRequireQuest : DoodadPhaseFuncTemplate
         {
             //character.Quests.OnInteraction(WorldInteractionId, character.CurrentTarget);
             if (character.Quests.HasQuest(QuestId))
-                return false; // продолжим выполнение, подходящий квест
-            else
-                return true; // прерываем, не подходящий квест
+                return false; // This player is on the correct quest, continue
+            return true; // Player doesn't have the quest, stop execution
         }
-        return true; // прерываем, не подходящий квест
+        return false; // caster is not a player, allow execution as we can't check
     }
 }

--- a/AAEmu.Game/Models/Game/Indun/Dungeon.cs
+++ b/AAEmu.Game/Models/Game/Indun/Dungeon.cs
@@ -12,9 +12,6 @@ using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Indun.Events;
 using AAEmu.Game.Models.Game.NPChar;
-using AAEmu.Game.Models.Game.Skills;
-using AAEmu.Game.Models.Game.Skills.Static;
-using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Utils;
 
@@ -24,25 +21,24 @@ namespace AAEmu.Game.Models.Game.Indun
 {
     public class Dungeon
     {
-        private static Logger Logger = LogManager.GetCurrentClassLogger();
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         private readonly List<uint> _players;
         private readonly World.World _world;
         private readonly ZoneInstanceId _zoneInstanceId;
-        private readonly List<Npc> _spawnedNpcs;
         public readonly IndunZone _indunZone;
         // unused private List<Character> _teleportList;
-        private ConcurrentDictionary<uint, DateTime> _leaveRequests;
+        private readonly ConcurrentDictionary<uint, DateTime> _leaveRequests;
         private Character _characterOwner;
         private Team.Team _teamOwner;
         private bool _isTeamOwned;
-        private Dictionary<uint, bool> _rooms;
+        private readonly Dictionary<uint, bool> _rooms;
         //private static Dictionary<uint, Dictionary<uint, int>> _attempts; // <ownerId, <zoneGroupId, attempts>> - использовано попыток прохождения данжона
         //private const int FreeAttempts = 3;  // свободных попыток
         //private const int ExtraAttempts = 2; // дополнительных попыток
         //public bool IsWaitingDungeonAccessAttemptsCleared { get; set; }
 
-        private object _lock = new();
+        private readonly object _lock = new();
 
         public bool IsTeamOwned { get => _isTeamOwned; }
         public Character GetCharacterOwner { get => _characterOwner; }
@@ -103,19 +99,18 @@ namespace AAEmu.Game.Models.Game.Indun
 
             // let's spawn Npc, Doodad, Slave, Gimmick
             Logger.Info($"[Dungeon] spawning Npc, Doodad, Slave, Gimmick...");
-            _spawnedNpcs = SpawnManager.Instance.SpawnAll(_world.Id, _world.TemplateId);
+            _ = SpawnManager.Instance.SpawnAll(_world.Id, _world.TemplateId);
             Logger.Info($"[Dungeon] spawned Npc, Doodad, Slave, Gimmick...");
 
             RegisterIndunEvents();
-
-            foreach (var npc in _spawnedNpcs)
-            {
-                if (npc == null) { continue; }
-                RegisterNpcEvents(npc);
-            }
         }
 
-        // для системных данжей, таких как мираж и библиотека
+        /// <summary>
+        /// For system dungeons like the mirage and the library
+        /// для системных данжей, таких как мираж и библиотека
+        /// </summary>
+        /// <param name="indunZone"></param>
+        /// <param name="character"></param>
         public Dungeon(IndunZone indunZone, Character character)
         {
             _indunZone = indunZone;
@@ -148,9 +143,9 @@ namespace AAEmu.Game.Models.Game.Indun
             // или
             // для group_id: 49=arche_mall, 70=instance_library_1, 71=instance_library_2, 72=instance_library_3
             Logger.Info($"[Dungeon] не делаем копию инстанса...");
-            _world = world; // не делаем копию инстанса
+            _world = world; // don't make a copy of the instance / не делаем копию инстанса
             _zoneInstanceId = new ZoneInstanceId(zoneKeys[0], _world.Id);
-            // выводится окошко о том, что создается данжон
+            // a window will pop up indicating that a dungeon is being created. / выводится окошко о том, что создается данжон
             character.SendPacket(new SCProcessingInstancePacket((int)_zoneInstanceId.ZoneId));
 
             RegisterIndunEvents();
@@ -164,7 +159,7 @@ namespace AAEmu.Game.Models.Game.Indun
         /// <summary>
         /// Returns true if the dungeon has players inside, false if not.
         /// </summary>
-        public bool HasPlayers => _players.Count > 0;
+        private bool HasPlayers => _players.Count > 0;
 
         /// <summary>
         /// Add player to Dungeon
@@ -201,7 +196,7 @@ namespace AAEmu.Game.Models.Game.Indun
         /// Remove player from Dungeon
         /// </summary>
         /// <param name="character"></param>
-        public bool RemovePlayer(Character character)
+        private bool RemovePlayer(Character character)
         {
             if (character == null) { return false; }
             lock (_lock)
@@ -234,7 +229,7 @@ namespace AAEmu.Game.Models.Game.Indun
             {
                 if (npc == null) { continue; }
 
-                UnregisterNpcEvents(npc);
+                npc.UnregisterNpcEvents();
                 npc.Delete();
                 ObjectIdManager.Instance.ReleaseId(npc.ObjId);
             }
@@ -254,7 +249,7 @@ namespace AAEmu.Game.Models.Game.Indun
 
             TickManager.Instance.OnTick.UnSubscribe(AreaClearTick);
 
-            RemovePlayer(character);
+            _ = RemovePlayer(character);
 
             if (!soloDungeon.IsOwner(character) || soloDungeon.HasPlayers) { return false; }
             if (_world == null) { return true; }
@@ -272,7 +267,7 @@ namespace AAEmu.Game.Models.Game.Indun
             {
                 if (npc == null) { continue; }
 
-                UnregisterNpcEvents(npc);
+                npc.UnregisterNpcEvents();
                 npc.Delete();
                 ObjectIdManager.Instance.ReleaseId(npc.ObjId);
             }
@@ -383,7 +378,7 @@ namespace AAEmu.Game.Models.Game.Indun
             character.Events.OnDisconnect -= OnDisconnect;
 
             _leaveRequests.TryRemove(character.Id, out _);
-            RemovePlayer(character);
+            _ = RemovePlayer(character);
 
             if (character.MainWorldPosition == null)
             {
@@ -413,7 +408,7 @@ namespace AAEmu.Game.Models.Game.Indun
             character.Events.OnDisconnect -= OnDisconnect;
 
             _leaveRequests.TryRemove(character.Id, out _);
-            RemovePlayer(character);
+            _ = RemovePlayer(character);
 
             if (character.MainWorldPosition == null)
             {
@@ -513,7 +508,7 @@ namespace AAEmu.Game.Models.Game.Indun
 
             if (IsSystem)
             {
-                RemovePlayer(args.Player);
+                _ = RemovePlayer(args.Player);
                 args.Player.Events.OnDungeonLeave -= OnDungeonLeave;
                 args.Player.Events.OnDisconnect -= OnDisconnect;
                 return;
@@ -524,197 +519,14 @@ namespace AAEmu.Game.Models.Game.Indun
                 IndunManager.Instance.RequestDeletion(args.Player, this);
             }
 
-            RemovePlayer(args.Player);
+            _ = RemovePlayer(args.Player);
             args.Player.Events.OnTeamJoin -= OnTeamJoin;
             args.Player.Events.OnTeamKick -= OnTeamLeave;
             args.Player.Events.OnTeamLeave -= OnTeamLeave;
             args.Player.Events.OnDungeonLeave -= OnDungeonLeave;
             args.Player.Events.OnDisconnect -= OnDisconnect;
         }
-
-        private void OnCombatStarted(object sender, OnCombatStartedArgs args)
-        {
-            if (args.Owner is not Npc npc)
-            {
-                if (args.Target is not Npc target)
-                {
-                    return;
-                }
-                npc = target;
-            }
-
-            if (npc.IsInBattle)
-            {
-                return;
-            }
-            npc.IsInBattle = true;
-
-            var skills = NpcGameData.Instance.GetNpSkill(npc.TemplateId, SkillUseConditionKind.InCombat);
-            if (skills == null) { return; }
-
-            Logger.Info($"Npc={npc.ObjId}:{npc.TemplateId} has started combat.");
-
-            foreach (var npcSkill in skills)
-            {
-                var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
-
-                if (skill is null) { continue; }
-
-                var skillCaster = SkillCaster.GetByType(SkillCasterType.Unit);
-                skillCaster.ObjId = npc.ObjId;
-
-                var skillTarget = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
-                skillTarget.ObjId = npc.ObjId;
-
-                if (npc.Cooldowns.CheckCooldown(skill.Id)) { continue; }
-                if (skill.Template.CooldownTime == 0)
-                {
-                    npc.Cooldowns.AddCooldown(skill.Id, uint.MaxValue); // выполняем один раз
-                }
-                Logger.Info($"Npc={npc.ObjId}:{npc.TemplateId} using skill={skill.Id}");
-                skill.Use(npc, skillCaster, skillTarget);
-            }
-        }
-
-        private void InIdle(object sender, InIdleArgs args)
-        {
-            if (args.Owner is not Npc npc) { return; }
-            var skills = NpcGameData.Instance.GetNpSkill(npc.TemplateId, SkillUseConditionKind.InIdle);
-            if (skills == null) { return; }
-
-            Logger.Info($"Npc={npc.ObjId}:{npc.TemplateId} has entered idle state.");
-
-            foreach (var npcSkill in skills)
-            {
-                var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
-
-                if (skill is null) { continue; }
-
-                var skillCaster = SkillCaster.GetByType(SkillCasterType.Unit);
-                skillCaster.ObjId = npc.ObjId;
-
-                var skillTarget = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
-                skillTarget.ObjId = npc.ObjId;
-
-                if (npc.Cooldowns.CheckCooldown(skill.Id)) { continue; }
-                if (skill.Template.CooldownTime == 0)
-                {
-                    npc.Cooldowns.AddCooldown(skill.Id, uint.MaxValue); // выполняем один раз
-                }
-                Logger.Info($"Npc={npc.ObjId}:{npc.TemplateId} using skill={skill.Id}");
-                skill.Use(npc, skillCaster, skillTarget);
-            }
-        }
-
-        private void OnDeath(object sender, OnDeathArgs args)
-        {
-            if (args.Victim is not Npc npc) { return; }
-            var skills = NpcGameData.Instance.GetNpSkill(npc.TemplateId, SkillUseConditionKind.OnDeath);
-            if (skills == null) { return; }
-
-            Logger.Info($"Npc objId={npc.ObjId}, templateId={npc.TemplateId} has died.");
-
-            //UnregisterNpcEvents(npc);
-            //UnregisterIndunEvents();
-
-            foreach (var npcSkill in skills)
-            {
-                var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
-
-                if (skill is null) { continue; }
-
-                var skillCaster = SkillCaster.GetByType(SkillCasterType.Unit);
-                skillCaster.ObjId = npc.ObjId;
-
-                var skillTarget = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
-                skillTarget.ObjId = npc.ObjId;
-
-                if (npc.Cooldowns.CheckCooldown(skill.Id)) { continue; }
-                if (skill.Template.CooldownTime == 0)
-                {
-                    npc.Cooldowns.AddCooldown(skill.Id, uint.MaxValue); // выполняем один раз
-                }
-                Logger.Info($"Npc={npc.ObjId}:{npc.TemplateId} using skill={skill.Id}");
-                skill.Use(npc, skillCaster, skillTarget);
-            }
-
-            const uint Dahuta = 13310u; // Npc Id=13310 "Dahuta", 50
-            if (npc.TemplateId is not Dahuta)
-            {
-                SpawnManager.Instance.SpawnWithinSourceRange(_world.TemplateId, args.Victim);
-            }
-        }
-
-        private void OnSpawn(object sender, OnSpawnArgs args)
-        {
-            if (args.Npc is not Npc npc) { return; }
-            var skills = NpcGameData.Instance.GetNpSkill(npc.TemplateId, SkillUseConditionKind.InIdle);
-            if (skills == null) { return; }
-
-            Logger.Info($"Npc objId: {npc.ObjId}, templateId: {npc.TemplateId} OnSpawn triggered.");
-
-            foreach (var npcSkill in skills)
-            {
-                var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
-
-                if (skill is null) { continue; }
-
-                var skillCaster = SkillCaster.GetByType(SkillCasterType.Unit);
-                skillCaster.ObjId = npc.ObjId;
-
-                var skillTarget = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
-                skillTarget.ObjId = npc.ObjId;
-
-                if (npc.Cooldowns.CheckCooldown(skill.Id)) { continue; }
-                if (skill.Template.CooldownTime == 0)
-                {
-                    npc.Cooldowns.AddCooldown(skill.Id, uint.MaxValue); // выполняем один раз
-                }
-                Logger.Info($"Npc={npc.ObjId}:{npc.TemplateId} using skill={skill.Id}");
-                skill.Use(npc, skillCaster, skillTarget);
-            }
-        }
-
-        private void OnDespawn(object sender, OnDespawnArgs args)
-        {
-            if (args.Npc is not Npc npc) { return; }
-            var skills = NpcGameData.Instance.GetNpSkill(npc.TemplateId, SkillUseConditionKind.InIdle);
-            if (skills == null) { return; }
-
-            Logger.Info($"Npc objId: {npc.ObjId}, templateId: {npc.TemplateId} OnDespawn triggered.");
-
-            foreach (var npcSkill in skills)
-            {
-                var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
-
-                if (skill is null) { continue; }
-
-                var skillCaster = SkillCaster.GetByType(SkillCasterType.Unit);
-                skillCaster.ObjId = npc.ObjId;
-
-                var skillTarget = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
-                skillTarget.ObjId = npc.ObjId;
-
-                if (npc.Cooldowns.CheckCooldown(skill.Id)) { continue; }
-                if (skill.Template.CooldownTime == 0)
-                {
-                    npc.Cooldowns.AddCooldown(skill.Id, uint.MaxValue); // выполняем один раз
-                }
-                Logger.Info($"Npc={npc.ObjId}:{npc.TemplateId} using skill={skill.Id}");
-                skill.Use(npc, skillCaster, skillTarget);
-            }
-        }
-
-        private void InAlert(object sender, InAlertArgs args)
-        {
-            Logger.Info($"Npc={args.Npc.ObjId}:{args.Npc.TemplateId} is in alert.");
-        }
-
-        private void InDead(object sender, InDeadArgs args)
-        {
-            Logger.Info($"Npc={args.Npc.ObjId} : {args.Npc.TemplateId} is in death state.");
-        }
-
+        
         /// <summary>
         /// Return true if the team Id matches to the team that owns the dungeon instance, false if not.
         /// </summary>
@@ -727,7 +539,7 @@ namespace AAEmu.Game.Models.Game.Indun
             return _teamOwner.Id == TeamManager.Instance.GetTeamByObjId(player.ObjId).Id;
         }
 
-        public bool IsOwner(Character character)
+        private bool IsOwner(Character character)
         {
             return _isTeamOwned == false && _characterOwner?.Id == character?.Id;
         }
@@ -787,7 +599,7 @@ namespace AAEmu.Game.Models.Game.Indun
             }
         }
 
-        public void RegisterIndunEvents()
+        private void RegisterIndunEvents()
         {
             Logger.Info($"Registering Indun Events...");
             foreach (var ev in IndunGameData.Instance.GetIndunEvents(_indunZone.ZoneGroupId))
@@ -796,7 +608,7 @@ namespace AAEmu.Game.Models.Game.Indun
             }
         }
 
-        public void UnregisterIndunEvents()
+        private void UnregisterIndunEvents()
         {
             Logger.Info($"Unregistering Indun Events...");
             foreach (var ev in IndunGameData.Instance.GetIndunEvents(_indunZone.ZoneGroupId))
@@ -805,135 +617,7 @@ namespace AAEmu.Game.Models.Game.Indun
             }
         }
 
-        public void RegisterNpcEvents(Npc npc)
-        {
-            if (npc == null) { return; }
-
-            var np = NpcGameData.Instance.GetNpSkill(npc.TemplateId);
-
-            if (np is null) { return; }
-
-            //Logger.Info($"Registering Events for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}");
-
-            foreach (var skill in np)
-            {
-                switch (skill.SkillUseCondition)
-                {
-                    case SkillUseConditionKind.InCombat:
-                        {
-                            Logger.Info($"Registering OnCombat event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.OnCombatStarted += OnCombatStarted;
-                            break;
-                        }
-                    case SkillUseConditionKind.InIdle:
-                        {
-                            Logger.Info($"Registering InIdle event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.InIdle += InIdle;
-                            break;
-                        }
-                    case SkillUseConditionKind.OnDeath:
-                        {
-                            Logger.Info($"Registering OnDeath event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.OnDeath += OnDeath;
-                            //int invocationCount = npc.Events.OnDeath.GetInvocationList().GetLength(0);
-                            break;
-                        }
-                    case SkillUseConditionKind.InAlert:
-                        {
-                            Logger.Info($"Registering InAlert event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.InAlert += InAlert;
-                            break;
-                        }
-                    case SkillUseConditionKind.InDead:
-                        {
-                            Logger.Info($"Registering InDead event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.InDead += InDead;
-                            break;
-                        }
-                    case SkillUseConditionKind.OnSpawn:
-                        {
-                            Logger.Info($"Registering OnSpawn event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.OnSpawn += OnSpawn;
-                            break;
-                        }
-                    case SkillUseConditionKind.OnDespawn:
-                        {
-                            Logger.Info($"Registering OnDespawn event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.OnDespawn += OnDespawn;
-                            break;
-                        }
-                    default:
-                        {
-                            Logger.Info("No SkillUseCondition found for skill " + skill.SkillId + " for npc " + npc.TemplateId);
-                            break;
-                        }
-                }
-            }
-        }
-
-        public void UnregisterNpcEvents(Npc npc)
-        {
-            var np = NpcGameData.Instance.GetNpSkill(npc.TemplateId);
-            if (np is null) { return; }
-
-            //Logger.Info($"Unregistering Npc Events for  objId: {npc.ObjId}, templateId: {npc.TemplateId}");
-
-            foreach (var skill in np)
-            {
-                switch (skill.SkillUseCondition)
-                {
-                    case SkillUseConditionKind.InCombat:
-                        {
-                            Logger.Info($"Unregistering OnCombat event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.OnCombatStarted -= OnCombatStarted;
-                            break;
-                        }
-                    case SkillUseConditionKind.InIdle:
-                        {
-                            Logger.Info($"Unregistering InIdle event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.InIdle -= InIdle;
-                            break;
-                        }
-                    case SkillUseConditionKind.OnDeath:
-                        {
-                            Logger.Info($"Unregistering OnDeath event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.OnDeath -= OnDeath;
-                            break;
-                        }
-                    case SkillUseConditionKind.InAlert:
-                        {
-                            Logger.Info($"Unregistering InAlert event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.InAlert += InAlert;
-                            break;
-                        }
-                    case SkillUseConditionKind.InDead:
-                        {
-                            Logger.Info($"Unregistering InDead event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.InDead += InDead;
-                            break;
-                        }
-                    case SkillUseConditionKind.OnSpawn:
-                        {
-                            Logger.Info($"Unregistering OnSpawn event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.OnSpawn += OnSpawn;
-                            break;
-                        }
-                    case SkillUseConditionKind.OnDespawn:
-                        {
-                            Logger.Info($"Unregistering OnDespawn event for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}, skill {skill.SkillId}");
-                            npc.Events.OnDespawn += OnDespawn;
-                            break;
-                        }
-                    default:
-                        {
-                            Logger.Info("No SkillUseCondition found for skill " + skill.SkillId + " for npc " + npc.TemplateId);
-                            break;
-                        }
-                }
-            }
-        }
-
-        public bool IsRoomCleared(uint roomId)
+        private bool IsRoomCleared(uint roomId)
         {
             return _rooms.TryGetValue(roomId, out var cleared) && cleared;
         }

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -26,7 +26,7 @@ using AAEmu.Game.Utils;
 
 namespace AAEmu.Game.Models.Game.NPChar;
 
-public class Npc : Unit
+public partial class Npc : Unit
 {
     public override UnitTypeFlag TypeFlag { get; } = UnitTypeFlag.Npc;
     //public uint TemplateId { get; set; } // moved to BaseUnit
@@ -767,7 +767,7 @@ public class Npc : Unit
     public override void DoDie(BaseUnit killer, KillReason killReason)
     {
        
-        HashSet<Character> eligiblePlayers = new HashSet<Character>();
+        var eligiblePlayers = new HashSet<Character>();
         if (CharacterTagging.TagTeam != 0)
         {
             //A team has tagging rights
@@ -839,7 +839,8 @@ public class Npc : Unit
                     }
                 }
             }
-                    foreach (Character pl in eligiblePlayers)
+            
+            foreach (var pl in eligiblePlayers)
             {
                 int plKillXP = 0;
                 int mateKillXP = 0;

--- a/AAEmu.Game/Models/Game/NPChar/NpcEvents.cs
+++ b/AAEmu.Game/Models/Game/NPChar/NpcEvents.cs
@@ -1,0 +1,307 @@
+﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.GameData;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Static;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Models.Game.NPChar;
+
+public partial class Npc
+{
+    public void RegisterNpcEvents()
+    {
+        var np = NpcGameData.Instance.GetNpSkills(TemplateId);
+
+        if (np is null) { return; }
+
+        // Logger.Info($"Registering Events for npc objId: {npc.ObjId}, templateId: {npc.TemplateId}");
+
+        foreach (var skill in np)
+        {
+            switch (skill.SkillUseCondition)
+            {
+                case SkillUseConditionKind.InCombat:
+                    Logger.Trace($"Registering OnCombat event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.OnCombatStarted += OnCombatStarted;
+                    break;
+                case SkillUseConditionKind.InIdle:
+                    Logger.Trace($"Registering InIdle event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.InIdle += InIdle;
+                    break;
+                case SkillUseConditionKind.OnDeath:
+                    Logger.Trace($"Registering OnDeath event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.OnDeath += OnDeath;
+                    //int invocationCount = npc.Events.OnDeath.GetInvocationList().GetLength(0);
+                    break;
+                case SkillUseConditionKind.InAlert:
+                    Logger.Trace($"Registering InAlert event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.InAlert += InAlert;
+                    break;
+                case SkillUseConditionKind.InDead:
+                    Logger.Trace($"Registering InDead event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.InDead += InDead;
+                    break;
+                case SkillUseConditionKind.OnSpawn:
+                    Logger.Trace($"Registering OnSpawn event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.OnSpawn += OnSpawn;
+                    break;
+                case SkillUseConditionKind.OnDespawn:
+                    Logger.Trace($"Registering OnDespawn event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.OnDespawn += OnDespawn;
+                    break;
+                case SkillUseConditionKind.OnAlert:
+                    Logger.Trace($"Registering OnAlert event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.InAlert += InAlert;
+                    break;
+                case SkillUseConditionKind.None:
+                default:
+                    Logger.Warn($"No SkillUseCondition found to register for skill {skill.SkillId} {skill.SkillUseCondition} for npc {TemplateId}");
+                    break;
+            }
+        }
+    }
+
+    public void UnregisterNpcEvents()
+    {
+        var npSkills = NpcGameData.Instance.GetNpSkills(TemplateId);
+        if (npSkills is null) { return; }
+
+        // Logger.Info($"Unregistering Npc Events for  objId: {npc.ObjId}, templateId: {npc.TemplateId}");
+
+        foreach (var skill in npSkills)
+        {
+            switch (skill.SkillUseCondition)
+            {
+                case SkillUseConditionKind.InCombat:
+                    Logger.Trace($"Unregistering OnCombat event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.OnCombatStarted -= OnCombatStarted;
+                    break;
+                case SkillUseConditionKind.InIdle:
+                    Logger.Trace($"Unregistering InIdle event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.InIdle -= InIdle;
+                    break;
+                case SkillUseConditionKind.OnDeath:
+                    Logger.Trace($"Unregistering OnDeath event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.OnDeath -= OnDeath;
+                    break;
+                case SkillUseConditionKind.InAlert:
+                    Logger.Trace($"Unregistering InAlert event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.InAlert -= InAlert;
+                    break;
+                case SkillUseConditionKind.InDead:
+                    Logger.Trace($"Unregistering InDead event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.InDead -= InDead;
+                    break;
+                case SkillUseConditionKind.OnSpawn:
+                    Logger.Trace($"Unregistering OnSpawn event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.OnSpawn -= OnSpawn;
+                    break;
+                case SkillUseConditionKind.OnDespawn:
+                    Logger.Trace($"Unregistering OnDespawn event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.OnDespawn -= OnDespawn;
+                    break;
+                case SkillUseConditionKind.OnAlert:
+                    Logger.Trace($"Unregistering OnAlert event for npc objId: {ObjId}, templateId: {TemplateId}, skill {skill.SkillId}");
+                    Events.InAlert -= InAlert;
+                    break;
+                case SkillUseConditionKind.None:
+                default:
+                    Logger.Debug($"No SkillUseCondition found to unregister for skill {skill.SkillId} {skill.SkillUseCondition} for npc {TemplateId}");
+                    break;
+            }
+        }
+    }
+
+    private void OnCombatStarted(object sender, OnCombatStartedArgs args)
+    {
+        if (args.Owner is not Npc npc)
+        {
+            if (args.Target is not Npc target)
+            {
+                return;
+            }
+
+            npc = target;
+        }
+
+        if (npc.IsInBattle)
+        {
+            return;
+        }
+
+        npc.IsInBattle = true;
+
+        var skills = NpcGameData.Instance.GetNpSkills(npc.TemplateId, SkillUseConditionKind.InCombat);
+        if (skills == null) { return; }
+
+        Logger.Trace($"Npc={npc.ObjId}:{npc.TemplateId} has started combat.");
+
+        foreach (var npcSkill in skills)
+        {
+            var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
+
+            if (skill is null) { continue; }
+
+            var skillCaster = SkillCaster.GetByType(SkillCasterType.Unit);
+            skillCaster.ObjId = npc.ObjId;
+
+            var skillTarget = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
+            skillTarget.ObjId = npc.ObjId;
+
+            if (npc.Cooldowns.CheckCooldown(skill.Id)) { continue; }
+
+            if (skill.Template.CooldownTime == 0)
+            {
+                npc.Cooldowns.AddCooldown(skill.Id, uint.MaxValue); // Run once / выполняем один раз
+            }
+
+            Logger.Trace($"Npc={npc.ObjId}:{npc.TemplateId} using skill={skill.Id}");
+            skill.Use(npc, skillCaster, skillTarget);
+        }
+    }
+
+    private void InIdle(object sender, InIdleArgs args)
+    {
+        if (args.Owner is not Npc npc) { return; }
+
+        var skills = NpcGameData.Instance.GetNpSkills(npc.TemplateId, SkillUseConditionKind.InIdle);
+        if (skills == null) { return; }
+
+        Logger.Trace($"Npc={npc.ObjId}:{npc.TemplateId} has entered idle state.");
+
+        foreach (var npcSkill in skills)
+        {
+            var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
+
+            if (skill is null) { continue; }
+
+            var skillCaster = SkillCaster.GetByType(SkillCasterType.Unit);
+            skillCaster.ObjId = npc.ObjId;
+
+            var skillTarget = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
+            skillTarget.ObjId = npc.ObjId;
+
+            if (npc.Cooldowns.CheckCooldown(skill.Id)) { continue; }
+
+            if (skill.Template.CooldownTime == 0)
+            {
+                npc.Cooldowns.AddCooldown(skill.Id, uint.MaxValue); // выполняем один раз
+            }
+
+            Logger.Trace($"Npc={npc.ObjId}:{npc.TemplateId} using skill={skill.Id}");
+            skill.Use(npc, skillCaster, skillTarget);
+        }
+    }
+
+    private void OnDeath(object sender, OnDeathArgs args)
+    {
+        if (args.Victim is not Npc npc) { return; }
+
+        var skills = NpcGameData.Instance.GetNpSkills(npc.TemplateId, SkillUseConditionKind.OnDeath);
+        if (skills == null) { return; }
+
+        Logger.Trace($"Npc objId={npc.ObjId}, templateId={npc.TemplateId} has died.");
+
+        //UnregisterNpcEvents(npc);
+        //UnregisterIndunEvents();
+
+        foreach (var npcSkill in skills)
+        {
+            var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
+
+            if (skill is null) { continue; }
+
+            var skillCaster = SkillCaster.GetByType(SkillCasterType.Unit);
+            skillCaster.ObjId = npc.ObjId;
+
+            var skillTarget = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
+            skillTarget.ObjId = npc.ObjId;
+
+            if (npc.Cooldowns.CheckCooldown(skill.Id)) { continue; }
+
+            if (skill.Template.CooldownTime == 0)
+            {
+                npc.Cooldowns.AddCooldown(skill.Id, uint.MaxValue); // выполняем один раз
+            }
+
+            Logger.Trace($"Npc={npc.ObjId}:{npc.TemplateId} using skill={skill.Id}");
+            skill.Use(npc, skillCaster, skillTarget);
+        }
+    }
+
+    private void OnSpawn(object sender, OnSpawnArgs args)
+    {
+        if (args.Npc is not Npc npc) { return; }
+
+        var skills = NpcGameData.Instance.GetNpSkills(npc.TemplateId, SkillUseConditionKind.InIdle);
+        if (skills == null) { return; }
+
+        Logger.Trace($"Npc objId: {npc.ObjId}, templateId: {npc.TemplateId} OnSpawn triggered.");
+
+        foreach (var npcSkill in skills)
+        {
+            var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
+
+            if (skill is null) { continue; }
+
+            var skillCaster = SkillCaster.GetByType(SkillCasterType.Unit);
+            skillCaster.ObjId = npc.ObjId;
+
+            var skillTarget = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
+            skillTarget.ObjId = npc.ObjId;
+
+            if (npc.Cooldowns.CheckCooldown(skill.Id)) { continue; }
+
+            if (skill.Template.CooldownTime == 0)
+            {
+                npc.Cooldowns.AddCooldown(skill.Id, uint.MaxValue); // выполняем один раз
+            }
+
+            Logger.Trace($"Npc={npc.ObjId}:{npc.TemplateId} using skill={skill.Id}");
+            skill.Use(npc, skillCaster, skillTarget);
+        }
+    }
+
+    private void OnDespawn(object sender, OnDespawnArgs args)
+    {
+        if (args.Npc is not Npc npc) { return; }
+
+        var skills = NpcGameData.Instance.GetNpSkills(npc.TemplateId, SkillUseConditionKind.InIdle);
+        if (skills == null) { return; }
+
+        Logger.Trace($"Npc objId: {npc.ObjId}, templateId: {npc.TemplateId} OnDespawn triggered.");
+
+        foreach (var npcSkill in skills)
+        {
+            var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
+
+            if (skill is null) { continue; }
+
+            var skillCaster = SkillCaster.GetByType(SkillCasterType.Unit);
+            skillCaster.ObjId = npc.ObjId;
+
+            var skillTarget = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
+            skillTarget.ObjId = npc.ObjId;
+
+            if (npc.Cooldowns.CheckCooldown(skill.Id)) { continue; }
+
+            if (skill.Template.CooldownTime == 0)
+            {
+                npc.Cooldowns.AddCooldown(skill.Id, uint.MaxValue); // выполняем один раз
+            }
+
+            Logger.Trace($"Npc={npc.ObjId}:{npc.TemplateId} using skill={skill.Id}");
+            skill.Use(npc, skillCaster, skillTarget);
+        }
+    }
+
+    private void InAlert(object sender, InAlertArgs args)
+    {
+        Logger.Trace($"Npc={args.Npc.ObjId}:{args.Npc.TemplateId} is in alert.");
+    }
+
+    private void InDead(object sender, InDeadArgs args)
+    {
+        Logger.Trace($"Npc={args.Npc.ObjId} : {args.Npc.TemplateId} is in death state.");
+    }
+}

--- a/AAEmu.Game/Models/Game/NPChar/NpcSpawner.cs
+++ b/AAEmu.Game/Models/Game/NPChar/NpcSpawner.cs
@@ -80,8 +80,10 @@ public class NpcSpawner : Spawner<Npc>
 
     public override void Despawn(Npc npc)
     {
+        npc.UnregisterNpcEvents();
         npc.Delete();
 
+        /*
         if (npc.Transform.WorldId > 0)
         {
             // Temporary range for instanced worlds
@@ -92,6 +94,7 @@ public class NpcSpawner : Spawner<Npc>
                 dungeon.UnregisterNpcEvents(npc);
             }
         }
+        */
 
         if (npc.Respawn == DateTime.MinValue)
         {

--- a/AAEmu.Game/Models/Game/NPChar/NpcSpawnerNpc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/NpcSpawnerNpc.cs
@@ -66,6 +66,8 @@ public class NpcSpawnerNpc : Spawner<Npc>
                 Logger.Warn($"Npc {MemberId}, from spawner Id {npcSpawner.Id} not exist at db");
                 return null;
             }
+            
+            npc.RegisterNpcEvents();
 
             Logger.Trace($"Spawn npc templateId {MemberId} objId {npc.ObjId} from spawnerId {NpcSpawnerTemplateId}");
 

--- a/AAEmu.sln.DotSettings
+++ b/AAEmu.sln.DotSettings
@@ -1,4 +1,4 @@
-<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AC/@EntryIndexedValue">AC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CS/@EntryIndexedValue">CS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=CT/@EntryIndexedValue">CT</s:String>
@@ -9,6 +9,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Actabilities/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Actability/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=additionales/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=arche/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Auroria/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=beautyshop/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=childable/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
- Added null-check to ``SkillManager.GetNpSkillTemplate``
- Fixed missing ``s`` typo in ``GetNpSkill``
- Changed ``DoodadFuncRequireQuests`` to be ignored if caster is not a ``Character``. This is mostly used in Doodad's initial state, and would work better if it's a actual spawn check rather than a conditional check on it's own. This is likely supposed to check the caster's killer if it's called from a OnDeath event. But works good enough to get the quests done for now.
- Moved the NPC event functions from ``Dungeon`` into a new partial class Npc file ``NpcEvents.cs`` and linked it to the standard spawners.
- Lowered the logging level of dungeon notifications
