### PR TITLE
[Game] Removed the empty area check

### DIFF
--- a/AAEmu.Game/GameData/SphereGameData.cs
+++ b/AAEmu.Game/GameData/SphereGameData.cs
@@ -60,7 +60,7 @@ public class SphereGameData : Singleton<SphereGameData>, IGameDataLoader
                         EnterOrLeave = reader.GetBoolean("enter_or_leave"),
                         SphereDetailId = reader.GetUInt32("sphere_detail_id"),
                         SphereDetailType = reader.GetString("sphere_detail_type"),
-                        TriggerConditionId = reader.GetUInt32("trigger_condition_id"),
+                        TriggerConditionId = (AreaSphereTriggerCondition)reader.GetUInt32("trigger_condition_id"),
                         TriggerConditionTime = reader.GetUInt32("trigger_condition_time", 0),
                         TeamMsg = reader.GetString("team_msg"),
                         CategoryId = reader.GetUInt32("category_id"),

--- a/AAEmu.Game/Models/Game/World/SphereQuest.cs
+++ b/AAEmu.Game/Models/Game/World/SphereQuest.cs
@@ -14,7 +14,7 @@ namespace AAEmu.Game.Models.Game.World;
 
 public enum AreaSphereTriggerCondition
 {
-    Invalid = 0,
+    None = 0,
     TriggerOnceAtAll = 1,
     TriggerOnceInRuntime = 2,
     TriggerEveryNTimeAfter = 3

--- a/AAEmu.Game/Models/Spheres/Spheres.cs
+++ b/AAEmu.Game/Models/Spheres/Spheres.cs
@@ -1,4 +1,6 @@
-﻿namespace AAEmu.Game.Models.Spheres;
+﻿using AAEmu.Game.Models.Game.World;
+
+namespace AAEmu.Game.Models.Spheres;
 
 public class Spheres
 {
@@ -7,7 +9,7 @@ public class Spheres
     public bool EnterOrLeave { get; set; }
     public uint SphereDetailId { get; set; }
     public string SphereDetailType { get; set; }
-    public uint TriggerConditionId { get; set; }
+    public AreaSphereTriggerCondition TriggerConditionId { get; set; }
     public uint TriggerConditionTime { get; set; }
     public string TeamMsg { get; set; }
     public uint CategoryId { get; set; }


### PR DESCRIPTION
- Removed the check where it would delete a shape when it's empty. This fixes skills like ``Magic Circle ( 12796 )`` and the ``Frigid Tracks ( 11314 )`` skill's ``Ice Wall ( 833 )`` doodad.
- Added changed ``AreaShape.TriggerConditionId`` to actually use ``AreaSphereTriggerCondition`` instead of uint.