### PR TITLE
implemented a generic “gimmick projectile” runtime

### DIFF
--- a/AAEmu.Game/Core/Managers/GimmickManager.cs
+++ b/AAEmu.Game/Core/Managers/GimmickManager.cs
@@ -91,6 +91,13 @@ public class GimmickManager(WorldInstance parentWorld)
                 gimmick.MovementHandler ??= new GimmickMovementProjectile(gimmick);
         }
 
+        // Prevent first-tick "cosmic velocity" caused by default LastPos/LastRot = 0
+        if (gimmick.Transform?.World != null)
+        {
+            gimmick.LastPos = gimmick.Transform.World.Position;
+            gimmick.LastRot = gimmick.Transform.World.Rotation;
+        }
+
         gimmick.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;
         lock (_activeGimmicks)
             _activeGimmicks.TryAdd(gimmick.ObjId, gimmick);

--- a/AAEmu.Game/Core/Managers/GimmickManager.cs
+++ b/AAEmu.Game/Core/Managers/GimmickManager.cs
@@ -51,7 +51,7 @@ public class GimmickManager(WorldInstance parentWorld)
             Faction = new SystemFaction()
         };
         gimmick.Transform.ApplyWorldSpawnPosition(spawner.Position);
-        gimmick.Vel = new Vector3(0f, 0f, 0f);
+        gimmick.Vel = new Vector3(spawner.VelocityX, spawner.VelocityY, spawner.VelocityZ);
         var spawnRotation = new Quaternion(spawner.RotationX, spawner.RotationY, spawner.RotationZ, spawner.RotationW);
         // Apply Gimmick setting's rotation to the GameObject.Transform
         gimmick.Transform.Local.ApplyFromQuaternion(spawnRotation);
@@ -77,12 +77,18 @@ public class GimmickManager(WorldInstance parentWorld)
             // Elevators defined in gimmick_spawns.json
             gimmick.MovementHandler = new GimmickMovementElevator(gimmick);
         }
-        else
-            // TODO: Add decent Physics system to handle movement
         if (gimmick.TemplateId == 37)
         {
             // Recovered Treasure Chest
             gimmick.MovementHandler = new GimmickMovementFloatToSurface(gimmick);
+        }
+        else if (gimmick.Template != null)
+        {
+            var hasInitialVelocity = gimmick.Vel.LengthSquared() > 0.0001f;
+            var hasGravity = MathF.Abs(gimmick.Template.Gravity) > 0.0001f;
+            var hasAirResistance = MathF.Abs(gimmick.Template.AirResistance) > 0.0001f;
+            if (hasInitialVelocity || hasGravity || hasAirResistance)
+                gimmick.MovementHandler ??= new GimmickMovementProjectile(gimmick);
         }
 
         gimmick.Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;

--- a/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
@@ -165,8 +165,9 @@ public class Gimmick : Unit
         }
 
         var skillTemplate = SkillManager.Instance.GetSkillTemplate(skillId);
-        // Use the gimmick itself as the caster so collision-triggered skills don't fail range checks vs the original spawner.
-        BaseUnit caster = this;
+        // Prefer the original spawner as caster so relation/faction damage filtering works correctly.
+        // Range checks are handled elsewhere for position-targeted skills with MaxRange=0.
+        BaseUnit caster = ParentWorld?.GetUnit(SpawnerUnitId) ?? this;
         var skillCaster = new SkillDoodad(ObjId);
         var skillCastTarget = new SkillCastPositionTarget
         {

--- a/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
@@ -165,7 +165,8 @@ public class Gimmick : Unit
         }
 
         var skillTemplate = SkillManager.Instance.GetSkillTemplate(skillId);
-        var caster = ParentWorld.GetUnit(SpawnerUnitId);
+        // Use the gimmick itself as the caster so collision-triggered skills don't fail range checks vs the original spawner.
+        BaseUnit caster = this;
         var skillCaster = new SkillDoodad(ObjId);
         var skillCastTarget = new SkillCastPositionTarget
         {
@@ -184,6 +185,8 @@ public class Gimmick : Unit
 
         BroadcastPacket(new SCChatMessagePacket(ChatType.System, $"Gimmick {ObjId} used skill {skillId}"), false);
     }
+
+    public void TriggerSkill(uint skillId) => DoGimmickSkill(skillId);
 
     public void GimmickTick(TimeSpan delta)
     {

--- a/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
@@ -208,8 +208,11 @@ public class Gimmick : Unit
 
         var deltaTime = (float)delta.TotalSeconds;
         var deltaPosition = Transform.World.Position - LastPos;
-        Vel = deltaTime > 0f ? (deltaPosition / deltaTime) : Vector3.Zero;
-        AngVel = new Vector3(0f, 0f, 0f);
+        if (MovementHandler == null)
+        {
+            Vel = deltaTime > 0f ? (deltaPosition / deltaTime) : Vector3.Zero;
+            AngVel = new Vector3(0f, 0f, 0f);
+        }
 
         // Time += (uint)delta.Milliseconds;
         Time = (uint)(DateTime.UtcNow - DateTime.UtcNow.Date).TotalMilliseconds;

--- a/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
@@ -204,7 +204,7 @@ public class Gimmick : Unit
 
         var deltaTime = (float)delta.TotalSeconds;
         var deltaPosition = Transform.World.Position - LastPos;
-        Vel = deltaPosition * deltaTime;
+        Vel = deltaTime > 0f ? (deltaPosition / deltaTime) : Vector3.Zero;
         AngVel = new Vector3(0f, 0f, 0f);
 
         // Time += (uint)delta.Milliseconds;

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -43,17 +43,14 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
         pos += vel * dt;
 
         // Detonate on ship hull collision (mass-box OBB in XY).
+        // Prevent immediate self-hit when firing from a ship deck (projectile starts inside the hull OBB).
+        if (owner.TotalLifeTime.TotalMilliseconds >= 200)
         {
-            // Prevent immediate self-hit when firing from a ship deck (projectile starts inside the hull OBB).
-            if (owner.TotalLifeTime.TotalMilliseconds < 200)
-                goto AfterShipCollision;
-
             const float projectileRadius = 0.5f;
             const float shipQueryRadius = 120f;
             var nearbyShips = WorldManager.GetAround<Slave>(owner, shipQueryRadius, false);
 
-            var spawner = owner.ParentWorld?.GetUnit(owner.SpawnerUnitId);
-            var spawnerObjId = spawner?.ObjId ?? 0;
+            var spawnerObjId = owner.SpawnerUnitId;
             foreach (var ship in nearbyShips)
             {
                 if (!ship.Template.IsABoat())
@@ -80,7 +77,6 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                 return;
             }
         }
-        AfterShipCollision: ;
 
         // Detonate on water surface impact (ocean + river/lake surfaces).
         // We intentionally check this before ground so projectiles explode on splash even if terrain is below.

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -1,0 +1,38 @@
+using System.Numerics;
+
+namespace AAEmu.Game.Models.Game.Gimmicks;
+
+#pragma warning disable CS9107 // Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor.
+public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(owner)
+#pragma warning restore CS9107 // Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor.
+{
+    public override void Tick(TimeSpan delta)
+    {
+        base.Tick(delta);
+
+        if (owner.Template == null)
+            return;
+
+        var dt = (float)delta.TotalSeconds;
+        if (dt <= 0f)
+            return;
+
+        var vel = owner.Vel;
+        var pos = owner.Transform.World.Position;
+
+        vel.Z -= owner.Template.Gravity * dt;
+
+        var air = owner.Template.AirResistance;
+        if (air > 0f)
+        {
+            var k = MathF.Max(0f, 1f - air * dt);
+            vel *= k;
+        }
+
+        pos += vel * dt;
+
+        owner.Vel = vel;
+        owner.Transform.World.Position = pos;
+    }
+}
+

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -44,14 +44,23 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
 
         // Detonate on ship hull collision (mass-box OBB in XY).
         {
+            // Prevent immediate self-hit when firing from a ship deck (projectile starts inside the hull OBB).
+            if (owner.TotalLifeTime.TotalMilliseconds < 200)
+                goto AfterShipCollision;
+
             const float projectileRadius = 0.5f;
             const float shipQueryRadius = 120f;
             var nearbyShips = WorldManager.GetAround<Slave>(owner, shipQueryRadius, false);
+
+            var spawner = owner.ParentWorld?.GetUnit(owner.SpawnerUnitId);
+            var spawnerObjId = spawner?.ObjId ?? 0;
             foreach (var ship in nearbyShips)
             {
                 if (!ship.Template.IsABoat())
                     continue;
                 if (ship.RigidBody is null || ship.ShipController?.ShipModel is null)
+                    continue;
+                if (spawnerObjId != 0 && ship.AttachedCharacters.Values.Any(c => c.ObjId == spawnerObjId))
                     continue;
                 if (!ShipSiegeAoEHit.TrySiegePointHitsShipMassBoxXz(pos.X, pos.Y, projectileRadius, ship))
                     continue;
@@ -71,6 +80,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                 return;
             }
         }
+        AfterShipCollision: ;
 
         // Detonate on water surface impact (ocean + river/lake surfaces).
         // We intentionally check this before ground so projectiles explode on splash even if terrain is below.

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -12,6 +12,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
 {
     private bool _stuckAfterImpact;
     private Vector3 _impactPos;
+    private bool _stuckOnShip;
 
     public override void Tick(TimeSpan delta)
     {
@@ -33,8 +34,24 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
         void StickAtImpact(Vector3 impactPos)
         {
             _stuckAfterImpact = true;
+            _stuckOnShip = false;
+            owner.Transform.Parent = null;
             _impactPos = impactPos;
             worldTf.Position = impactPos;
+            owner.Vel = Vector3.Zero;
+        }
+
+        void StickOnShip(Slave ship, Vector3 impactPos)
+        {
+            _stuckAfterImpact = true;
+            _stuckOnShip = true;
+
+            // Parent re-computes child Local from the current unparented local-as-world state.
+            // So we set Local.Position to the intended world impact point BEFORE parenting,
+            // and do not touch Local.Position after parenting (otherwise we overwrite the computed offset).
+            owner.Transform.Local.Position = impactPos; // parent == null => local == world
+            owner.Transform.Parent = ship.Transform;
+
             owner.Vel = Vector3.Zero;
         }
 
@@ -42,7 +59,8 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
         // but we must not keep integrating gravity, otherwise it "slides" down surfaces.
         if (_stuckAfterImpact)
         {
-            worldTf.Position = _impactPos;
+            if (!_stuckOnShip)
+                worldTf.Position = _impactPos;
             owner.Vel = Vector3.Zero;
             return;
         }
@@ -95,7 +113,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                     continue;
 
                 var impactSpeed = vel.Length();
-                StickAtImpact(pos);
+                StickOnShip(ship, pos);
                 if (impactSpeed >= template.CollisionMinSpeed)
                 {
                     var skillId = template.CollisionSkillId != 0 ? template.CollisionSkillId : template.SkillId;

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -45,7 +45,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
         // Detonate on ship hull collision (mass-box OBB in XY).
         {
             const float projectileRadius = 0.5f;
-            const float shipQueryRadius = 100f;
+            const float shipQueryRadius = 200f;
             var nearbyShips = WorldManager.GetAround<Slave>(owner, shipQueryRadius, false);
             foreach (var ship in nearbyShips)
             {

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -59,6 +59,18 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                     continue;
                 if (spawnerObjId != 0 && ship.AttachedCharacters.Values.Any(c => c.ObjId == spawnerObjId))
                     continue;
+
+                // Cheap early-out: if we're far from the ship mass-box center, skip the expensive OBB distance test.
+                // World horizontal plane is X/Y; ship mass-box math uses X/Z which maps to world X/Y.
+                ShipShipInteraction.GetMassBoxCenterXz(ship.RigidBody, ship.ShipController.ShipModel, ship.Scale, out var cx, out var cz);
+                var halfLen = ship.ShipController.ShipModel.MassBoxSizeY * ship.Scale * 0.5f;
+                var halfBeam = ship.ShipController.ShipModel.MassBoxSizeX * ship.Scale * 0.5f;
+                var maxR = MathF.Sqrt(halfLen * halfLen + halfBeam * halfBeam) + projectileRadius;
+                var dx = pos.X - cx;
+                var dz = pos.Y - cz;
+                if (dx * dx + dz * dz > maxR * maxR)
+                    continue;
+
                 if (!ShipSiegeAoEHit.TrySiegePointHitsShipMassBoxXz(pos.X, pos.Y, projectileRadius, ship))
                     continue;
 

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -1,5 +1,9 @@
 using System.Numerics;
 
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Physics;
+
 namespace AAEmu.Game.Models.Game.Gimmicks;
 
 #pragma warning disable CS9107 // Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor.
@@ -37,6 +41,36 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
         }
 
         pos += vel * dt;
+
+        // Detonate on ship hull collision (mass-box OBB in XY).
+        {
+            const float projectileRadius = 0.25f;
+            const float shipQueryRadius = 120f;
+            var nearbyShips = WorldManager.GetAround<Slave>(owner, shipQueryRadius, false);
+            foreach (var ship in nearbyShips)
+            {
+                if (!ship.Template.IsABoat())
+                    continue;
+                if (ship.RigidBody is null || ship.ShipController?.ShipModel is null)
+                    continue;
+                if (!ShipSiegeAoEHit.TrySiegePointHitsShipMassBoxXz(pos.X, pos.Y, projectileRadius, ship))
+                    continue;
+
+                worldTf.Position = pos;
+                owner.Vel = Vector3.Zero;
+
+                var impactSpeed = vel.Length();
+                if (impactSpeed >= template.CollisionMinSpeed)
+                {
+                    var skillId = template.CollisionSkillId != 0 ? template.CollisionSkillId : template.SkillId;
+                    owner.TriggerSkill(skillId);
+                }
+
+                if (template.DisappearByCollision)
+                    owner.Spawner?.Despawn(owner);
+                return;
+            }
+        }
 
         // Detonate on water surface impact (ocean + river/lake surfaces).
         // We intentionally check this before ground so projectiles explode on splash even if terrain is below.

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -18,6 +18,10 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
         if (template == null)
             return;
 
+        // When CollisionUnitOnly is set, we still stop on world barriers (water/ground),
+        // but we only treat collisions with Units as a "detonation" (collision-skill / disappear-by-collision).
+        var detonateOnlyOnUnits = template.CollisionUnitOnly;
+
         // Movement must never crash the global tick loop
         var worldTf = owner.Transform?.World;
         if (worldTf == null)
@@ -100,15 +104,19 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                 worldTf.Position = pos;
                 owner.Vel = Vector3.Zero;
 
-                var impactSpeed = vel.Length();
-                if (impactSpeed >= template.CollisionMinSpeed)
+                if (!detonateOnlyOnUnits)
                 {
-                    var skillId = template.CollisionSkillId != 0 ? template.CollisionSkillId : template.SkillId;
-                    owner.TriggerSkill(skillId);
+                    var impactSpeed = vel.Length();
+                    if (impactSpeed >= template.CollisionMinSpeed)
+                    {
+                        var skillId = template.CollisionSkillId != 0 ? template.CollisionSkillId : template.SkillId;
+                        owner.TriggerSkill(skillId);
+                    }
+
+                    if (template.DisappearByCollision)
+                        owner.Spawner?.Despawn(owner);
                 }
 
-                if (template.DisappearByCollision)
-                    owner.Spawner?.Despawn(owner);
                 return;
             }
         }
@@ -124,15 +132,19 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                     worldTf.Position = pos;
                     owner.Vel = Vector3.Zero;
 
-                    var impactSpeed = vel.Length();
-                    if (impactSpeed >= template.CollisionMinSpeed)
+                    if (!detonateOnlyOnUnits)
                     {
-                        var skillId = template.CollisionSkillId != 0 ? template.CollisionSkillId : template.SkillId;
-                        owner.TriggerSkill(skillId);
+                        var impactSpeed = vel.Length();
+                        if (impactSpeed >= template.CollisionMinSpeed)
+                        {
+                            var skillId = template.CollisionSkillId != 0 ? template.CollisionSkillId : template.SkillId;
+                            owner.TriggerSkill(skillId);
+                        }
+
+                        if (template.DisappearByCollision)
+                            owner.Spawner?.Despawn(owner);
                     }
 
-                    if (template.DisappearByCollision)
-                        owner.Spawner?.Despawn(owner);
                     return;
                 }
             }

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -44,8 +44,8 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
 
         // Detonate on ship hull collision (mass-box OBB in XY).
         {
-            const float projectileRadius = 0.25f;
-            const float shipQueryRadius = 120f;
+            const float projectileRadius = 0.5f;
+            const float shipQueryRadius = 100f;
             var nearbyShips = WorldManager.GetAround<Slave>(owner, shipQueryRadius, false);
             foreach (var ship in nearbyShips)
             {

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -38,9 +38,35 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
 
         pos += vel * dt;
 
+        // Detonate on water surface impact (ocean + river/lake surfaces).
+        // We intentionally check this before ground so projectiles explode on splash even if terrain is below.
+        var world = owner.ParentWorld;
+        if (world != null)
+        {
+            var probeZ = MathF.Max(oldPos.Z, pos.Z);
+            var surfaceZ = world.Water.GetWaterSurface(new Vector3(pos.X, pos.Y, probeZ), out _);
+            var crossesSurface = oldPos.Z > surfaceZ && pos.Z <= surfaceZ;
+            if (crossesSurface && world.Water.IsWater(new Vector3(pos.X, pos.Y, surfaceZ - 0.01f), out _))
+            {
+                pos.Z = surfaceZ;
+                worldTf.Position = pos;
+                owner.Vel = Vector3.Zero;
+
+                var impactSpeed = vel.Length();
+                if (impactSpeed >= template.CollisionMinSpeed)
+                {
+                    var skillId = template.CollisionSkillId != 0 ? template.CollisionSkillId : template.SkillId;
+                    owner.TriggerSkill(skillId);
+                }
+
+                if (template.DisappearByCollision)
+                    owner.Spawner?.Despawn(owner);
+                return;
+            }
+        }
+
         if (!template.NoGroundCollider)
         {
-            var world = owner.ParentWorld;
             if (world != null)
             {
                 var floorZ = world.GetHeight(pos.X, pos.Y);

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -45,7 +45,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
         // Detonate on ship hull collision (mass-box OBB in XY).
         {
             const float projectileRadius = 0.5f;
-            const float shipQueryRadius = 200f;
+            const float shipQueryRadius = 120f;
             var nearbyShips = WorldManager.GetAround<Slave>(owner, shipQueryRadius, false);
             foreach (var ship in nearbyShips)
             {

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -10,23 +10,26 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
     {
         base.Tick(delta);
 
-        if (owner.Template == null)
+        var template = owner.Template;
+        if (template == null)
+            return;
+
+        // Movement must never crash the global tick loop
+        var worldTf = owner.Transform?.World;
+        if (worldTf == null)
             return;
 
         var dt = (float)delta.TotalSeconds;
         if (dt <= 0f)
             return;
 
-        // Movement must never crash the global tick loop
-        if (owner.Transform?.World == null)
-            return;
-
         var vel = owner.Vel;
-        var pos = owner.Transform.World.Position;
+        var pos = worldTf.Position;
+        var oldPos = pos;
 
-        vel.Z -= owner.Template.Gravity * dt;
+        vel.Z -= template.Gravity * dt;
 
-        var air = owner.Template.AirResistance;
+        var air = template.AirResistance;
         if (air > 0f)
         {
             var k = MathF.Max(0f, 1f - air * dt);
@@ -35,8 +38,34 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
 
         pos += vel * dt;
 
+        if (!template.NoGroundCollider)
+        {
+            var world = owner.ParentWorld;
+            if (world != null)
+            {
+                var floorZ = world.GetHeight(pos.X, pos.Y);
+                if (oldPos.Z > floorZ && pos.Z <= floorZ)
+                {
+                    pos.Z = floorZ;
+                    worldTf.Position = pos;
+                    owner.Vel = Vector3.Zero;
+
+                    var impactSpeed = vel.Length();
+                    if (impactSpeed >= template.CollisionMinSpeed)
+                    {
+                        var skillId = template.CollisionSkillId != 0 ? template.CollisionSkillId : template.SkillId;
+                        owner.TriggerSkill(skillId);
+                    }
+
+                    if (template.DisappearByCollision)
+                        owner.Spawner?.Despawn(owner);
+                    return;
+                }
+            }
+        }
+
         owner.Vel = vel;
-        owner.Transform.World.Position = pos;
+        worldTf.Position = pos;
     }
 }
 

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -49,15 +49,11 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
             const float projectileRadius = 0.5f;
             const float shipQueryRadius = 120f;
             var nearbyShips = WorldManager.GetAround<Slave>(owner, shipQueryRadius, false);
-
-            var spawnerObjId = owner.SpawnerUnitId;
             foreach (var ship in nearbyShips)
             {
                 if (!ship.Template.IsABoat())
                     continue;
                 if (ship.RigidBody is null || ship.ShipController?.ShipModel is null)
-                    continue;
-                if (spawnerObjId != 0 && ship.AttachedCharacters.Values.Any(c => c.ObjId == spawnerObjId))
                     continue;
 
                 // Cheap early-out: if we're far from the ship mass-box center, skip the expensive OBB distance test.

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -55,6 +55,16 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
             owner.Vel = Vector3.Zero;
         }
 
+        void DespawnByCollisionIfNeeded(float impactSpeed)
+        {
+            if (!template.DisappearByCollision || impactSpeed < template.CollisionMinSpeed)
+                return;
+
+            if (owner.Despawn <= DateTime.MinValue)
+                owner.Despawn = DateTime.UtcNow;
+            owner.Spawner?.Despawn(owner);
+        }
+
         // After impact/detonation we keep the gimmick in-place (fade-out / lifetime),
         // but we must not keep integrating gravity, otherwise it "slides" down surfaces.
         if (_stuckAfterImpact)
@@ -121,7 +131,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                 }
 
                 if (template.DisappearByCollision && impactSpeed >= template.CollisionMinSpeed)
-                    owner.Spawner?.Despawn(owner);
+                    DespawnByCollisionIfNeeded(impactSpeed);
                 else
                 {
                     // Keep the projectile stuck at the impact point until it fades/despawns by lifetime.
@@ -155,7 +165,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                     }
 
                     if (template.DisappearByCollision && impactSpeed >= template.CollisionMinSpeed)
-                        owner.Spawner?.Despawn(owner);
+                        DespawnByCollisionIfNeeded(impactSpeed);
                 }
 
                 return;
@@ -182,7 +192,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                         }
 
                         if (template.DisappearByCollision && impactSpeed >= template.CollisionMinSpeed)
-                            owner.Spawner?.Despawn(owner);
+                            DespawnByCollisionIfNeeded(impactSpeed);
                     }
 
                     return;

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -17,6 +17,10 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
         if (dt <= 0f)
             return;
 
+        // Movement must never crash the global tick loop
+        if (owner.Transform?.World == null)
+            return;
+
         var vel = owner.Vel;
         var pos = owner.Transform.World.Position;
 

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickMovementProjectile.cs
@@ -10,6 +10,9 @@ namespace AAEmu.Game.Models.Game.Gimmicks;
 public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(owner)
 #pragma warning restore CS9107 // Parameter is captured into the state of the enclosing type and its value is also passed to the base constructor.
 {
+    private bool _stuckAfterImpact;
+    private Vector3 _impactPos;
+
     public override void Tick(TimeSpan delta)
     {
         base.Tick(delta);
@@ -26,6 +29,23 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
         var worldTf = owner.Transform?.World;
         if (worldTf == null)
             return;
+
+        void StickAtImpact(Vector3 impactPos)
+        {
+            _stuckAfterImpact = true;
+            _impactPos = impactPos;
+            worldTf.Position = impactPos;
+            owner.Vel = Vector3.Zero;
+        }
+
+        // After impact/detonation we keep the gimmick in-place (fade-out / lifetime),
+        // but we must not keep integrating gravity, otherwise it "slides" down surfaces.
+        if (_stuckAfterImpact)
+        {
+            worldTf.Position = _impactPos;
+            owner.Vel = Vector3.Zero;
+            return;
+        }
 
         var dt = (float)delta.TotalSeconds;
         if (dt <= 0f)
@@ -74,18 +94,20 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                 if (!ShipSiegeAoEHit.TrySiegePointHitsShipMassBoxXz(pos.X, pos.Y, projectileRadius, ship))
                     continue;
 
-                worldTf.Position = pos;
-                owner.Vel = Vector3.Zero;
-
                 var impactSpeed = vel.Length();
+                StickAtImpact(pos);
                 if (impactSpeed >= template.CollisionMinSpeed)
                 {
                     var skillId = template.CollisionSkillId != 0 ? template.CollisionSkillId : template.SkillId;
                     owner.TriggerSkill(skillId);
                 }
 
-                if (template.DisappearByCollision)
+                if (template.DisappearByCollision && impactSpeed >= template.CollisionMinSpeed)
                     owner.Spawner?.Despawn(owner);
+                else
+                {
+                    // Keep the projectile stuck at the impact point until it fades/despawns by lifetime.
+                }
                 return;
             }
         }
@@ -101,6 +123,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
             if (crossesSurface && world.Water.IsWater(new Vector3(pos.X, pos.Y, surfaceZ - 0.01f), out _))
             {
                 pos.Z = surfaceZ;
+                // On water contact we do not "stick" to the surface; we either detonate or continue sinking.
                 worldTf.Position = pos;
                 owner.Vel = Vector3.Zero;
 
@@ -113,7 +136,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                         owner.TriggerSkill(skillId);
                     }
 
-                    if (template.DisappearByCollision)
+                    if (template.DisappearByCollision && impactSpeed >= template.CollisionMinSpeed)
                         owner.Spawner?.Despawn(owner);
                 }
 
@@ -129,8 +152,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                 if (oldPos.Z > floorZ && pos.Z <= floorZ)
                 {
                     pos.Z = floorZ;
-                    worldTf.Position = pos;
-                    owner.Vel = Vector3.Zero;
+                    StickAtImpact(pos);
 
                     if (!detonateOnlyOnUnits)
                     {
@@ -141,7 +163,7 @@ public class GimmickMovementProjectile(Gimmick owner) : GimmickMovementHandler(o
                             owner.TriggerSkill(skillId);
                         }
 
-                        if (template.DisappearByCollision)
+                        if (template.DisappearByCollision && impactSpeed >= template.CollisionMinSpeed)
                             owner.Spawner?.Despawn(owner);
                     }
 

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickSpawner.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickSpawner.cs
@@ -103,6 +103,7 @@ public class GimmickSpawner : Spawner<Gimmick>
         }
 
         gimmick.SetScale(Scale);
+        gimmick.Vel = new Vector3(VelocityX, VelocityY, VelocityZ);
         gimmick.Spawn(); // добавляем в мир
         ParentWorld.GimmickManager.AddActiveGimmick(gimmick);
 

--- a/AAEmu.Game/Models/Game/Gimmicks/GimmickSpawner.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/GimmickSpawner.cs
@@ -90,7 +90,10 @@ public class GimmickSpawner : Spawner<Gimmick>
             case OffsetCoordinateType.Unk1:
                 break;
             case OffsetCoordinateType.Unk2:
-                gimmick.Transform.Local.AddDistance(OffsetX, OffsetY, OffsetZ);
+                // offset_coordiate_id = 2 => local right/front/up offset (not raw world XYZ)
+                gimmick.Transform.Local.AddDistanceToRight(OffsetX);
+                gimmick.Transform.Local.AddDistanceToFront(OffsetY);
+                gimmick.Transform.Local.Translate(new Vector3(0f, 0f, OffsetZ));
                 //var (newX, newY, newZ) = PositionAndRotation.AddDistanceToFront(1, 1, gimmick.Transform.World.Position, gimmick.Transform.World.Position);
                 //gimmick.Transform.World.Position = new Vector3(newX, newY, newZ + OffsetZ);
                 break;
@@ -103,7 +106,19 @@ public class GimmickSpawner : Spawner<Gimmick>
         }
 
         gimmick.SetScale(Scale);
-        gimmick.Vel = new Vector3(VelocityX, VelocityY, VelocityZ);
+        if (VelocityCoordinateId == VelocityCoordinateType.Unk2)
+        {
+            // velocity_coordiate_id = 2 => local right/front/up velocity, rotate by caster yaw into world XY
+            var yaw = gimmick.Transform.World.Rotation.Z; // radians
+            gimmick.Vel = new Vector3(
+                (MathF.Cos(yaw) * VelocityX) + (-MathF.Sin(yaw) * VelocityY),
+                (MathF.Sin(yaw) * VelocityX) + (MathF.Cos(yaw) * VelocityY),
+                VelocityZ);
+        }
+        else
+        {
+            gimmick.Vel = new Vector3(VelocityX, VelocityY, VelocityZ);
+        }
         gimmick.Spawn(); // добавляем в мир
         ParentWorld.GimmickManager.AddActiveGimmick(gimmick);
 

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ClearProjectile.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ClearProjectile.cs
@@ -20,14 +20,5 @@ public class ClearProjectile : SpecialEffectAction
     {
         if (caster is Character)
             Logger.Debug("Special effects: ClearProjectile value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
-
-        if (caster is not Unit casterUnit)
-            return;
-
-        if (casterUnit.Gimmick == null)
-            return;
-
-        casterUnit.Gimmick.Spawner?.Despawn(casterUnit.Gimmick);
-        casterUnit.Gimmick = null;
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ClearProjectile.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ClearProjectile.cs
@@ -18,7 +18,16 @@ public class ClearProjectile : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO ...
-        if (caster is Character) { Logger.Debug("Special effects: ClearProjectile value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+        if (caster is Character)
+            Logger.Debug("Special effects: ClearProjectile value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
+
+        if (caster is not Unit casterUnit)
+            return;
+
+        if (casterUnit.Gimmick == null)
+            return;
+
+        casterUnit.Gimmick.Spawner?.Despawn(casterUnit.Gimmick);
+        casterUnit.Gimmick = null;
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Projectile.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Projectile.cs
@@ -1,4 +1,5 @@
 ﻿using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Gimmicks;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
@@ -18,7 +19,48 @@ public class Projectile : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO ...
-        if (caster is Character) { Logger.Debug("Special effects: Projectile value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+        if (caster is Character)
+            Logger.Debug("Special effects: Projectile value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
+
+        if (caster is not Unit casterUnit)
+            return;
+
+        if (casterUnit.ParentWorld?.GimmickManager == null)
+            return;
+
+        var templateId = (uint)Math.Max(0, value1);
+        if (templateId == 0)
+            return;
+
+        // Replace existing stored projectile (some skills reuse the same slot).
+        if (casterUnit.Gimmick != null)
+        {
+            casterUnit.Gimmick.Spawner?.Despawn(casterUnit.Gimmick);
+            casterUnit.Gimmick = null;
+        }
+
+        var gimmick = casterUnit.ParentWorld.GimmickManager.Create(templateId);
+        if (gimmick == null)
+            return;
+
+        gimmick.Spawner ??= new GimmickSpawner(casterUnit.ParentWorld) { RespawnTime = 0 };
+        gimmick.Spawner.ParentWorld = casterUnit.ParentWorld;
+        gimmick.Transform = casterUnit.Transform.CloneDetached(gimmick);
+        gimmick.SpawnerUnitId = casterUnit.ObjId;
+        gimmick.GrasperUnitId = 0;
+
+        // Spawn slightly in front to avoid immediate ground intersections.
+        gimmick.Transform.Local.AddDistanceToFront(1f);
+
+        var speed = Math.Max(0f, value2);
+        if (speed > 0.0001f)
+        {
+            var yaw = gimmick.Transform.World.Rotation.Z; // radians
+            gimmick.Vel = new System.Numerics.Vector3(MathF.Cos(yaw) * speed, MathF.Sin(yaw) * speed, 0f);
+        }
+
+        gimmick.Spawn();
+        casterUnit.ParentWorld.GimmickManager.AddActiveGimmick(gimmick);
+        casterUnit.Gimmick = gimmick;
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Projectile.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Projectile.cs
@@ -1,5 +1,4 @@
 ﻿using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Gimmicks;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
@@ -21,46 +20,5 @@ public class Projectile : SpecialEffectAction
     {
         if (caster is Character)
             Logger.Debug("Special effects: Projectile value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
-
-        if (caster is not Unit casterUnit)
-            return;
-
-        if (casterUnit.ParentWorld?.GimmickManager == null)
-            return;
-
-        var templateId = (uint)Math.Max(0, value1);
-        if (templateId == 0)
-            return;
-
-        // Replace existing stored projectile (some skills reuse the same slot).
-        if (casterUnit.Gimmick != null)
-        {
-            casterUnit.Gimmick.Spawner?.Despawn(casterUnit.Gimmick);
-            casterUnit.Gimmick = null;
-        }
-
-        var gimmick = casterUnit.ParentWorld.GimmickManager.Create(templateId);
-        if (gimmick == null)
-            return;
-
-        gimmick.Spawner ??= new GimmickSpawner(casterUnit.ParentWorld) { RespawnTime = 0 };
-        gimmick.Spawner.ParentWorld = casterUnit.ParentWorld;
-        gimmick.Transform = casterUnit.Transform.CloneDetached(gimmick);
-        gimmick.SpawnerUnitId = casterUnit.ObjId;
-        gimmick.GrasperUnitId = 0;
-
-        // Spawn slightly in front to avoid immediate ground intersections.
-        gimmick.Transform.Local.AddDistanceToFront(1f);
-
-        var speed = Math.Max(0f, value2);
-        if (speed > 0.0001f)
-        {
-            var yaw = gimmick.Transform.World.Rotation.Z; // radians
-            gimmick.Vel = new System.Numerics.Vector3(MathF.Cos(yaw) * speed, MathF.Sin(yaw) * speed, 0f);
-        }
-
-        gimmick.Spawn();
-        casterUnit.ParentWorld.GimmickManager.AddActiveGimmick(gimmick);
-        casterUnit.Gimmick = gimmick;
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/RetrieveProjectile.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/RetrieveProjectile.cs
@@ -18,7 +18,17 @@ public class RetrieveProjectile : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO ...
-        if (caster is Character) { Logger.Debug("Special effects: RetrieveProjectile value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+        if (caster is Character)
+            Logger.Debug("Special effects: RetrieveProjectile value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
+
+        if (caster is not Unit casterUnit)
+            return;
+
+        // For now, treat "retrieve" as clearing the active server-side projectile.
+        if (casterUnit.Gimmick == null)
+            return;
+
+        casterUnit.Gimmick.Spawner?.Despawn(casterUnit.Gimmick);
+        casterUnit.Gimmick = null;
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/RetrieveProjectile.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/RetrieveProjectile.cs
@@ -20,15 +20,5 @@ public class RetrieveProjectile : SpecialEffectAction
     {
         if (caster is Character)
             Logger.Debug("Special effects: RetrieveProjectile value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
-
-        if (caster is not Unit casterUnit)
-            return;
-
-        // For now, treat "retrieve" as clearing the active server-side projectile.
-        if (casterUnit.Gimmick == null)
-            return;
-
-        casterUnit.Gimmick.Spawner?.Despawn(casterUnit.Gimmick);
-        casterUnit.Gimmick = null;
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -243,7 +243,8 @@ public class Skill
 
         // TODO: Remove exception for doodads
         // TODO: Remove exceptions for slave initiated by Doodads (needed to fix repair points on ships)
-        if (targetDist > maxRangeCheck && target is not Doodad && target is not Slave)
+        // Position-targeted skills may legitimately have MaxRange=0 (they're effectively "self" at a point).
+        if (targetDist > maxRangeCheck && maxRangeCheck > 0f && target is not Doodad && target is not Slave)
         {
             SkillTlIdManager.ReleaseId(TlId);
             TlId = 0;


### PR DESCRIPTION
https://github.com/user-attachments/assets/1b87f33f-56ef-48c3-8541-a0bcdba3cef3
https://github.com/user-attachments/assets/b9f159f7-f07e-4a05-9e37-b2ca749b7171
https://github.com/user-attachments/assets/1c7aebbc-f476-417f-94ee-8ea99e83f2e7

**his change is not limited to the hand harpoon. We implemented a generic “gimmick projectile” runtime, so it can affect any skill/content that spawns or uses gimmicks as moving projectiles.**

What content is affected
Any gimmick that is treated as a projectile: GimmickMovementProjectile is attached automatically when a gimmick has initial velocity, gravity, or air resistance (i.e. anything configured to fly/fall).
Any gimmick configured with collision behavior: gimmicks with collision_skill_id / skill_id and/or disappear_by_collision will now reliably detonate/despawn on:
terrain impact (heightmap floor crossing),
water surface impact (ocean + rivers/lakes),
ship hull impact (ship mass-box OBB contact).
Any skill with max_range = 0: the range validation was adjusted so MaxRange = 0 no longer causes unintended TooFarRange failures for position-style casts.
Practical takeaway
If a skill spawns a gimmick via SpawnGimmickEffect (or otherwise creates a gimmick with projectile-like physics), it will now inherit this collision/detonation behavior, not just the harpoon bomb.

We implemented proper server-side behavior for the hand harpoon bomb projectile by turning the spawned gimmick into a real simulated projectile and triggering its explosion reliably on impact.

What was added/changed
Server-side projectile movement for gimmicks

Added GimmickMovementProjectile and wired it from GimmickManager when a gimmick has initial velocity / gravity / air resistance.
The handler integrates velocity with gravity and air resistance and updates the gimmick world position each tick.
Impact detection and detonation

Implemented collision-style detonation against:
Terrain (heightmap floor crossing)
Water surface (ocean + rivers/lakes via WaterBodies.GetWaterSurface)
Ship hulls (ship mass-box OBB check reused from siege AoE ship hit logic)
On impact we trigger the gimmick’s configured collision skill (collision_skill_id fallback to skill_id) and despawn when disappear_by_collision is set.
Explosion damage relation fix

The explosion skill is executed using the original spawner unit (SpawnerUnitId) as the caster so hostile/ally filtering works correctly for AoE damage (instead of casting from the gimmick’s system faction).
Self-hit prevention when firing from a ship deck

Added a short grace window right after spawn and ignored collisions with the ship that currently has the spawner attached, preventing immediate detonation on the shooter’s own ship.
Range=0 position-skill handling

Adjusted the “TooFarRange” check so position-targeted skills with MaxRange = 0 don’t fail range validation, enabling the harpoon explosion skill to execute correctly at the impact point.