### PR TITLE
[Game] Fixed Item with skill usage cancelling

### DIFF
--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -335,13 +335,13 @@ public class SlaveManager : Singleton<SlaveManager>
             // return;
         }
 
-        var item = owner.Inventory.GetItemById(skillData.ItemId);
-        if (item == null) return;
+        if ((skillData.ItemId == 0) || (skillData.ItemTemplateId == 0))
+            return;
 
-        var itemTemplate = (SummonSlaveTemplate)ItemManager.Instance.GetTemplate(item.TemplateId);
-        if (itemTemplate == null) return;
+        if (skillData.SkillSourceItem.Template is not SummonSlaveTemplate itemTemplate)
+            return;
 
-        Create(owner, null, itemTemplate.SlaveId, item, hideSpawnEffect, positionOverride); // TODO replace the underlying code with this call
+        Create(owner, null, itemTemplate.SlaveId, skillData.SkillSourceItem, hideSpawnEffect, positionOverride);
     }
 
     // added "/slave spawn <templateId>" to be called from the script command

--- a/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
@@ -3019,7 +3019,7 @@ public class DoodadManager : Singleton<DoodadManager>
 
         foreach (var item in items)
         {
-            character.ItemUse(preferredItem.Id);
+            character.ItemUse(preferredItem);
             character.Inventory.ConsumeItem(new[] { SlotType.Inventory }, ItemTaskType.DoodadCreate, item, 1,
                 preferredItem);
         }

--- a/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
@@ -125,10 +125,11 @@ public class CSStartSkillPacket : GamePacket
         {
             // A skill triggered by a item
             var player = Connection.ActiveChar; 
-            var item = player.Inventory.GetItemById(si.ItemId);
+            // var item = player.Inventory.GetItemById(si.ItemId);
             // добавил проверку на ItemBindType.BindOnPickup для записи портала с помощью камина в доме
-            if (item == null || skillId != item.Template.UseSkillId && item.Template.BindType != ItemBindType.BindOnPickup)
+            if (si.SkillSourceItem == null || skillId != si.SkillSourceItem.Template.UseSkillId && si.SkillSourceItem.Template.BindType != ItemBindType.BindOnPickup)
                 return;
+            // si.ItemTemplateId = item.TemplateId;
             skill = new Skill(SkillManager.Instance.GetSkillTemplate(skillId));
             skillResult = skill.Use(player, skillCaster, skillCastTarget, skillObject, false, out skillResultErrorValue);
         }

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -1639,6 +1639,39 @@ public partial class Character : Unit, ICharacter
         }
     }
 
+    /// <summary>
+    /// ItemUse - is used to work the quests
+    /// </summary>
+    /// <param name="item"></param>
+    public void ItemUse(Item item)
+    {
+        if (item is not null)
+        {
+            // Trigger event
+            Events?.OnItemUse(this, new OnItemUseArgs
+            {
+                ItemId = item.TemplateId
+            });
+        }
+    }
+
+    /// <summary>
+    /// Trigger OnItemUse using a item template
+    /// </summary>
+    /// <param name="itemTemplate"></param>
+    public void ItemUseByTemplate(uint itemTemplate)
+    {
+        if (itemTemplate > 0)
+        {
+            // Trigger event
+            Events?.OnItemUse(this, new OnItemUseArgs
+            {
+                ItemId = itemTemplate
+            });
+        }
+    }
+
+    
     public void SetAction(byte slot, ActionSlotType type, uint actionId)
     {
         Slots[slot].Type = type;

--- a/AAEmu.Game/Models/Game/Skills/Plots/Plot.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Plot.cs
@@ -1,5 +1,7 @@
 ﻿using System.Threading.Tasks;
+using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Skills.Plots.Tree;
 using AAEmu.Game.Models.Game.Units;
 
@@ -26,10 +28,13 @@ public class Plot
         // I am guessing we want to do something here to run it in a thread, or at least using Async
         await Tree.Execute(state);
 
-        // Handle item use that generate only plots
-        if ((casterCaster is SkillItem skillItem) && (caster is Character player))
+        if (casterCaster is SkillItem skillItem && caster is Character player && skillItem.SkillSourceItem != null)
         {
-            player.ItemUse(skillItem.ItemId);
+            // Trigger item use if not cancelled
+            if (!state.CancellationRequested())
+                player.ItemUse(skillItem.SkillSourceItem);
+            // Free the item from lock
+            player.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.ItemUnlock, new ItemUpdate(skillItem.SkillSourceItem), []));
         }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/SkillCaster.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillCaster.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.Items;
 
 namespace AAEmu.Game.Models.Game.Skills;
 
@@ -86,10 +88,27 @@ public class SkillCasterUnk1 : SkillCaster
 
 public class SkillItem : SkillCaster
 {
-    public ulong ItemId { get; set; }
+    private ulong _itemId;
+    public ulong ItemId
+    {
+        get => _itemId;
+        set
+        {
+            if (_itemId == value)
+                return;
+            _itemId = value;
+            if (_itemId > 0)
+            {
+                SkillSourceItem = ItemManager.Instance.GetItemByItemId(value);
+                ItemTemplateId = SkillSourceItem?.TemplateId ?? 0;
+            }
+        }
+    }
+
     public uint ItemTemplateId { get; set; }
     public byte Type1 { get; set; }
     public uint Type2 { get; set; }
+    public Item SkillSourceItem { get; private set; }
 
     public SkillItem()
     {


### PR DESCRIPTION
- Fixed a bug with ``unit_reqs`` check where in some cases not meeting all requirements would still succeed.
- Cancelling a skill cast item that uses plots no longer locks up the item in your inventory.
- Added a placeholder in ``SkillItem`` SkillCaster for the original item used to start a skill (if any).

This fix closes #1015 - [BUG] Harani mainquest 3541