### PR TITLE
fix(game): persist dock, helm, and daily-contract player state

### DIFF
--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -184,6 +184,7 @@ public class SlaveManager(WorldInstance parentWorldInstance)
             character.Transform.Parent = null;
             character.Transform.StickyParent = null;
             character.Buffs.TriggerRemoveOn(BuffRemoveOn.Unmount);
+            character.Buffs.TriggerRemoveOn(BuffRemoveOn.Unbond);
             character.AttachedPoint = AttachPointKind.None;
             character.BroadcastPacket(new SCUnitDetachedPacket(character.ObjId, reason), true);
             WorldIntegration.RelayUnitAttachToZone?.Invoke(character.ObjId, 0, 0, false);
@@ -200,6 +201,7 @@ public class SlaveManager(WorldInstance parentWorldInstance)
         }
 
         character.Buffs.TriggerRemoveOn(BuffRemoveOn.Unmount);
+        character.Buffs.TriggerRemoveOn(BuffRemoveOn.Unbond);
         character.AttachedPoint = AttachPointKind.None;
 
         character.BroadcastPacket(new SCUnitDetachedPacket(character.ObjId, reason), true);
@@ -215,7 +217,7 @@ public class SlaveManager(WorldInstance parentWorldInstance)
     /// <param name="objId"></param>
     /// <param name="attachPoint"></param>
     /// <param name="bondKind"></param>
-    public void BindSlave(Character character, uint objId, AttachPointKind attachPoint, AttachUnitReason bondKind)
+    public void BindSlave(Character character, uint objId, AttachPointKind attachPoint, AttachUnitReason bondKind, int occupySkillId = 0)
     {
         // Check if the target spot is already taken
         var slave = GetSlaveByObjId(objId);
@@ -243,6 +245,8 @@ public class SlaveManager(WorldInstance parentWorldInstance)
                 new SCSlaveBoundPacket(character.Id, slave.MasterWorldId, objId), true);
             if (WorldIntegration.ZoneAuthority && slave.Template.IsABoat())
                 WorldIntegration.RelayShipControlChangeToZone?.Invoke(objId, true);
+            if (occupySkillId > 0 || slave.Template.IsABoat())
+                SlaveOccupyBuffs.ApplyBuffEffects(character, occupySkillId > 0 ? (uint)occupySkillId : 0, slave);
         }
 
         slave.AttachedCharacters.Add(attachPoint, character);

--- a/AAEmu.Game/Core/Managers/TodayAssignmentManager.cs
+++ b/AAEmu.Game/Core/Managers/TodayAssignmentManager.cs
@@ -19,7 +19,7 @@ namespace AAEmu.Game.Core.Managers;
 /// Daily schedule (today_quest_* tables).
 /// Client visuals for Locked: grey until level+cost item (client); green when satisfy.
 /// Flow: LOCKED → Unlock → READY (blue, no quest) → Accept → PROGRESS → DONE.
-/// Paid steps (item cost): unlock once per character; each new day seeds READY again.
+/// Unlock is once per character (item cost only on paid steps). Each new day seeds READY again.
 /// </summary>
 public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
 {
@@ -42,8 +42,7 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
     private readonly Dictionary<uint, uint> _resetsUsed = [];
 
     /// <summary>
-    /// Paid slot unlocks that survive across days (item cost paid once per character).
-    /// Free steps (no item cost) are not stored here.
+    /// Slot unlocks that survive across days (item cost paid once on paid steps).
     /// </summary>
     private readonly Dictionary<uint, HashSet<uint>> _lifetimeUnlocks = [];
 
@@ -455,15 +454,15 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
         }
 
         // Green unlock → blue Ready only (no quest start). Item cost once for paid slots.
-        if (IsPaidStep(step))
+        if (TodayAssignmentUnlockPolicy.MustConsumeItemCost(
+                IsPaidStep(step), HasLifetimeUnlock(character.Id, realStep)))
         {
-            if (!HasLifetimeUnlock(character.Id, realStep))
-            {
-                if (!TryConsumeUnlockCost(character, step, realStep))
-                    return;
-                GrantLifetimeUnlock(character.Id, realStep);
-            }
+            if (!TryConsumeUnlockCost(character, step, realStep))
+                return;
         }
+
+        if (TodayAssignmentUnlockPolicy.GrantLifetimeOnUnlock)
+            GrantLifetimeUnlock(character.Id, realStep);
 
         var state = new ActiveTodayAssignment
         {
@@ -479,7 +478,7 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
         Logger.Info(
             "TodayAssignment unlocked→Ready {0}: realStep={1} group={2} costItem={3}x{4} lifetime={5}",
             character.Name, realStep, group.Id, step.ItemId, step.ItemNum,
-            IsPaidStep(step) && HasLifetimeUnlock(character.Id, realStep));
+            HasLifetimeUnlock(character.Id, realStep));
 
         SendState(character, realStep, state, init: false);
         SendResetCount(character);
@@ -775,7 +774,7 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
                 (int)step.Id,
                 0,
                 0,
-                (sbyte)TodayAssignmentStatus.Locked,
+                (sbyte)TodayAssignmentUnlockPolicy.StatusForNewDay(lifetimeUnlocked: false),
                 init: true));
         }
     }
@@ -970,7 +969,7 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
     }
 
     /// <summary>
-    /// One-time migration: any past daily row for a paid step implies the character already paid.
+    /// One-time migration: any past Ready+ row means the slot was already unlocked.
     /// </summary>
     private void BackfillLifetimeUnlocksFromHistory(Character character)
     {
@@ -991,8 +990,7 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
             while (reader.Read())
             {
                 var realStep = reader.GetUInt32("real_step");
-                var step = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
-                if (!IsPaidStep(step) || HasLifetimeUnlock(character.Id, realStep))
+                if (HasLifetimeUnlock(character.Id, realStep))
                     continue;
 
                 RememberLifetimeUnlock(character.Id, realStep);
@@ -1013,7 +1011,7 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
     }
 
     /// <summary>
-    /// After midnight / first login of the day: paid slots already unlocked sit Ready (blue), not Locked.
+    /// After midnight / first login of the day: previously unlocked slots sit Ready (blue), not Locked.
     /// </summary>
     private void SeedReadyForLifetimeUnlocks(Character character)
     {
@@ -1022,11 +1020,12 @@ public class TodayAssignmentManager : Singleton<TodayAssignmentManager>
 
         foreach (var realStep in unlockedSteps)
         {
-            if (TryGetActive(character.Id, realStep, out _))
+            if (!TodayAssignmentUnlockPolicy.ShouldSeedReady(
+                    lifetimeUnlocked: true, hasTodayRow: TryGetActive(character.Id, realStep, out _)))
                 continue;
 
             var step = TodayQuestGameData.Instance.GetStepByRealStep(realStep);
-            if (step == null || !IsPaidStep(step))
+            if (step == null)
                 continue;
 
             if (!MeetsStepEligibility(character, step, realStep, log: false))

--- a/AAEmu.Game/Core/Managers/World/AreaTriggerManager.cs
+++ b/AAEmu.Game/Core/Managers/World/AreaTriggerManager.cs
@@ -20,6 +20,12 @@ public class AreaTriggerManager : Singleton<AreaTriggerManager>, IAreaTriggerMan
         TickManager.Instance.OnTick.Subscribe(Tick, TimeSpan.FromMilliseconds(200), true);
     }
 
+    /// <summary>
+    /// Keep ticking while the doodad's region has players, or leftover occupants still need leave.
+    /// </summary>
+    public static bool ShouldTick(bool ownerRegionHasPlayers, bool hasOccupants) =>
+        ownerRegionHasPlayers || hasOccupants;
+
     public void AddAreaTrigger(AreaTrigger trigger)
     {
         trigger.Owner?.AttachAreaTriggers.Add(trigger);
@@ -51,9 +57,13 @@ public class AreaTriggerManager : Singleton<AreaTriggerManager>, IAreaTriggerMan
 
             foreach (var trigger in _areaTriggers)
             {
-                // if (trigger.Owner.Position)
-                if (trigger?.Owner?.Region?.HasPlayerActivity() ?? false)
-                    trigger?.Tick(delta);
+                if (trigger == null)
+                    continue;
+                // Idle-region skip is a cost filter. Occupied triggers must still Tick so OnLeave
+                // can strip duration-0 clout buffs after the occupant teleports away.
+                var ownerBusy = trigger.Owner?.Region?.HasPlayerActivity() ?? false;
+                if (ShouldTick(ownerBusy, trigger.HasOccupants))
+                    trigger.Tick(delta);
             }
 
             lock (_remLock)

--- a/AAEmu.Game/Core/Packets/C2G/CSBindSlavePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSBindSlavePacket.cs
@@ -42,6 +42,6 @@ public class CSBindSlavePacket() : GamePacket(CSOffsets.CSBindSlavePacket, 1)
         // Client Tl picks hull (helm) or equipment sail (SlaveKind=8). Seat is always Driver
         // for CSBindSlave; doodad attachments pass AttachPointKind via BindSlave overload.
         character.ParentWorld.SlaveManager.BindSlave(
-            character, slave.ObjId, AttachPointKind.Driver, AttachUnitReason.NewMaster);
+            character, slave.ObjId, AttachPointKind.Driver, AttachUnitReason.NewMaster, skillType);
     }
 }

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -2513,6 +2513,11 @@ public partial class Character : Unit, ICharacter
     {
         base.OnZoneChange(lastZoneKey, newZoneKey); // Unit
 
+        // SphereBuff volumes (dock Moored / Ezi / shipyard) are position-based. A zone-key change
+        // from teleport can leave the old volume without waiting for the next sphere tick.
+        if (lastZoneKey != newZoneKey)
+            Quests?.ReconcileQuestAreaSpheres();
+
         var lastZone = ZoneManager.Instance.GetZoneByKey(lastZoneKey);
         var lastZoneGroupId = (short)(lastZone?.GroupId ?? 0);
         var newZone = ZoneManager.Instance.GetZoneByKey(newZoneKey);

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -13,6 +13,7 @@ using AAEmu.Game.Models.Game.Quests;
 using AAEmu.Game.Models.Game.Quests.Acts;
 using AAEmu.Game.Models.Game.Quests.Static;
 using AAEmu.Game.Models.Game.Quests.Templates;
+using AAEmu.Game.Models.Spheres;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
@@ -807,6 +808,8 @@ public class CharacterQuests(Character owner)
         {
             if (geo.SphereId == 0)
                 continue;
+            if (!CanTriggerQuestAreaSphere(geo.SphereId))
+                continue;
             nowIds.Add(geo.SphereId);
             if (_insideQuestAreaSphereIds.Contains(geo.SphereId))
             {
@@ -855,10 +858,20 @@ public class CharacterQuests(Character owner)
     /// <summary>
     /// While still inside a SphereBuff volume, ensure char + slave_applicable mounts still have the buff.
     /// </summary>
+    private bool CanTriggerQuestAreaSphere(uint sphereId)
+    {
+        var db = SphereGameData.Instance.GetSphere(sphereId);
+        if (db == null)
+            return true;
+        return UnitRequirementsGameData.Instance.CanTriggerSphere(db, Owner);
+    }
+
     private void EnsureSphereBuffWhileInside(uint sphereId)
     {
         var db = SphereGameData.Instance.GetSphere(sphereId);
         if (db?.SphereDetailType != "SphereBuff")
+            return;
+        if (!UnitRequirementsGameData.Instance.CanTriggerSphere(db, Owner))
             return;
         ApplySphereBuff(db.SphereDetailId, enter: true);
     }
@@ -997,15 +1010,18 @@ public class CharacterQuests(Character owner)
             if (detail.BuffId == 0)
                 return;
 
-            if (!Owner.Buffs.CheckBuff(detail.BuffId))
+            var buffTemplate = SkillManager.Instance.GetBuffTemplate(detail.BuffId);
+            var slaveApplicable = buffTemplate?.SlaveApplicable == true;
+
+            if (SphereBuffTargets.ApplyToCharacter(slaveApplicable) &&
+                !Owner.Buffs.CheckBuff(detail.BuffId))
             {
                 Owner.Buffs.AddBuff(detail.BuffId, Owner);
                 Logger.Info("SphereBuff APPLY char={0} buff={1} detail={2}", Owner.Name, detail.BuffId, sphereBuffDetailId);
             }
 
-            // slave_applicable: Moored (13817) HealthRegen+200 and Ezi (13816) collision/speed mods
-            // belong on the hull. Character-only application left ships with formula regen ~0.
-            ApplySphereBuffToOwnedMounts(detail.BuffId, detail.AndPet, add: true, sphereBuffDetailId);
+            if (SphereBuffTargets.ApplyToSlave(slaveApplicable))
+                ApplySphereBuffToOwnedMounts(detail.BuffId, detail.AndPet, add: true, sphereBuffDetailId);
             return;
         }
 
@@ -1013,6 +1029,7 @@ public class CharacterQuests(Character owner)
         if (removeId == 0)
             return;
 
+        // Always strip leftover character copies (older sessions applied hull buffs to the PC).
         if (Owner.Buffs.CheckBuff(removeId))
         {
             Owner.Buffs.RemoveBuff(removeId);
@@ -1032,6 +1049,8 @@ public class CharacterQuests(Character owner)
         {
             var db = SphereGameData.Instance.GetSphere(sphereId);
             if (db?.SphereDetailType != "SphereBuff")
+                continue;
+            if (!UnitRequirementsGameData.Instance.CanTriggerSphere(db, Owner))
                 continue;
             var detail = SphereGameData.Instance.GetSphereBuff(db.SphereDetailId);
             if (detail == null || detail.BuffId == 0)

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -1020,7 +1020,8 @@ public class CharacterQuests(Character owner)
                 Logger.Info("SphereBuff APPLY char={0} buff={1} detail={2}", Owner.Name, detail.BuffId, sphereBuffDetailId);
             }
 
-            if (SphereBuffTargets.ApplyToSlave(slaveApplicable))
+            // The helper gates hulls on slave_applicable itself; and_pet is independent of that.
+            if (SphereBuffTargets.ApplyToOwnedMounts(slaveApplicable, detail.AndPet))
                 ApplySphereBuffToOwnedMounts(detail.BuffId, detail.AndPet, add: true, sphereBuffDetailId);
             return;
         }

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadFunc.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadFunc.cs
@@ -20,7 +20,8 @@ public class DoodadFunc
     public void Use(BaseUnit caster, Doodad owner, uint skillId = 0, int nextPhase = 0)
     {
         var template = DoodadManager.Instance.GetFuncTemplate(FuncId, FuncType);
-
-        template?.Use(caster, owner, skillId, nextPhase);
+        // Helm attachments store occupy skill on doodad_funcs.func_skill_id; F-use often arrives with skillId 0.
+        var appliedSkill = skillId != 0 ? skillId : SkillId;
+        template?.Use(caster, owner, appliedSkill, nextPhase);
     }
 }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncAttachment.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncAttachment.cs
@@ -39,7 +39,9 @@ public class DoodadFuncAttachment : DoodadFuncTemplate
             // Ships // TODO Check how sit on the ship
             else
             {
-                character.ParentWorld.SlaveManager.BindSlave(character, owner.ParentObjId, AttachPointId, AttachUnitReason.BoardTransfer);
+                character.ParentWorld.SlaveManager.BindSlave(
+                    character, owner.ParentObjId, AttachPointId, AttachUnitReason.BoardTransfer,
+                    occupySkillId: (int)skillId);
             }
         }
     }

--- a/AAEmu.Game/Models/Game/Slaves/SlaveOccupyBuffs.cs
+++ b/AAEmu.Game/Models/Game/Slaves/SlaveOccupyBuffs.cs
@@ -1,0 +1,95 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Effects;
+using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Models.Game.Slaves;
+
+/// <summary>
+/// Helm occupy skills apply BuffEffects (Captain's Intuition / helm protection) on the driver.
+/// ZoneAuthority CSStartSkill does not reliably land those on the PC, so BindSlave reapplies
+/// BuffEffect rows only (not InteractionEffect — bind already happened).
+/// </summary>
+public static class SlaveOccupyBuffs
+{
+    public static IEnumerable<uint> BuffIdsFromSkill(SkillTemplate template)
+    {
+        if (template?.Effects == null)
+            yield break;
+        foreach (var effect in template.Effects)
+        {
+            if (effect?.Template is BuffEffect buffEffect && buffEffect.Buff != null)
+                yield return buffEffect.Buff.Id;
+        }
+    }
+
+    public static uint ResolveOccupySkillId(uint packetSkillId, Slave slave)
+    {
+        if (HasBuffEffects(packetSkillId))
+            return packetSkillId;
+
+        if (slave?.AttachedDoodads == null)
+            return packetSkillId;
+
+        foreach (var doodad in slave.AttachedDoodads)
+        {
+            if (doodad == null)
+                continue;
+            foreach (var func in DoodadManager.Instance.GetFuncsForGroup(doodad.FuncGroupId))
+            {
+                if (func.FuncType != "DoodadFuncAttachment" || func.SkillId == 0)
+                    continue;
+                if (HasBuffEffects(func.SkillId))
+                    return func.SkillId;
+            }
+        }
+
+        return packetSkillId;
+    }
+
+    public static void ApplyBuffEffects(Character character, uint occupySkillId, Slave slave = null)
+    {
+        if (character == null)
+            return;
+
+        var skillId = ResolveOccupySkillId(occupySkillId, slave);
+        if (skillId == 0)
+            return;
+
+        var template = SkillManager.Instance.GetSkillTemplate(skillId);
+        if (template == null)
+            return;
+
+        var caster = SkillCaster.GetByType(SkillCasterType.Unit);
+        caster.ObjId = character.ObjId;
+        var target = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
+        target.ObjId = character.ObjId;
+        var skill = new Skill(template) { SuppressZoneSkillRelay = true };
+
+        foreach (var effect in template.Effects)
+        {
+            if (effect?.Template is not BuffEffect)
+                continue;
+            effect.Template.Apply(
+                character,
+                caster,
+                character,
+                target,
+                new CastSkill(template.Id, 0),
+                new EffectSource(skill),
+                new SkillObject(),
+                DateTime.UtcNow);
+        }
+    }
+
+    private static bool HasBuffEffects(uint skillId)
+    {
+        if (skillId == 0)
+            return false;
+        var template = SkillManager.Instance.GetSkillTemplate(skillId);
+        return BuffIdsFromSkill(template).Any();
+    }
+}

--- a/AAEmu.Game/Models/Game/Slaves/SlaveOccupyBuffs.cs
+++ b/AAEmu.Game/Models/Game/Slaves/SlaveOccupyBuffs.cs
@@ -1,6 +1,8 @@
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.DoodadObj.Funcs;
+using AAEmu.Game.Models.Game.DoodadObj.Static;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Skills.Templates;
@@ -27,8 +29,8 @@ public static class SlaveOccupyBuffs
     }
 
     /// <summary>
-    /// Occupy skill must be listed on this hull's helm doodad attachments. A client BindSlave
-    /// skillType is only used when it matches that list; otherwise the first helm occupy skill
+    /// Occupy skill must be a Driver-seat helm attachment on this hull. A client BindSlave
+    /// skillType is only used when it matches that list; otherwise the first Driver occupy skill
     /// is used. Unknown/empty list → 0 (no buffs).
     /// </summary>
     public static uint ResolveOccupySkillId(uint packetSkillId, IReadOnlyList<uint> allowedOccupySkillIds)
@@ -51,6 +53,13 @@ public static class SlaveOccupyBuffs
     public static uint ResolveOccupySkillId(uint packetSkillId, Slave slave)
         => ResolveOccupySkillId(packetSkillId, HelmOccupySkillIds(slave).ToList());
 
+    /// <summary>
+    /// CSBindSlave always seats Driver. Only doodad_func_attachments whose seat is Driver
+    /// may contribute occupy buffs (helm wheels); cannon/passenger/mast attachments must not.
+    /// </summary>
+    public static bool IsDriverOccupySeat(AttachPointKind attachPoint)
+        => attachPoint == AttachPointKind.Driver;
+
     public static IEnumerable<uint> HelmOccupySkillIds(Slave slave)
     {
         if (slave?.AttachedDoodads == null)
@@ -63,6 +72,10 @@ public static class SlaveOccupyBuffs
             foreach (var func in DoodadManager.Instance.GetFuncsForGroup(doodad.FuncGroupId))
             {
                 if (func.FuncType != "DoodadFuncAttachment" || func.SkillId == 0)
+                    continue;
+                if (DoodadManager.Instance.GetFuncTemplate(func.FuncId, func.FuncType) is not DoodadFuncAttachment attach)
+                    continue;
+                if (!IsDriverOccupySeat(attach.AttachPointId))
                     continue;
                 if (HasBuffEffects(func.SkillId))
                     yield return func.SkillId;

--- a/AAEmu.Game/Models/Game/Slaves/SlaveOccupyBuffs.cs
+++ b/AAEmu.Game/Models/Game/Slaves/SlaveOccupyBuffs.cs
@@ -26,13 +26,35 @@ public static class SlaveOccupyBuffs
         }
     }
 
-    public static uint ResolveOccupySkillId(uint packetSkillId, Slave slave)
+    /// <summary>
+    /// Occupy skill must be listed on this hull's helm doodad attachments. A client BindSlave
+    /// skillType is only used when it matches that list; otherwise the first helm occupy skill
+    /// is used. Unknown/empty list → 0 (no buffs).
+    /// </summary>
+    public static uint ResolveOccupySkillId(uint packetSkillId, IReadOnlyList<uint> allowedOccupySkillIds)
     {
-        if (HasBuffEffects(packetSkillId))
-            return packetSkillId;
+        if (allowedOccupySkillIds == null || allowedOccupySkillIds.Count == 0)
+            return 0;
 
+        if (packetSkillId != 0)
+        {
+            for (var i = 0; i < allowedOccupySkillIds.Count; i++)
+            {
+                if (allowedOccupySkillIds[i] == packetSkillId)
+                    return packetSkillId;
+            }
+        }
+
+        return allowedOccupySkillIds[0];
+    }
+
+    public static uint ResolveOccupySkillId(uint packetSkillId, Slave slave)
+        => ResolveOccupySkillId(packetSkillId, HelmOccupySkillIds(slave).ToList());
+
+    public static IEnumerable<uint> HelmOccupySkillIds(Slave slave)
+    {
         if (slave?.AttachedDoodads == null)
-            return packetSkillId;
+            yield break;
 
         foreach (var doodad in slave.AttachedDoodads)
         {
@@ -43,11 +65,9 @@ public static class SlaveOccupyBuffs
                 if (func.FuncType != "DoodadFuncAttachment" || func.SkillId == 0)
                     continue;
                 if (HasBuffEffects(func.SkillId))
-                    return func.SkillId;
+                    yield return func.SkillId;
             }
         }
-
-        return packetSkillId;
     }
 
     public static void ApplyBuffEffects(Character character, uint occupySkillId, Slave slave = null)

--- a/AAEmu.Game/Models/Game/TodayAssignment/TodayAssignmentUnlockPolicy.cs
+++ b/AAEmu.Game/Models/Game/TodayAssignment/TodayAssignmentUnlockPolicy.cs
@@ -1,0 +1,23 @@
+namespace AAEmu.Game.Models.Game.TodayAssignment;
+
+/// <summary>
+/// Slot unlocks persist for the character. Daily reset drops quest progress only;
+/// previously unlocked slots come back Ready (blue), not Locked (green).
+/// </summary>
+public static class TodayAssignmentUnlockPolicy
+{
+    /// <summary>Any successful unlock (free or paid) is remembered for the character.</summary>
+    public static bool GrantLifetimeOnUnlock => true;
+
+    public static bool MustConsumeItemCost(bool isPaidStep, bool alreadyLifetimeUnlocked)
+        => isPaidStep && !alreadyLifetimeUnlocked;
+
+    /// <summary>
+    /// New UTC day with no today-row yet: lifetime-unlocked → Ready, never unlocked → Locked.
+    /// </summary>
+    public static TodayAssignmentStatus StatusForNewDay(bool lifetimeUnlocked)
+        => lifetimeUnlocked ? TodayAssignmentStatus.Ready : TodayAssignmentStatus.Locked;
+
+    public static bool ShouldSeedReady(bool lifetimeUnlocked, bool hasTodayRow)
+        => lifetimeUnlocked && !hasTodayRow;
+}

--- a/AAEmu.Game/Models/Game/Units/UnitReqNation.cs
+++ b/AAEmu.Game/Models/Game/Units/UnitReqNation.cs
@@ -1,0 +1,18 @@
+namespace AAEmu.Game.Models.Game.Units;
+
+/// <summary>
+/// Nation / mother-faction identity for unit_reqs. Race factions (Nuian 101, …) resolve to
+/// their alliance (Nuia 148 / Haranya 149); alliance rows keep their own id when mother is 0.
+/// </summary>
+public static class UnitReqNation
+{
+    public static uint EffectiveNationId(uint factionId, uint motherId)
+        => motherId != 0 ? motherId : factionId;
+
+    /// <summary>
+    /// <c>nation_member</c> with value1=0: character's nation must match the zone's faction
+    /// (west zones 148, east 149). Empty zone faction never matches.
+    /// </summary>
+    public static bool IsNationMemberOfZone(uint effectiveNationId, uint zoneFactionId)
+        => zoneFactionId != 0 && effectiveNationId == zoneFactionId;
+}

--- a/AAEmu.Game/Models/Game/Units/UnitReqs.cs
+++ b/AAEmu.Game/Models/Game/Units/UnitReqs.cs
@@ -310,7 +310,7 @@ public class UnitReqs
                 return Ret(SkillResultKeys.skill_urk_tod, currentTime >= Value1 && currentTime <= Value2);
 
             case UnitReqsKindType.MotherFaction:
-                return Ret(SkillResultKeys.skill_urk_mother_faction, (uint)(unit?.Faction.MotherId ?? 0) == Value1);
+                return Ret(SkillResultKeys.skill_urk_mother_faction, EffectiveNationId(unit) == Value1);
 
             case UnitReqsKindType.ActAbilityPoint:
                 return RetWithValue(SkillResultKeys.skill_urk_actability_point, Value1,
@@ -366,17 +366,19 @@ public class UnitReqs
                 return RetWithValue(SkillResultKeys.skill_urk_faction_match_only, Value1, (uint)(unit?.Faction?.Id ?? 0) == Value1);
 
             case UnitReqsKindType.MotherFactionOnly:
-                // Is this the same as UnitReqsKindType.MotherFaction ? 
-                return Ret(SkillResultKeys.skill_urk_mother_faction_only, (uint)(unit?.Faction?.MotherId ?? 0) == Value1);
+                return Ret(SkillResultKeys.skill_urk_mother_faction_only, EffectiveNationId(unit) == Value1);
 
             case UnitReqsKindType.FactionMatchOnlyNot:
                 return Ret(SkillResultKeys.skill_urk_faction_match_only_not, (uint)(unit?.Faction?.Id ?? 0) != Value1);
 
             case UnitReqsKindType.MotherFactionOnlyNot:
-                return Ret(SkillResultKeys.skill_urk_mother_faction_only_not, (uint)(unit?.Faction?.MotherId ?? 0) != Value1);
+                return Ret(SkillResultKeys.skill_urk_mother_faction_only_not, EffectiveNationId(unit) != Value1);
 
-            // case UnitReqsKindType.NationMember:
-            // case UnitReqsKindType.NationMemberNot:
+            case UnitReqsKindType.NationMember:
+                return Ret(SkillResultKeys.skill_urk_nation_member, IsNationMemberOfCurrentZone(owner, unit));
+
+            case UnitReqsKindType.NationMemberNot:
+                return Ret(SkillResultKeys.skill_urk_nation_member_not, !IsNationMemberOfCurrentZone(owner, unit));
             // case UnitReqsKindType.DominionMemberAtPos:
             // case UnitReqsKindType.DominionMemberAtPosNot:
             // case UnitReqsKindType.Housing:
@@ -659,6 +661,22 @@ public class UnitReqs
                 "Unsupported UnitReq blocked: id={0} owner={1}:{2} kind={3} values={4},{5},{6}",
                 Id, OwnerType, OwnerId, KindType, Value1, Value2, Value3);
             return new UnitReqsValidationResult(SkillResultKeys.skill_urk_unknown, 0, 0);
+        }
+
+        static uint EffectiveNationId(Unit unit)
+        {
+            var factionId = (uint)(unit?.Faction?.Id ?? 0);
+            var motherId = (uint)(unit?.Faction?.MotherId ?? 0);
+            return UnitReqNation.EffectiveNationId(factionId, motherId);
+        }
+
+        static bool IsNationMemberOfCurrentZone(BaseUnit owner, Unit unit)
+        {
+            var zone = owner?.Transform != null
+                ? ZoneManager.Instance.GetZoneByKey(owner.Transform.ZoneId)
+                : null;
+            var zoneFaction = (uint)(zone?.FactionId ?? 0);
+            return UnitReqNation.IsNationMemberOfZone(EffectiveNationId(unit), zoneFaction);
         }
     }
 }

--- a/AAEmu.Game/Models/Game/World/AreaTrigger.cs
+++ b/AAEmu.Game/Models/Game/World/AreaTrigger.cs
@@ -34,6 +34,12 @@ public class AreaTrigger
     public int TickRate { get; set; }
     private DateTime _lastTick = DateTime.MinValue;
 
+    /// <summary>
+    /// True while at least one unit still has this trigger's inside-buff. The owner region may
+    /// already be idle (player teleported away); the manager must keep ticking until leave runs.
+    /// </summary>
+    public bool HasOccupants => TriggeredUnits.Count > 0;
+
     private void UpdateUnits()
     {
         if (Owner == null || Shape == null || !Owner.IsVisible)
@@ -43,11 +49,7 @@ public class AreaTrigger
         }
 
         // Get units currently in the shape
-        var currentUnitsInShape = WorldManager.GetAroundByShape<Unit>(Owner, Shape);
-        if (currentUnitsInShape == null)
-        {
-            return;
-        }
+        var currentUnitsInShape = WorldManager.GetAroundByShape<Unit>(Owner, Shape) ?? [];
 
         // Check who left since last check
         var leftUnits = Units?.Where(oldU => currentUnitsInShape.All(newU => oldU.ObjId != newU.ObjId)) ?? [];

--- a/AAEmu.Game/Models/Spheres/SphereBuffTargets.cs
+++ b/AAEmu.Game/Models/Spheres/SphereBuffTargets.cs
@@ -1,0 +1,12 @@
+namespace AAEmu.Game.Models.Spheres;
+
+/// <summary>
+/// Harbor SphereBuff routing. Compact <c>slave_applicable</c> is the gate: dock regen / Ezi
+/// blessing sit on the hull; shipyard-allowed sits on the character.
+/// </summary>
+public static class SphereBuffTargets
+{
+    public static bool ApplyToCharacter(bool slaveApplicable) => !slaveApplicable;
+
+    public static bool ApplyToSlave(bool slaveApplicable) => slaveApplicable;
+}

--- a/AAEmu.Game/Models/Spheres/SphereBuffTargets.cs
+++ b/AAEmu.Game/Models/Spheres/SphereBuffTargets.cs
@@ -9,4 +9,11 @@ public static class SphereBuffTargets
     public static bool ApplyToCharacter(bool slaveApplicable) => !slaveApplicable;
 
     public static bool ApplyToSlave(bool slaveApplicable) => slaveApplicable;
+
+    /// <summary>
+    /// Whether the owned-mount pass runs at all. Pets follow <c>and_pet</c> on their own;
+    /// a character-only buff with <c>and_pet</c> still has to reach a pet that is already out.
+    /// </summary>
+    public static bool ApplyToOwnedMounts(bool slaveApplicable, bool andPet) =>
+        slaveApplicable || andPet;
 }

--- a/AAEmu.UnitTests/Game/Core/Managers/World/AreaTriggerManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/World/AreaTriggerManagerTests.cs
@@ -1,0 +1,23 @@
+using AAEmu.Game.Core.Managers.World;
+
+namespace AAEmu.UnitTests.Game.Core.Managers.World;
+
+/// <summary>
+/// Occupied doodad clouts (duration 0) must keep ticking after the owner region goes idle,
+/// otherwise leave never runs and the inside-buff sticks on the player.
+/// </summary>
+public class AreaTriggerManagerTests
+{
+    [Test]
+    [Arguments(true, false, true)]
+    [Arguments(true, true, true)]
+    [Arguments(false, true, true)]
+    [Arguments(false, false, false)]
+    public async Task ShouldTick_KeepsOccupiedTriggersAliveWhenRegionIsIdle(
+        bool ownerRegionHasPlayers, bool hasOccupants, bool expected)
+    {
+        var tick = AreaTriggerManager.ShouldTick(ownerRegionHasPlayers, hasOccupants);
+
+        await Assert.That(tick).IsEqualTo(expected);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Slaves/SlaveOccupyBuffsTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Slaves/SlaveOccupyBuffsTests.cs
@@ -51,4 +51,21 @@ public class SlaveOccupyBuffsTests
 
         await Assert.That(SlaveOccupyBuffs.BuffIdsFromSkill(template).Any()).IsFalse();
     }
+
+    [Test]
+    public async Task ResolveOccupySkillId_IgnoresPacketSkillNotOnTheHull()
+    {
+        uint[] helm = [28472];
+
+        await Assert.That(SlaveOccupyBuffs.ResolveOccupySkillId(99999, helm)).IsEqualTo(28472u);
+        await Assert.That(SlaveOccupyBuffs.ResolveOccupySkillId(28472, helm)).IsEqualTo(28472u);
+        await Assert.That(SlaveOccupyBuffs.ResolveOccupySkillId(12076, helm)).IsEqualTo(28472u);
+    }
+
+    [Test]
+    public async Task ResolveOccupySkillId_EmptyHullAppliesNothing()
+    {
+        await Assert.That(SlaveOccupyBuffs.ResolveOccupySkillId(28472, [])).IsEqualTo(0u);
+        await Assert.That(SlaveOccupyBuffs.ResolveOccupySkillId(28472, (IReadOnlyList<uint>)null)).IsEqualTo(0u);
+    }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/Slaves/SlaveOccupyBuffsTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Slaves/SlaveOccupyBuffsTests.cs
@@ -22,6 +22,26 @@ public class SphereBuffTargetsTests
         await Assert.That(SphereBuffTargets.ApplyToCharacter(slaveApplicable: false)).IsTrue();
         await Assert.That(SphereBuffTargets.ApplyToSlave(slaveApplicable: false)).IsFalse();
     }
+
+    [Test]
+    public async Task CharacterBuffWithAndPetStillReachesAnAlreadySummonedPet()
+    {
+        // sphere 2325 -> SphereBuff 15 -> buff 13789: and_pet=true, slave_applicable=false
+        await Assert.That(SphereBuffTargets.ApplyToOwnedMounts(slaveApplicable: false, andPet: true)).IsTrue();
+        await Assert.That(SphereBuffTargets.ApplyToSlave(slaveApplicable: false)).IsFalse();
+    }
+
+    [Test]
+    public async Task HullBuffRunsTheMountPassWithoutAndPet()
+    {
+        await Assert.That(SphereBuffTargets.ApplyToOwnedMounts(slaveApplicable: true, andPet: false)).IsTrue();
+    }
+
+    [Test]
+    public async Task CharacterOnlyBuffSkipsTheMountPass()
+    {
+        await Assert.That(SphereBuffTargets.ApplyToOwnedMounts(slaveApplicable: false, andPet: false)).IsFalse();
+    }
 }
 
 public class SlaveOccupyBuffsTests

--- a/AAEmu.UnitTests/Game/Models/Game/Slaves/SlaveOccupyBuffsTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Slaves/SlaveOccupyBuffsTests.cs
@@ -1,0 +1,54 @@
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Effects;
+using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Slaves;
+using AAEmu.Game.Models.Spheres;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Slaves;
+
+public class SphereBuffTargetsTests
+{
+    [Test]
+    public async Task HarborHullBuffsDoNotSitOnTheCharacter()
+    {
+        await Assert.That(SphereBuffTargets.ApplyToCharacter(slaveApplicable: true)).IsFalse();
+        await Assert.That(SphereBuffTargets.ApplyToSlave(slaveApplicable: true)).IsTrue();
+    }
+
+    [Test]
+    public async Task ShipyardAllowedSitsOnTheCharacter()
+    {
+        await Assert.That(SphereBuffTargets.ApplyToCharacter(slaveApplicable: false)).IsTrue();
+        await Assert.That(SphereBuffTargets.ApplyToSlave(slaveApplicable: false)).IsFalse();
+    }
+}
+
+public class SlaveOccupyBuffsTests
+{
+    [Test]
+    public async Task BuffIdsFromSkill_SkipsNonBuffEffects()
+    {
+        var template = new SkillTemplate
+        {
+            Id = 28472,
+            Effects =
+            [
+                new SkillEffect { Template = new InteractionEffect() },
+                new SkillEffect { Template = new BuffEffect { Buff = new BuffTemplate { Id = 4690 } } },
+                new SkillEffect { Template = new BuffEffect { Buff = new BuffTemplate { Id = 11064 } } }
+            ]
+        };
+
+        var ids = SlaveOccupyBuffs.BuffIdsFromSkill(template).ToList();
+
+        await Assert.That(ids).IsEquivalentTo(new uint[] { 4690, 11064 });
+    }
+
+    [Test]
+    public async Task BuffIdsFromSkill_EmptyWhenOccupyHasNoBuffs()
+    {
+        var template = new SkillTemplate { Id = 12076, Effects = [] };
+
+        await Assert.That(SlaveOccupyBuffs.BuffIdsFromSkill(template).Any()).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Slaves/SlaveOccupyBuffsTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Slaves/SlaveOccupyBuffsTests.cs
@@ -1,3 +1,4 @@
+using AAEmu.Game.Models.Game.DoodadObj.Static;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Skills.Templates;
@@ -67,5 +68,14 @@ public class SlaveOccupyBuffsTests
     {
         await Assert.That(SlaveOccupyBuffs.ResolveOccupySkillId(28472, [])).IsEqualTo(0u);
         await Assert.That(SlaveOccupyBuffs.ResolveOccupySkillId(28472, (IReadOnlyList<uint>)null)).IsEqualTo(0u);
+    }
+
+    [Test]
+    public async Task IsDriverOccupySeat_RejectsPassengerAndCannon()
+    {
+        await Assert.That(SlaveOccupyBuffs.IsDriverOccupySeat(AttachPointKind.Driver)).IsTrue();
+        await Assert.That(SlaveOccupyBuffs.IsDriverOccupySeat(AttachPointKind.Passenger0)).IsFalse();
+        await Assert.That(SlaveOccupyBuffs.IsDriverOccupySeat(AttachPointKind.Cannon0)).IsFalse();
+        await Assert.That(SlaveOccupyBuffs.IsDriverOccupySeat(AttachPointKind.Mast0)).IsFalse();
     }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/TodayAssignment/TodayAssignmentUnlockPolicyTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/TodayAssignment/TodayAssignmentUnlockPolicyTests.cs
@@ -1,0 +1,42 @@
+using AAEmu.Game.Models.Game.TodayAssignment;
+
+namespace AAEmu.UnitTests.Game.Models.Game.TodayAssignment;
+
+public class TodayAssignmentUnlockPolicyTests
+{
+    [Test]
+    public async Task NewDay_LifetimeUnlocked_IsReadyNotLocked()
+    {
+        await Assert.That(TodayAssignmentUnlockPolicy.StatusForNewDay(lifetimeUnlocked: true))
+            .IsEqualTo(TodayAssignmentStatus.Ready);
+        await Assert.That(TodayAssignmentUnlockPolicy.ShouldSeedReady(true, hasTodayRow: false))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task NewDay_NeverUnlocked_StaysLocked()
+    {
+        await Assert.That(TodayAssignmentUnlockPolicy.StatusForNewDay(lifetimeUnlocked: false))
+            .IsEqualTo(TodayAssignmentStatus.Locked);
+        await Assert.That(TodayAssignmentUnlockPolicy.ShouldSeedReady(false, hasTodayRow: false))
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task NewDay_DoesNotOverwriteTodaysRow()
+    {
+        await Assert.That(TodayAssignmentUnlockPolicy.ShouldSeedReady(true, hasTodayRow: true))
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task ItemCost_OnlyOnceOnPaidSteps()
+    {
+        await Assert.That(TodayAssignmentUnlockPolicy.MustConsumeItemCost(true, alreadyLifetimeUnlocked: false))
+            .IsTrue();
+        await Assert.That(TodayAssignmentUnlockPolicy.MustConsumeItemCost(true, alreadyLifetimeUnlocked: true))
+            .IsFalse();
+        await Assert.That(TodayAssignmentUnlockPolicy.MustConsumeItemCost(false, alreadyLifetimeUnlocked: false))
+            .IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Units/UnitReqNationTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Units/UnitReqNationTests.cs
@@ -1,0 +1,40 @@
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.StaticValues;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Units;
+
+public class UnitReqNationTests
+{
+    [Test]
+    public async Task RaceFactionResolvesToAlliance()
+    {
+        await Assert.That(UnitReqNation.EffectiveNationId((uint)FactionsEnum.Nuian, (uint)FactionsEnum.NuiaAlliance))
+            .IsEqualTo((uint)FactionsEnum.NuiaAlliance);
+        await Assert.That(UnitReqNation.EffectiveNationId((uint)FactionsEnum.Firran, (uint)FactionsEnum.HaranyaAlliance))
+            .IsEqualTo((uint)FactionsEnum.HaranyaAlliance);
+    }
+
+    [Test]
+    public async Task AllianceWithNoMotherKeepsItsId()
+    {
+        await Assert.That(UnitReqNation.EffectiveNationId((uint)FactionsEnum.NuiaAlliance, 0))
+            .IsEqualTo((uint)FactionsEnum.NuiaAlliance);
+    }
+
+    [Test]
+    public async Task WesternCharacterIsNotEastZoneNationMember()
+    {
+        var west = UnitReqNation.EffectiveNationId((uint)FactionsEnum.Nuian, (uint)FactionsEnum.NuiaAlliance);
+        await Assert.That(UnitReqNation.IsNationMemberOfZone(west, (uint)FactionsEnum.HaranyaAlliance))
+            .IsFalse();
+        await Assert.That(UnitReqNation.IsNationMemberOfZone(west, (uint)FactionsEnum.NuiaAlliance))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task EmptyZoneFactionNeverMatches()
+    {
+        await Assert.That(UnitReqNation.IsNationMemberOfZone((uint)FactionsEnum.NuiaAlliance, 0))
+            .IsFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Harbor SphereBuffs: hull vs character from `slave_applicable`; apply only when sphere `unit_reqs` pass (nation / mother faction vs zone).
- Helm occupy: apply doodad occupy BuffEffects (Captain's Intuition / helm protection) on BindSlave; strip on Unbond.
- Area clout: keep ticking occupied triggers after teleport so duration-0 leave buffs clear; reconcile spheres on zone change.
- Daily contracts: lifetime unlock for every slot (not paid-only); UTC reset reseeds Ready (blue), not Locked (green).

## Test plan
- [ ] Grab helm → Captain's Intuition while steering; leaves on unbind
- [ ] Western dock: shipyard-allowed on character; Moored/Ezi on hull only
- [ ] Western character in Eastern harbor: no those buffs
- [ ] Teleport out of a duration-0 clout (e.g. Abyssal Curse) → buff drops
- [ ] Daily contracts already unlocked stay blue after UTC reset


Made with [Cursor](https://cursor.com)