### PR TITLE
fix(doodads): correct climate match for Climate.None and null zone

### DIFF
--- a/AAEmu.Game/Core/Managers/World/ZoneManager.cs
+++ b/AAEmu.Game/Core/Managers/World/ZoneManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Models.Game.DoodadObj;
@@ -264,7 +264,7 @@ public class ZoneManager(IWorldManager worldManager) : Singleton<ZoneManager>, I
     public bool DoodadHasMatchingClimate(Doodad doodad)
     {
         // If no climate defined, then don't give a bonus
-        if (doodad.Template.ClimateId == Climate.Any || doodad.Template.ClimateId == Climate.Any)
+        if (doodad.Template == null || doodad.Template.ClimateId == Climate.None || doodad.Template.ClimateId == Climate.Any)
             return false;
 
         // Get doodad's zone (if missing zoneId (key)
@@ -275,6 +275,8 @@ public class ZoneManager(IWorldManager worldManager) : Singleton<ZoneManager>, I
             doodad.Transform.ZoneId = zoneId;
         }
         var zone = GetZoneByKey(doodad.Transform.ZoneId);
+        if (zone == null)
+            return false;
 
         // Get the climates list for this zone
         var zoneClimates = GetClimatesByZone(zone);


### PR DESCRIPTION
## Problem

The doodad climate match in `ZoneManager` has three issues:

1. A duplicated condition: `ClimateId == Climate.Any || ClimateId == Climate.Any` (the second branch was meant to be a different value).
2. No handling for `Climate.None`.
3. A `NullReferenceException` when the zone `Template` is null: the code calls `GetClimatesByZone(...)` without guarding for a missing zone.

## Fix

De-duplicate the condition, handle `Climate.None`, and null-guard the zone before the climate lookup.

## Notes

- `AAEmu.Game` builds with 0 errors on `client_version/zone-10.0.2_r575`.
- Verified live on a CN 10.0.2.13 (r575) server.