### PR TITLE
fix(slaves): reject boarding a destroyed vehicle on the core path

### DIFF
--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -220,7 +220,7 @@ public class SlaveManager(WorldInstance parentWorldInstance)
         // Check if the target spot is already taken
         var slave = GetSlaveByObjId(objId);
 
-        if (slave == null || slave.AttachedCharacters.ContainsKey(attachPoint))
+        if (slave == null || slave.IsDead || slave.AttachedCharacters.ContainsKey(attachPoint))
             return;
 
         // Check if the vehicle has the MasterOwnership buff and if the character is not the owner, block the attachment.


### PR DESCRIPTION
## Problem

The entry-point `BindSlave(GameConnection, tlId)` already checks `IsDead`, but the **core** `BindSlave(Character, objId, ...)` does not, and `DoodadFuncAttachment` boards via `BoardTransfer` without any death check. A destroyed/dead slave can still be boarded through those paths.

## Fix

Add the `IsDead` guard on the core boarding path so a destroyed vehicle can't be boarded regardless of entry point.

## Notes

- Small guard, no behavioral code beyond the rejection.
- `AAEmu.Game` builds with 0 errors on `client_version/zone-10.0.2_r575`.
- Verified live on a CN 10.0.2.13 (r575) server.