### PR TITLE
fix(quests): preserve progress on reusable trigger spheres

### DIFF
--- a/AAEmu.Game/GameData/SphereGameData.cs
+++ b/AAEmu.Game/GameData/SphereGameData.cs
@@ -437,9 +437,19 @@ public class SphereGameData : Singleton<SphereGameData>, IGameDataLoader
             return null;
 
         var pakDataSpheres = SphereQuestManager.GetSpheresForQuest(dbSphereQuest.QuestId);
+        var requiredComponent = requiredComponentId > 0
+            ? QuestManager.Instance.GetComponent(requiredComponentId)
+            : null;
+
         foreach (var pakDataSphere in pakDataSpheres)
         {
-            if (pakDataSphere.Contains(worldPosition) && (requiredComponentId == 0 || pakDataSphere.ComponentId == requiredComponentId))
+            var componentMatches = requiredComponentId == 0 || pakDataSphere.ComponentId == requiredComponentId;
+            if (!componentMatches &&
+                dbSphere.TriggerConditionId == AreaSphereTriggerCondition.TriggerEveryNTimeAfter &&
+                requiredComponent?.ParentQuestTemplate?.Id == dbSphereQuest.QuestId)
+                componentMatches = true;
+
+            if (pakDataSphere.Contains(worldPosition) && componentMatches)
                 return pakDataSphere;
         }
 

--- a/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjSphere.cs
+++ b/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjSphere.cs
@@ -1,4 +1,5 @@
-﻿using AAEmu.Game.Models.Game.Quests.Templates;
+﻿using AAEmu.Game.GameData;
+using AAEmu.Game.Models.Game.Quests.Templates;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
 
@@ -58,6 +59,9 @@ public class QuestActObjSphere(QuestComponentTemplate parentComponent) : QuestAc
             return;
 
         Logger.Debug($"{QuestActTemplateName}({DetailId}).OnExitSphere: Quest: {questAct.QuestComponent.Parent.Parent.TemplateId}, Owner {questAct.QuestComponent.Parent.Parent.Owner.Name} ({questAct.QuestComponent.Parent.Parent.Owner.Id}), ComponentId {args.SphereQuest.ComponentId}");
+        if (SphereGameData.Instance.GetSphere(SphereId)?.TriggerConditionId == AreaSphereTriggerCondition.TriggerEveryNTimeAfter)
+            return;
+
         SetObjective(questAct, 0);
     }
 


### PR DESCRIPTION
## Problem

Reusable quest spheres (those using `AreaSphereTriggerCondition.TriggerEveryNTimeAfter`) reset their accumulated progress instead of preserving it across triggers, so the objective never advances as intended.

## Fix

Preserve reusable-sphere progress: honor the `TriggerEveryNTimeAfter` handling in `SphereGameData` / `QuestActObjSphere` and guard the exit path so progress is retained.

## Notes

- `AAEmu.Game` builds with 0 errors on `client_version/zone-10.0.2_r575`.
- Verified live on a CN 10.0.2.13 (r575) server.