### PR TITLE
fix(mates): reject mounting a dead mate

### DIFF
--- a/AAEmu.Game/Core/Managers/MateManager.cs
+++ b/AAEmu.Game/Core/Managers/MateManager.cs
@@ -174,7 +174,7 @@ public class MateManager(WorldInstance parentWorldInstance)
     {
         var character = connection.ActiveChar;
         var mateInfo = GetActiveMateByTlId(tlId);
-        if (mateInfo == null) return;
+        if (mateInfo == null || mateInfo.IsDead) return;
 
         // Request seat position
         if (mateInfo.Passengers.TryGetValue(attachPoint, out var seatInfo))


### PR DESCRIPTION
## Problem

`MateManager.MountMate` only guards for a missing mate (`if (mateInfo == null) return;`). It has no death check, so a player can mount a mate that is dead.

## Fix

Reject the mount when the mate is dead.

## Notes

- `AAEmu.Game` builds with 0 errors on `client_version/zone-10.0.2_r575`.
- Verified live on a CN 10.0.2.13 (r575) server.