### PR TITLE
[Data] Solis Mirage portal and some DS worldgates

### DIFF
--- a/AAEmu.Game/Data/Portal/worldgates.json
+++ b/AAEmu.Game/Data/Portal/worldgates.json
@@ -235,5 +235,15 @@
         "Z": 140.2,
         "Yaw": 42.2,
         "SubZoneId": 632
+    },
+    {
+        "Id": 652,
+        "Name": "Diamond Shores Pirate/Player Nation Base",
+        "ZoneId": 301,
+	    "X": 19332.0,
+        "Y": 26883.0,
+        "Z": 130.5,
+        "Yaw": 0,
+        "SubZoneId": 1110
     }
 ]

--- a/AAEmu.Game/Scripts/SubCommands/Doodads/DoodadPositionSubCommand.cs
+++ b/AAEmu.Game/Scripts/SubCommands/Doodads/DoodadPositionSubCommand.cs
@@ -21,9 +21,9 @@ public class DoodadPositionSubCommand : SubCommandBase
         AddParameter(new NumericSubCommandParameter<float>("x", "x=<new x>", false, "x"));
         AddParameter(new NumericSubCommandParameter<float>("y", "y=<new y>", false, "y"));
         AddParameter(new NumericSubCommandParameter<float>("z", "z=<new z>", false, "z"));
-        AddParameter(new NumericSubCommandParameter<float>("roll", "roll=<new roll degrees>", false, "roll", 0, 360));
-        AddParameter(new NumericSubCommandParameter<float>("pitch", "pitch=<new pitch degrees>", false, "pitch", 0, 360));
-        AddParameter(new NumericSubCommandParameter<float>("yaw", "yaw=<new yaw degrees>", false, "yaw", 0, 360));
+        AddParameter(new NumericSubCommandParameter<float>("roll", "roll=<new roll degrees>", false, "roll", -360f, 360f));
+        AddParameter(new NumericSubCommandParameter<float>("pitch", "pitch=<new pitch degrees>", false, "pitch", -360f, 360f));
+        AddParameter(new NumericSubCommandParameter<float>("yaw", "yaw=<new yaw degrees>", false, "yaw", -360f, 360f));
     }
 
     public override void Execute(ICharacter character, string triggerArgument, IDictionary<string, ParameterValue> parameters, IMessageOutput messageOutput)

--- a/AAEmu.Game/Scripts/SubCommands/Doodads/DoodadSpawnSubCommand.cs
+++ b/AAEmu.Game/Scripts/SubCommands/Doodads/DoodadSpawnSubCommand.cs
@@ -33,7 +33,7 @@ public class DoodadSpawnSubCommand : SubCommandBase
         using var charPos = character.Transform.CloneDetached();
         charPos.Local.AddDistanceToFront(3f);
         var defaultYaw = (float)MathUtil.CalculateAngleFrom(charPos, character.Transform);
-        var newYaw = GetOptionalParameterValue(parameters, "yaw", defaultYaw.RadToDeg()).DegToRad();
+        var newYaw = GetOptionalParameterValue(parameters, "yaw", defaultYaw).DegToRad();
         var doodadSpawner = new DoodadSpawner
         {
             Id = 0,


### PR DESCRIPTION
- Added Mirage Portal to it's 1.x location and moved the modern one underground.
- Added missing Ayanad Library Worldgates in Solis, Cinder and Growlgate. Implemented the target location of the Pirate/PlayerNation worldgate to DS.
- Fixed spawn doodad GM command's rotation parsing.

This closes #1025 - [DATA] Portal for Mirage missing
