### PR TITLE
[Game] Added null-check for CheckBuffTag

### DIFF
--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -170,6 +170,8 @@ public class Buffs : IBuffs
     public bool CheckBuffTag(uint tagId)
     {
         var buffs = SkillManager.Instance.GetBuffsByTagId(tagId);
+        if (buffs == null)
+            return false;
 
         // Create a copy of the list of effects to avoid changing the list while iterating
         IEnumerable<Buff> effects;


### PR DESCRIPTION
- Added a null-check for the ``CheckBuffTag`` function. This fixes a crash with quest ``A Scrumper in Farmer's Clothing ( 3580 )`` where it's referencing a non-existing tag
