### PR TITLE
fix(crime): store the zone key, not the zone row id, in ReportCrime

### DIFF
--- a/AAEmu.Game/Core/Managers/CrimeManager.cs
+++ b/AAEmu.Game/Core/Managers/CrimeManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 using System.Numerics;
 using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
@@ -188,7 +188,7 @@ public class CrimeManager(IWorldManager worldManager,
             }
         }
 
-        var zoneKey = zoneManager.GetZoneByKey(evidence.Transform.ZoneId);
+        var zone = zoneManager.GetZoneByKey(evidence.Transform.ZoneId);
 
         var newId = crimeIdManager.GetNextId();
         var newEvent = new CrimeEvent()
@@ -202,7 +202,7 @@ public class CrimeManager(IWorldManager worldManager,
             CrimeTime = evidence.PlantTime,
             ReportTime = DateTime.UtcNow,
             Position = evidence.Transform.World.Position,
-            ZoneKey = zoneKey?.Id ?? 0u,
+            ZoneKey = zone?.ZoneKey ?? 0u,
             Arg1 = arg1,
             Arg2 = arg2,
             Arg3 = arg3,


### PR DESCRIPTION
## Problem

`CrimeManager.ReportCrime` resolves the zone with `GetZoneByKey(...)` and then stores `zoneKey?.Id ?? 0u`. `GetZoneByKey` returns a `Zone` whose `.Id` is the **DB row id**, not the zone key. The crime record therefore gets the wrong `zone_key` value.

## Fix

Store the actual zone key (`.ZoneKey`) instead of the row id.

## Notes

- `AAEmu.Game` builds with 0 errors on `client_version/zone-10.0.2_r575`.
- This is the recurring zone-id-vs-zone-key trap: `characters.zone_id`, `zones.zone_key` and the world/create logs all speak in zone **keys**, while a `Zone.Id` is the DB row id.
- Verified live on a CN 10.0.2.13 (r575) server.