### PR TITLE
fix(combat): reroll auto-attack hit results instead of latching the first

### DIFF
--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -1143,7 +1143,9 @@ public class Skill
                             break;
                     }
                 }
-                HitTypes.TryAdd(targetUnit.ObjId, diceResult);
+                // Auto-attack tasks reuse their Skill instance, so each swing must replace the
+                // previous result for this target instead of latching the first hit or miss forever.
+                HitTypes[targetUnit.ObjId] = diceResult;
             }
             else if (target is Doodad doodad)
             {


### PR DESCRIPTION
## Problem

The auto-attack `Skill` instance is reused across swings. It records hit results with `HitTypes.TryAdd(targetUnit.ObjId, diceResult)`. Because `TryAdd` is a no-op when the key already exists, the **first** hit/miss result for a target is latched forever — every subsequent auto-attack against that target replays the original roll (a first miss stays a permanent miss, a first crit stays a permanent crit).

## Fix

Assign with the indexer (`HitTypes[targetUnit.ObjId] = diceResult`) so each swing rerolls.

## Notes

- `AAEmu.Game` builds with 0 errors on `client_version/zone-10.0.2_r575`.
- Verified live on a CN 10.0.2.13 (r575) server.