### PR TITLE
fix(zones): start conflict zones at Tension, not the testing-only Conflict override

### DIFF
--- a/AAEmu.Game/Core/Managers/World/ZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/World/ZoneManager.cs
@@ -151,11 +151,6 @@ public class ZoneManager(IWorldManager worldManager) : Singleton<ZoneManager>, I
 
                             _groups[zoneGroupId].Conflict = template;
                             _conflicts.Add(zoneGroupId, template);
-
-                            // Only do intial setup when the zone isn't closed
-                            if (!template.Closed)
-                                template.SetState(ZoneConflictType
-                                    .Conflict); // Set to Conflict for testing, normally it should start at Tension
                         }
                         else
                             Logger.Warn("ZoneGroupId: {0} doesn't exist for conflict", zoneGroupId);


### PR DESCRIPTION
## Problem

`ZoneManager.Load` forces every open conflict zone into `ZoneConflictType.Conflict` on startup:

```csharp
// Only do intial setup when the zone isn't closed
if (!template.Closed)
    template.SetState(ZoneConflictType.Conflict); // Set to Conflict for testing, normally it should start at Tension
```

The inline comment already flags this as a testing-only override ("normally it should start at Tension"). As shipped it boots **all** conflict zones straight into the Conflict (war) state regardless of their intended initial state.

## Fix

Remove the testing override so conflict zones start at their default `Tension` state and transition through the normal tension→conflict progression.

## Notes

- 5-line deletion, no behavioral code added.
- `AAEmu.Game` builds with 0 errors on `client_version/zone-10.0.2_r575`.
- Verified live on a CN 10.0.2.13 (r575) server: conflict zones now open at Tension and escalate normally instead of booting at war.