### PR TITLE
[Game] Added shutdown to scripts

### DIFF
--- a/AAEmu.Game/Core/Managers/SaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SaveManager.cs
@@ -5,6 +5,7 @@ using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models;
+using AAEmu.Game.Models.Tasks;
 using AAEmu.Game.Models.Tasks.SaveTask;
 
 using NLog;
@@ -20,6 +21,7 @@ public class SaveManager : Singleton<SaveManager>
     private bool _isSaving;
     private object _lock = new();
     private SaveTickStartTask saveTask;
+    public ShutdownTask ShutdownTask { get; set; } = null;
 
     public SaveManager()
     {

--- a/AAEmu.Game/Models/Tasks/ShutdownTask.cs
+++ b/AAEmu.Game/Models/Tasks/ShutdownTask.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Core.Packets.G2C;
+
+namespace AAEmu.Game.Models.Tasks;
+
+public class ShutdownTask : Task
+{
+    private DateTime _lastCheckTime = DateTime.MinValue;
+    private bool _alreadyShuttingDown;
+    private DateTime _shutdownTime;
+    private DateTime _nextTriggerTime = DateTime.MinValue;
+    private readonly int _exitCode;
+    // Timings to show a popup, in seconds
+    private readonly List<uint> _triggerPoints =
+    [
+        14400, // 4h
+        10800, // 3h
+        7200, // 2h
+        3600, // 60m
+        2700, // 45m
+        1800, // 30m
+        1200, // 20m
+        900, // 15m
+        600, // 10m
+        300, // 5m
+        240, // 4m
+        180, // 3m
+        120, // 2m
+        90,
+        60, // 1m
+        45,
+        30,
+        20,
+        10
+    ];
+
+    public ShutdownTask(DateTime shutdownTime, int exitCode)
+    {
+        _shutdownTime = shutdownTime;
+        _exitCode = exitCode;
+        _nextTriggerTime = CalculateLargestNextTrigger();
+    }
+
+    private DateTime CalculateLargestNextTrigger()
+    {
+        var remaining = _shutdownTime - DateTime.UtcNow;
+        var remainingDelta = Math.Ceiling(remaining.TotalSeconds);
+        foreach (var triggerPoint in _triggerPoints)
+        {
+            if (remainingDelta > triggerPoint)
+                return _shutdownTime - TimeSpan.FromSeconds(triggerPoint);
+        }
+
+        return DateTime.MaxValue;
+    }
+
+    public void ChangeShutdownTime(DateTime shutdownTime)
+    {
+        _shutdownTime = shutdownTime;
+        var remaining = (int)Math.Ceiling((_shutdownTime - DateTime.UtcNow).TotalMinutes);
+        WorldManager.Instance.BroadcastPacketToServer(new SCNoticeMessagePacket(3, Color.Red, 10000, $"Server shutdown has been rescheduled to {remaining} minutes from now!"));
+        _nextTriggerTime = CalculateLargestNextTrigger();
+    }
+
+    public override void Execute()
+    {
+        if (_alreadyShuttingDown)
+            return;
+
+        if (_shutdownTime <= DateTime.UtcNow)
+        {
+            _alreadyShuttingDown = true;
+            // Do server shut down now
+
+            // Wipe all BuyBack containers manually, as there will be no trigger for disconnected players
+            try
+            {
+                foreach (var character in WorldManager.Instance.GetAllCharacters())
+                    character.BuyBackItems.Wipe();
+            }
+            catch (Exception)
+            {
+                // Ignore
+            }
+
+            if (SaveManager.Instance.DoSave())
+            {
+                WorldManager.Instance.BroadcastPacketToServer(new SCNoticeMessagePacket(3, Color.Magenta, 15000,
+                    "The server is shutting down right now!"));
+                Environment.Exit(_exitCode); // Manual Shutdown
+            }
+
+            return;
+        }
+
+        var remainingTime = _shutdownTime - DateTime.UtcNow;
+        var remainingSeconds = (int)Math.Ceiling(remainingTime.TotalSeconds);
+        if (DateTime.UtcNow < _nextTriggerTime)
+            return;
+        
+        _nextTriggerTime = CalculateLargestNextTrigger();
+
+        var showSeconds = remainingSeconds <= 100;
+        var showMinutes = remainingSeconds <= 3600 && !showSeconds;
+        var showHours = remainingSeconds > 3600 && !showSeconds;;
+
+        var shutdownText = "The server is shutting down soon!";
+        var popupTime = 3000;
+
+        if (showHours)
+        {
+            shutdownText = $"The server is shutting down in {remainingSeconds / 3600} hours!";
+            popupTime = 10000;
+        }
+        else if (showMinutes)
+        {
+            shutdownText = $"The server is shutting down in {remainingSeconds / 60} minutes!";
+            popupTime = 6000;
+        }
+        else if (showSeconds)
+        {
+            shutdownText = $"The server is shutting down in {remainingSeconds} seconds!";
+            popupTime = 3000;
+        }
+
+        WorldManager.Instance.BroadcastPacketToServer(
+            new SCNoticeMessagePacket(3, 
+                Color.Red, 
+                popupTime, 
+                shutdownText));
+    }
+}

--- a/AAEmu.Game/Scripts/Commands/Scripts.cs
+++ b/AAEmu.Game/Scripts/Commands/Scripts.cs
@@ -1,6 +1,12 @@
-﻿using AAEmu.Game.Core.Managers;
+﻿using System;
+using System.Drawing;
+
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Tasks;
 using AAEmu.Game.Utils.Scripts;
 
 namespace AAEmu.Game.Scripts.Commands;
@@ -19,7 +25,7 @@ public class Scripts : ICommand
 
     public string GetCommandHelpText()
     {
-        return "Does script related actions. Allowed <action> are: reload, reboot, save";
+        return "Does script related actions. Allowed <action> are: reload, reboot, save, shutdown";
     }
 
     public void Execute(Character character, string[] args, IMessageOutput messageOutput)
@@ -50,6 +56,59 @@ public class Scripts : ICommand
             case "reloadslavepoints":
                 SlaveManager.Instance.LoadSlaveAttachmentPointLocations();
                 character.SendMessage("[Scripts] Slave Attachment Point Locations .json Reloaded");
+                break;
+            case "shutdown":
+                var shutdownTime = DateTime.UtcNow.AddMinutes(30);
+                var doCancel = false;
+                if (args.Length > 1)
+                {
+                    if (args[1].ToLower() == "cancel")
+                        doCancel = true;
+                    else if (args[1].ToLower() == "now")
+                        shutdownTime = DateTime.UtcNow;
+                    else if (uint.TryParse(args[1], out var shutdownTimeMinutes))
+                        shutdownTime = DateTime.UtcNow.AddMinutes(shutdownTimeMinutes);
+                }
+
+                var shutdownTimeRemaining = shutdownTime - DateTime.UtcNow;
+
+                if ((SaveManager.Instance.ShutdownTask != null) && (doCancel))
+                {
+                    SaveManager.Instance.ShutdownTask.Cancel();
+                    character.SendMessage($"[Scripts] Shutdown cancelled.");
+                    WorldManager.Instance.BroadcastPacketToServer(new SCNoticeMessagePacket(3, Color.Aqua, 10000, "The server shutdown has been cancelled!"));
+                    SaveManager.Instance.ShutdownTask = null;
+                    return;
+                }
+                
+                if (doCancel)
+                {
+                    character.SendMessage($"[Scripts] No shutdown to cancel");
+                    return;
+                }
+                
+                if (SaveManager.Instance.ShutdownTask != null)
+                {
+                    character.SendMessage($"[Scripts] Shutdown was already in progress, changed to {shutdownTimeRemaining.TotalMinutes:F0} minutes from now.");
+                    SaveManager.Instance.ShutdownTask.ChangeShutdownTime(shutdownTime.AddSeconds(1));
+                    return;
+                }
+
+                if (SaveManager.Instance.DoSave())
+                {
+                    SaveManager.Instance.ShutdownTask = new ShutdownTask(shutdownTime.AddSeconds(5), -1); // Manual Normal Shutdown (-1)
+                    TaskManager.Instance.Schedule(SaveManager.Instance.ShutdownTask, null, TimeSpan.FromSeconds(1));
+                    character.SendMessage($"[Scripts] Shutdown sequence started, shutting down in |nn;{shutdownTimeRemaining.TotalMinutes:F0}|r minutes");
+                }
+                else
+                {
+                    character.SendMessage("[Scripts] Shutdown cancelled because there were save errors, if you want to shutdown regardless without saving, use |nn;/scripts forcedshutdown|r instead.");
+                }
+                break;
+            case "forcedshutdown":
+                WorldManager.Instance.BroadcastPacketToServer(new SCNoticeMessagePacket(3, Color.Magenta, 15000, "The server is shutting down right now!"));
+                character.SendMessage("[Scripts] Shutting down immediately!");
+                Environment.Exit(-2); // Manual Forced Shutdown (-2)
                 break;
             default:
                 character.SendMessage("|cFFFF0000[Scripts] Undefined action...|r");


### PR DESCRIPTION
Added a ``/scripts shutdown`` command. Allowed arguments are:
- ``cancel`` to cancel any ongoing shutdown
- ``now`` to shut down immediately
- ``<x>`` to shut down after ``x`` minutes from now
All online players will get a warning of the shutdown request, and will also get warnings at set varying intervals.