### PR TITLE
fix(auction): apply category/grade/level filters alongside keyword search

### DIFF
--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -641,38 +641,36 @@ public class AuctionManager(IItemManager itemManager, INameManager nameManager, 
                     }
                 }
             }
-            else
+            // Keyword and item filters are cumulative. A keyword search must not bypass
+            // the selected category, grade, or level range.
+            if (settings.CategoryA != search.CategoryA && search.CategoryA != 0)
             {
-                // Проверка по категориям и другим параметрам
-                if (settings.CategoryA != search.CategoryA && search.CategoryA != 0)
-                {
-                    continue;
-                }
+                continue;
+            }
 
-                if (settings.CategoryB != search.CategoryB && search.CategoryB != 0)
-                {
-                    continue;
-                }
+            if (settings.CategoryB != search.CategoryB && search.CategoryB != 0)
+            {
+                continue;
+            }
 
-                if (settings.CategoryC != search.CategoryC && search.CategoryC != 0)
-                {
-                    continue;
-                }
+            if (settings.CategoryC != search.CategoryC && search.CategoryC != 0)
+            {
+                continue;
+            }
 
-                if (lot.Item.Grade != search.Grade && search.Grade != 0)
-                {
-                    continue;
-                }
+            if (lot.Item.Grade != search.Grade && search.Grade != 0)
+            {
+                continue;
+            }
 
-                if (template.Level > search.MaxItemLevel && search.MaxItemLevel != 0)
-                {
-                    continue;
-                }
+            if (template.Level > search.MaxItemLevel && search.MaxItemLevel != 0)
+            {
+                continue;
+            }
 
-                if (template.Level < search.MinItemLevel && search.MinItemLevel != 0)
-                {
-                    continue;
-                }
+            if (template.Level < search.MinItemLevel && search.MinItemLevel != 0)
+            {
+                continue;
             }
 
             searchedArticles.Add(lot);


### PR DESCRIPTION
## Problem

`AuctionManager.SearchAuctionLots` puts the keyword search in an `else` branch, so a keyword query **bypasses** the category, grade and level filters. Searching by name returns matches from every category/grade/level instead of the ones the player selected.

## Fix

Combine the keyword and item filters so both constrain the result set together.

## Notes

- `AAEmu.Game` builds with 0 errors on `client_version/zone-10.0.2_r575`.
- Verified live on a CN 10.0.2.13 (r575) server.