### PR TITLE
fix(housing): transfer all furniture ownership when a house is sold

### DIFF
--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -1462,16 +1462,16 @@ public class HousingManager(
     /// <param name="house"></param>
     /// <param name="characterId"></param>
     /// <returns>The number of items that have their owner information updated</returns>
-    private static uint UpdateFurnitureOwner(House house, uint characterId)
+    private static uint UpdateFurnitureOwner(House house, uint characterId, FactionsEnum newFaction)
     {
         uint res = 0;
         var furnitureList = house.ParentWorld.GetDoodadByHouseDbId(house.Id);
         foreach (var furniture in furnitureList)
         {
-            if (furniture.AttachPoint != AttachPointKind.None)
-                continue;
             furniture.OwnerId = characterId;
-            furniture.BroadcastPacket(new SCDoodadOriginatorPacket(furniture.ObjId, characterId, 0), true);
+            furniture.BroadcastPacket(new SCDoodadOriginatorPacket(furniture.ObjId, characterId, newFaction), true);
+            if (furniture.IsPersistent)
+                furniture.Save();
             res++;
         }
         return res;
@@ -1605,7 +1605,7 @@ public class HousingManager(
         if (oldOwner is { IsOnline: true })
             oldOwner.SendPacket(new SCHouseRemovedPacket(house.TlId));
 
-        UpdateFurnitureOwner(house, character.Id);
+        UpdateFurnitureOwner(house, character.Id, character.Faction.Id);
 
         house.IsDirty = true;
 

--- a/AAEmu.Game/Core/Packets/G2C/SCDoodadOriginatorPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDoodadOriginatorPacket.cs
@@ -1,16 +1,17 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCDoodadOriginatorPacket(uint objId, uint newOwnerId, uint faction)
+public class SCDoodadOriginatorPacket(uint objId, uint newOwnerId, FactionsEnum newFaction)
     : GamePacket(SCOffsets.SCDoodadOriginatorPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
         stream.WriteBc(objId);
         stream.Write(newOwnerId);
-        stream.Write(faction);
+        stream.Write((uint)newFaction);
 
         return stream;
     }


### PR DESCRIPTION
## Problem

`HousingManager.UpdateFurnitureOwner` skips attached furniture (`continue` when `AttachPoint != None`), passes faction `0`, and never `Save()`s the change. After a house sale, attached furniture keeps the previous owner.

## Fix

Transfer ownership for all furniture including attached pieces, carry the correct faction, and persist the change.

## Notes

- `AAEmu.Game` builds with 0 errors on `client_version/zone-10.0.2_r575`.
- Verified live on a CN 10.0.2.13 (r575) server.