### PR TITLE
[Game] Fixed a oversight in the final check for quest completion

### DIFF
--- a/AAEmu.Game/Models/Game/Quests/NewQuestCode.cs
+++ b/AAEmu.Game/Models/Game/Quests/NewQuestCode.cs
@@ -286,8 +286,12 @@ public partial class Quest
                 }
             }
         }
+        
+        var res = Template.Selective ?
+        (QuestObjectiveStatus)Math.Max((byte)totalResultStatusMin, (byte)totalResultStatusMax) :
+        (QuestObjectiveStatus)Math.Min((byte)totalResultStatusMin, (byte)totalResultStatusMax);
 
-        return (QuestObjectiveStatus)Math.Min((byte)totalResultStatusMin, (byte)totalResultStatusMax);// QuestObjectiveStatus.NotReady;
+        return res;
     }
 
     /// <summary>


### PR DESCRIPTION
- Fixed a bug in GetQuestObjectiveStatus that didn't take into account Selective progress.

This fix closes #1022 - [BUG] Quest 6655 - The Key To Regrading - Locking up controls when trying to complete quest.
And likely also some others.