### PR TITLE
[Game] Prevents the error of character equipment appearing in pet cells:

### DIFF
--- a/AAEmu.Game/Models/Game/Char/Inventory.cs
+++ b/AAEmu.Game/Models/Game/Char/Inventory.cs
@@ -618,7 +618,7 @@ public class Inventory
         }
         else if (mate != null && fromType == SlotType.EquipmentMate)
         {
-            Owner.BroadcastPacket(new SCUnitEquipmentsChangedPacket(mate.ObjId, fromSlot, Equipment.GetItemBySlot(toSlot)), true);
+            Owner.BroadcastPacket(new SCUnitEquipmentsChangedPacket(mate.ObjId, fromSlot, null), true);
         }
 
         if (toType == SlotType.Equipment)


### PR DESCRIPTION
- when removing armor from a pet's inventory, the character's weapons or clothes appear in the slots.