### PR TITLE
feat(world): zone-authority sim, stream AOI, helm persist

### DIFF
--- a/AAEmu.Game/AAEmu.Game.csproj
+++ b/AAEmu.Game/AAEmu.Game.csproj
@@ -55,6 +55,9 @@
     <None Update="Configurations\TowerDefs.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Configurations\StreamAoi.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Configurations\InitialConfig.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/AAEmu.Game/Configurations/StreamAoi.json
+++ b/AAEmu.Game/Configurations/StreamAoi.json
@@ -1,0 +1,10 @@
+{
+  "StreamAoi": {
+    "Ambient": { "EnterMetres": 105, "ExitMetres": 110 },
+    "Large": { "EnterMetres": 225, "ExitMetres": 248 },
+    "Ship": { "EnterMetres": 225, "ExitMetres": 248 },
+    "Event": { "EnterMetres": 700, "ExitMetres": 700 },
+    "LargeNpcTemplateIds": [ 7607, 14915 ],
+    "LargeModelIds": [ 897, 530 ]
+  }
+}

--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -87,7 +87,7 @@ public class ItemManager(ISkillManager skillManager, IItemIdManager itemIdManage
 
     public ItemTemplate GetTemplate(uint id)
     {
-        return _templates.GetValueOrDefault(id);
+        return _templates?.GetValueOrDefault(id);
     }
 
     public int? GetShopPrice(uint itemId, ShopCurrencyType currency)

--- a/AAEmu.Game/Core/Managers/SlaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SlaveManager.cs
@@ -44,6 +44,12 @@ public class SlaveManager(WorldInstance parentWorldInstance)
     private const float HeadingSweepStepRadians = MathF.PI / 12f; // 15°
 
     /// <summary>
+    /// Water surfaces more than this above the caster are treated as bad polygons / sky lakes
+    /// (Cinderstone inland hits), not a legal hull spawn.
+    /// </summary>
+    public const float MaxBoatSurfaceAboveCasterMetres = 8f;
+
+    /// <summary>
     /// Water surface at a position, resolved from the ingested bodies themselves.
     /// </summary>
     /// <remarks>
@@ -74,6 +80,36 @@ public class SlaveManager(WorldInstance parentWorldInstance)
 
         return float.IsNaN(best) ? world.Water.OceanLevel : best;
     }
+
+    /// <summary>Unit forward alignment of a probe relative to the caster (1 = dead ahead, -1 = behind).</summary>
+    public static float BoatSpawnForwardDot(Vector3 caster, float casterYaw, Vector3 probe)
+    {
+        var fx = -MathF.Sin(casterYaw);
+        var fy = MathF.Cos(casterYaw);
+        var dx = probe.X - caster.X;
+        var dy = probe.Y - caster.Y;
+        var len = MathF.Sqrt(dx * dx + dy * dy);
+        if (len < 0.001f)
+            return 1f;
+        return (dx * fx + dy * fy) / len;
+    }
+
+    /// <summary>
+    /// Navigable depth under the hull, and reject sky/inland water polygons far above the caster.
+    /// </summary>
+    public static bool IsBoatSurfaceAllowed(float casterZ, float surfaceZ, float floorZ, float minDepth)
+    {
+        if (surfaceZ - floorZ <= minDepth)
+            return false;
+        // High inland hit (floor and surface both above the caster) — not coastal ocean below.
+        if (surfaceZ > casterZ + MaxBoatSurfaceAboveCasterMetres && floorZ > casterZ + 2f)
+            return false;
+        return true;
+    }
+
+    /// <summary>Higher is better: prefer ahead of the caster and near the template forward offset.</summary>
+    public static float ScoreBoatSpawnCandidate(float forwardDot, float distance, float preferredDistance) =>
+        forwardDot * 100f - MathF.Abs(distance - preferredDistance);
 
     public Slave GetActiveSlaveByOwnerObjId(uint objId)
     {
@@ -206,8 +242,8 @@ public class SlaveManager(WorldInstance parentWorldInstance)
 
         character.BroadcastPacket(new SCUnitDetachedPacket(character.ObjId, reason), true);
         WorldIntegration.RelayUnitAttachToZone?.Invoke(character.ObjId, slave.ObjId, (byte)attachPoint, false);
-        if (WorldIntegration.ZoneAuthority && attachPoint == AttachPointKind.Driver && slave.Template.IsABoat())
-            WorldIntegration.RelayShipControlChangeToZone?.Invoke(slave.ObjId, false);
+        // Helm leave does not send WZShipControlChange control=0. That flag is the zone's ship
+        // physics/wave gate: turning it off freezes the hull. Keep sim on until WithdrawBoatFromZone.
     }
 
     /// <summary>
@@ -542,7 +578,7 @@ public class SlaveManager(WorldInstance parentWorldInstance)
             // If no spawn position override has been provided, then handle normal spawning algorithm
 
             // owner.SendMessage("SlaveSpawnOffset: x:{0} y:{1}", slaveTemplate.SpawnXOffset, slaveTemplate.SpawnYOffset);
-            if (owner != null)
+            if (owner != null && !slaveTemplate.IsABoat())
             {
                 spawnPos.Local.AddDistanceToFront(Math.Clamp(slaveTemplate.SpawnYOffset, 5f, 50f));
             }
@@ -558,13 +594,14 @@ public class SlaveManager(WorldInstance parentWorldInstance)
                     return null;
                 }
 
-                // Probe from where the caster stands. Water bodies are only reported to callers at or
-                // above their own floor, so sampling after the hull has been dropped to sea level makes
-                // every lake and river sit unreachably far above the query and read as open ocean.
-                var casterLevelPos = spawnPos.World.Position;
+                // Sweep from the caster's feet — not from an already-advanced "front" point.
+                // Advancing first aimed the search inland when facing shore, so the first hit was
+                // often behind the player (or a high inland water polygon → hull in the sky).
+                var casterLevelPos = owner?.Transform.World.Position ?? spawnPos.World.Position;
+                var casterYaw = owner?.Transform.World.Rotation.Z ?? spawnPos.World.Rotation.Z;
+                var forwardOffset = Math.Clamp(slaveTemplate.SpawnYOffset, 5f, 50f);
                 var worldWaterLevel = GetWaterSurfaceFromAreas(world, casterLevelPos);
                 spawnPos.Local.SetHeight(worldWaterLevel);
-
 
                 // temporary grab ship information so that we can use it to find a suitable spot in front to summon it
                 var tempShipModel = ModelManager.Instance.GetShipModel(slaveTemplate.ModelId);
@@ -581,58 +618,65 @@ public class SlaveManager(WorldInstance parentWorldInstance)
                                         tempShipModel.KeelHeight;
                 }
 
-                // Sweep outwards from the caster rather than only along their facing: a player summoning
-                // from a bank is rarely aimed squarely at open water, and a forward-only probe reports
-                // "no water" for a lake that is a few metres to the side.
                 var searchRange = 50f + (tempShipModel?.MassBoxSizeX ?? 10f);
-                var sweepOrigin = (Position: casterLevelPos, Rotation: spawnPos.World.Rotation);
                 var waterAreas = world.Water.GetAreasSnapshot();
-                var foundNavigableWater = false;
-                for (var distance = 5f; distance <= searchRange && !foundNavigableWater; distance += 1f)
+                Vector3? bestPos = null;
+                var bestScore = float.NegativeInfinity;
+
+                // Two passes: forward hemisphere first, then any heading if the bank faces land.
+                for (var pass = 0; pass < 2 && bestPos == null; pass++)
                 {
-                    for (var step = 0; step < HeadingSweepSteps; step++)
+                    var requireForward = pass == 0;
+                    for (var distance = forwardOffset; distance <= searchRange; distance += 1f)
                     {
-                        // 0, +15, -15, +30, -30 ... so the caster's own heading still wins ties.
-                        var yawOffset = (step + 1) / 2 * HeadingSweepStepRadians * (step % 2 == 0 ? 1f : -1f);
-                        var yaw = sweepOrigin.Rotation.Z + yawOffset;
+                        for (var step = 0; step < HeadingSweepSteps; step++)
+                        {
+                            // 0, +15, -15, +30, -30 ... so the caster's own heading still wins ties.
+                            var yawOffset = (step + 1) / 2 * HeadingSweepStepRadians * (step % 2 == 0 ? 1f : -1f);
+                            var yaw = casterYaw + yawOffset;
 
-                        // Offset built here rather than through a cloned Transform: the clone's world
-                        // position does not pick up a local translation, so every probe re-sampled the
-                        // origin and the scan could only ever report whatever was under the caster.
-                        var probePos = new Vector3(
-                            sweepOrigin.Position.X - distance * MathF.Sin(yaw),
-                            sweepOrigin.Position.Y + distance * MathF.Cos(yaw),
-                            sweepOrigin.Position.Z);
+                            var probePos = new Vector3(
+                                casterLevelPos.X - distance * MathF.Sin(yaw),
+                                casterLevelPos.Y + distance * MathF.Cos(yaw),
+                                casterLevelPos.Z);
 
-                        var floorHeight = World.Template.GeoData.GetHeight(probePos);
-                        if (floorHeight <= 0f)
-                            continue;
+                            var forwardDot = BoatSpawnForwardDot(casterLevelPos, casterYaw, probePos);
+                            if (requireForward && forwardDot < 0f)
+                                continue;
 
-                        var surfaceHeight = GetWaterSurfaceFromAreas(world, waterAreas, probePos);
-                        if (surfaceHeight - floorHeight <= minDepth)
-                            continue;
+                            var floorHeight = World.Template.GeoData.GetHeight(probePos);
+                            if (floorHeight <= 0f)
+                                continue;
 
-                        spawnPos.Local.SetPosition(probePos.X, probePos.Y, surfaceHeight);
-                        foundNavigableWater = true;
-                        break;
+                            var surfaceHeight = GetWaterSurfaceFromAreas(world, waterAreas, probePos);
+                            if (!IsBoatSurfaceAllowed(casterLevelPos.Z, surfaceHeight, floorHeight, minDepth))
+                                continue;
+
+                            var score = ScoreBoatSpawnCandidate(forwardDot, distance, forwardOffset);
+                            if (score <= bestScore)
+                                continue;
+
+                            bestScore = score;
+                            bestPos = new Vector3(probePos.X, probePos.Y, surfaceHeight);
+                        }
                     }
                 }
 
-                if (!foundNavigableWater)
+                if (bestPos == null)
                 {
-
                     // GetWaterSurface reports the ocean plane for any coordinate, including dry land far
                     // above it, so without this the hull is placed at sea level directly beneath a player
                     // standing inland - buried in the terrain and invisible, with no error to explain it.
                     Logger.Warn(
                         "SlaveSpawn boat template={0} refused: no water at least {1:0.0} deep within {2:0.0}m of ({3:0.0},{4:0.0}); ground {5:0.0}, surface {6:0.0}",
                         slaveTemplate.Id, minDepth, searchRange,
-                        spawnPos.World.Position.X, spawnPos.World.Position.Y,
-                        World.Template.GeoData.GetHeight(spawnPos.World.Position), worldWaterLevel);
+                        casterLevelPos.X, casterLevelPos.Y,
+                        World.Template.GeoData.GetHeight(casterLevelPos), worldWaterLevel);
                     owner?.SendErrorMessage(ErrorMessageType.SlaveSpawnErrorInvalidArea);
                     return null;
                 }
 
+                spawnPos.Local.SetPosition(bestPos.Value.X, bestPos.Value.Y, bestPos.Value.Z);
                 spawnPos.Local.Position += spawnOffsetPos;
 
             }
@@ -1258,6 +1302,7 @@ public class SlaveManager(WorldInstance parentWorldInstance)
 
         WorldIntegration.RelayUnitStateToZone?.Invoke(zoneId, slaveStateBody);
         slave.ZoneAnnouncedTo = zoneId;
+        WorldIntegration.RelayShipControlChangeToZone?.Invoke(slave.ObjId, true);
         Logger.Info("WZUnitState queued for slave obj={0} zoneId={1} bodyLen={2}",
             slave.ObjId, zoneId, slaveStateBody.Length);
     }
@@ -1268,6 +1313,7 @@ public class SlaveManager(WorldInstance parentWorldInstance)
         if (slave == null || slave.ZoneAnnouncedTo == 0)
             return;
 
+        WorldIntegration.RelayShipControlChangeToZone?.Invoke(slave.ObjId, false);
         WorldIntegration.RelayUnitRemovedToZoneId?.Invoke(slave.ZoneAnnouncedTo, slave.ObjId);
         Logger.Info("WZUnitRemoved for slave obj={0} zoneId={1}", slave.ObjId, slave.ZoneAnnouncedTo);
         slave.ZoneAnnouncedTo = 0;

--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -488,6 +488,8 @@ public class CharacterManager(
             return;
         }
 
+        customModel.ClearUnusedVisualRaceOverride((byte)race);
+
         name = name.NormalizeName();
         var nameValidationCode = nameManager.ValidateCharacterName(name);
         if (nameValidationCode != CharacterCreateError.Ok)

--- a/AAEmu.Game/Core/Managers/World/SpawnManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpawnManager.cs
@@ -839,7 +839,7 @@ public class SpawnManager(WorldInstance parentWorld)
 
                         var zoneId = gimmick.Transform.ZoneId;
                         WorldIntegration.RelayGimmickCreatedToZone?.Invoke(
-                            gimmick.ToSpawnData(), (int)zoneId);
+                            gimmick.ToZoneWireSpawnData(), (int)zoneId);
                         count++;
                         if (count % 25 == 0)
                             Logger.Debug($"In world {World} Gimmicks spawned: {count}...");

--- a/AAEmu.Game/Core/Managers/World/WorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/WorldManager.cs
@@ -1306,7 +1306,12 @@ public class WorldManager(
                 if (stuff is Npc npc && npc.IsZoneMirror)
                     character.ReleaseMirrorNpcSlot(npc.ObjId);
                 if (stuff is Slave slave)
-                    character.ReleaseSlaveSlot(slave.ObjId);
+                {
+                    // Keeps exit-band eligibility for a hull already streamed (230 m after a
+                    // cinema must repaint, not wait for a fresh 225 m entry).
+                    slave.ResendVisibleObject(character);
+                    continue;
+                }
                 stuff.AddVisibleObject(character);
             }
         }

--- a/AAEmu.Game/Core/Managers/World/WorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/WorldManager.cs
@@ -1305,6 +1305,8 @@ public class WorldManager(
                 // Elf starters saw an empty world until they walked far enough for new AOI entries.
                 if (stuff is Npc npc && npc.IsZoneMirror)
                     character.ReleaseMirrorNpcSlot(npc.ObjId);
+                if (stuff is Slave slave)
+                    character.ReleaseSlaveSlot(slave.ObjId);
                 stuff.AddVisibleObject(character);
             }
         }

--- a/AAEmu.Game/Core/Managers/World/WzCoordPolicy.cs
+++ b/AAEmu.Game/Core/Managers/World/WzCoordPolicy.cs
@@ -1,0 +1,34 @@
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Core.Managers.World;
+
+/// <summary>
+/// Retail WZ space is the same rule in every zone. Per-zone origin comes from that zone's
+/// world.xml <c>originX/originY</c> (metres = cell × 1024). World never hardcodes a ZoneId.
+///
+/// Live objects on WZ (player, ZWSpawnNpc remirror, slave/boat, house, doodad, gimmick, CSMove)
+/// stay <b>continent</b> — the same numbers as Transform/SC. The dedicate subtracts origin for
+/// sectors and ship physics. Rewriting those bodies to zone-local in World makes invalid sector
+/// cells and "end of world" hulls in every zone that has a non-zero origin.
+///
+/// Packets that compare against level files (<c>npc_spawners.g</c> activate circle) convert
+/// continent → local once via <see cref="ZoneManager.ConvertToLocalCoordinates"/>.
+///
+/// World-authored event NPCs (tower/plot army) use the same continent WZ Create as the player.
+/// Zone-local Create made dedicate subtract origin twice → invalid sectors and fall-through.
+/// </summary>
+public static class WzCoordPolicy
+{
+    /// <summary>Opt-in debug rewrite of live WZ to zone-local. Not retail. Never use for boats.</summary>
+    public static bool DebugRewriteLiveToZoneLocal => ZoneCoordBoundary.UseLocalOnZoneWire;
+
+    public static bool KeepContinentOnLiveWz(Unit unit)
+    {
+        if (unit is Slave { Template: not null } slave && slave.Template.IsABoat())
+            return true;
+        if (unit is Npc { ZoneSimUsesLocalCoordinates: true })
+            return false;
+        return !DebugRewriteLiveToZoneLocal;
+    }
+}

--- a/AAEmu.Game/Core/Managers/World/ZoneCoordBoundary.cs
+++ b/AAEmu.Game/Core/Managers/World/ZoneCoordBoundary.cs
@@ -7,53 +7,63 @@ using NLog;
 namespace AAEmu.Game.Core.Managers.World;
 
 /// <summary>
-/// Optional World-side unit-space remapping at the zone TCP boundary.
-/// Spawner geometry packets (Activate circle, ZWSpawnNpc parse) always use zone-local convert;
-/// this flag only affects WZ unit Create/move bodies — leave it off unless reproducing a local-space
-/// unit wire layout.
+/// World-side unit-space remapping at the zone TCP boundary.
+/// See <see cref="WzCoordPolicy"/> for the retail rule (all zones, origin from world.xml).
+/// Spawner geometry packets (Activate circle) always convert continent → zone-local.
+/// Live WZ stays continent unless <see cref="UseLocalOnZoneWire"/> is opted in (debug only).
 /// </summary>
 public static class ZoneCoordBoundary
 {
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
     /// <summary>
-    /// When true, World rewrites WZ unit placement + moves into zone-local and ZW moves into world.
-    /// Default <c>false</c>: World sends/receives world coords on WZNpcState/WZUnitState/movements.
-    /// Force-local can double-subtract zone origin and place units off-mesh. Opt-in:
-    /// <c>AAEMU_WZ_UNIT_POS_LOCAL=1</c>. Kill with <c>WORLD=1</c> / <c>LOCAL=0</c>. Never flip mid-session.
+    /// When true, World rewrites WZ unit/doodad/gimmick placement + moves into zone-local and ZW moves into world.
+    /// Default <c>false</c> (continent on WZ). Opt in: <c>AAEMU_WZ_UNIT_POS_LOCAL=1</c>.
+    /// World-authored event NPCs use continent WZ Create (same as the player).
     /// </summary>
     public static bool UseLocalOnZoneWire { get; } = ResolveUseLocalOnZoneWire();
 
     static ZoneCoordBoundary()
     {
         Logger.Info(
-            "ZoneCoordBoundary: UseLocalOnZoneWire={0} (default world-on-wire; LOCAL=1 only for regression repro)",
+            "ZoneCoordBoundary: UseLocalOnZoneWire={0} (default continent on WZ; LOCAL=1 rewrites to zone-local)",
             UseLocalOnZoneWire);
     }
 
-    private static bool ResolveUseLocalOnZoneWire()
+    public static bool ResolveUseLocalOnZoneWire() =>
+        ResolveUseLocalOnZoneWire(
+            Environment.GetEnvironmentVariable("AAEMU_WZ_UNIT_POS_WORLD"),
+            Environment.GetEnvironmentVariable("AAEMU_WZ_UNIT_POS_LOCAL"));
+
+    /// <summary>
+    /// LOCAL=1 → zone-local on the zone wire. WORLD=1, LOCAL=0, or unset → continent.
+    /// </summary>
+    public static bool ResolveUseLocalOnZoneWire(string worldEnv, string localEnv)
     {
-        if (IsEnv("AAEMU_WZ_UNIT_POS_WORLD", "1"))
+        if (IsValue(worldEnv, "1"))
             return false;
-        if (IsEnv("AAEMU_WZ_UNIT_POS_LOCAL", "0"))
+        if (IsValue(localEnv, "0"))
             return false;
-        // Opt-in only — default is world coordinates on unit wire.
-        return IsEnv("AAEMU_WZ_UNIT_POS_LOCAL", "1");
+        return IsValue(localEnv, "1");
     }
 
-    private static bool IsEnv(string name, string value) =>
-        string.Equals(Environment.GetEnvironmentVariable(name), value, StringComparison.Ordinal);
+    private static bool IsValue(string env, string value) =>
+        string.Equals(env, value, StringComparison.Ordinal);
 
-    public static Vector3 ToZoneLocal(uint zoneId, Vector3 worldPos)
+    public static Vector3 ToZoneLocal(uint zoneId, Vector3 worldPos, bool force = false)
     {
-        if (!UseLocalOnZoneWire || zoneId == 0)
+        if (zoneId == 0)
+            return worldPos;
+        if (!force && !UseLocalOnZoneWire)
             return worldPos;
         return ZoneManager.Instance.ConvertToLocalCoordinates(zoneId, worldPos);
     }
 
-    public static Vector3 ToWorld(uint zoneId, Vector3 zoneLocalPos)
+    public static Vector3 ToWorld(uint zoneId, Vector3 zoneLocalPos, bool force = false)
     {
-        if (!UseLocalOnZoneWire || zoneId == 0)
+        if (zoneId == 0)
+            return zoneLocalPos;
+        if (!force && !UseLocalOnZoneWire)
             return zoneLocalPos;
         return ZoneManager.Instance.ConvertToWorldCoordinates(zoneId, zoneLocalPos);
     }
@@ -81,19 +91,21 @@ public static class ZoneCoordBoundary
         }
     }
 
-    public static void ShiftLocalToWorld(uint zoneId, MoveType move)
+    public static void ShiftLocalToWorld(uint zoneId, MoveType move, bool force = false)
     {
-        if (!CarriesSpatialPosition(move) || !UseLocalOnZoneWire || zoneId == 0)
+        if (!CarriesSpatialPosition(move) || zoneId == 0)
+            return;
+        if (!force && !UseLocalOnZoneWire)
             return;
 
-        var p = ToWorld(zoneId, new Vector3(move.X, move.Y, move.Z));
+        var p = ToWorld(zoneId, new Vector3(move.X, move.Y, move.Z), force);
         move.X = p.X;
         move.Y = p.Y;
         move.Z = p.Z;
 
         if (move is UnitMoveType unit && (unit.ActorFlags & 0x20) != 0)
         {
-            var p2 = ToWorld(zoneId, new Vector3(unit.X2, unit.Y2, unit.Z2));
+            var p2 = ToWorld(zoneId, new Vector3(unit.X2, unit.Y2, unit.Z2), force);
             unit.X2 = p2.X;
             unit.Y2 = p2.Y;
             unit.Z2 = p2.Z;

--- a/AAEmu.Game/Core/Packets/G2C/UnitState/UnitStateAppearanceSerializer.cs
+++ b/AAEmu.Game/Core/Packets/G2C/UnitState/UnitStateAppearanceSerializer.cs
@@ -15,8 +15,7 @@ internal static class UnitStateAppearanceSerializer
         {
             appearance.Race = (byte)context.Character.Race;
             appearance.Gender = (byte)context.Character.Gender;
-            appearance.VisualRace = (byte)context.Character.Race;
-            appearance.VisualGender = (byte)context.Character.Gender;
+            appearance.ClearUnusedVisualRaceOverride((byte)context.Character.Race);
         }
         if (context.Npc is not null && appearance.BodyWeight == 0f)
             appearance.BodyWeight = 1f;

--- a/AAEmu.Game/Core/Packets/G2C/UnitState/UnitStatePlacementSerializer.cs
+++ b/AAEmu.Game/Core/Packets/G2C/UnitState/UnitStatePlacementSerializer.cs
@@ -13,7 +13,7 @@ internal static class UnitStatePlacementSerializer
     public static void Write(PacketStream stream, UnitStateWireContext context)
     {
         var unit = context.Unit;
-        // Only client packets ground World-owned NPCs. A Zone placement override is already local.
+        // WZ override is already zone-local XYZ (Z unchanged). Do not snap it against the continent heightmap.
         if (context.PlacementOverride is null)
             GroundWorldNpc(unit, context);
 

--- a/AAEmu.Game/GameData/TowerDefGameData.cs
+++ b/AAEmu.Game/GameData/TowerDefGameData.cs
@@ -26,6 +26,12 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
     /// </summary>
     private HashSet<uint> _priorityNpcTemplateIds = [];
 
+    /// <summary>
+    /// Kill-quota Npc / NpcGroup members from tower_def_prog_kill_targets (and KillNpcId).
+    /// Used with boss grade for the 1.5 km event stream — not ambient MAX priority for infantry.
+    /// </summary>
+    private HashSet<uint> _killQuotaNpcTemplateIds = [];
+
     /// <summary>Spawner template id → direct <c>Npc</c> members (portal seed unit ids).</summary>
     private Dictionary<uint, HashSet<uint>> _spawnerMemberNpcs = [];
 
@@ -42,6 +48,7 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
         _towerDefProgs = [];
         _eventSpawnerTemplateIds = [];
         _priorityNpcTemplateIds = [];
+        _killQuotaNpcTemplateIds = [];
         _spawnerMemberNpcs = [];
 
         using (var command = connection.CreateCommand())
@@ -297,8 +304,41 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
 
         _npcGroupMembers = groupMembers;
         _priorityNpcTemplateIds = priorityNpcs;
+        _killQuotaNpcTemplateIds = BuildKillQuotaNpcTemplateIds(groupMembers);
         ApplyScheduleMetadata();
         IsLoaded = true;
+    }
+
+    private HashSet<uint> BuildKillQuotaNpcTemplateIds(Dictionary<uint, HashSet<uint>> groupMembers)
+    {
+        var set = new HashSet<uint>();
+        foreach (var towerDef in _towerDefs.Values)
+        {
+            if (towerDef.KillNpcId != 0)
+                set.Add(towerDef.KillNpcId);
+            if (towerDef.Progs == null)
+                continue;
+            foreach (var prog in towerDef.Progs)
+            {
+                if (prog.KillTargets == null)
+                    continue;
+                foreach (var kill in prog.KillTargets)
+                {
+                    if (kill.KillTargetId == 0)
+                        continue;
+                    if (string.Equals(kill.KillTargetType, "Npc", StringComparison.Ordinal))
+                        set.Add(kill.KillTargetId);
+                    else if (string.Equals(kill.KillTargetType, "NpcGroup", StringComparison.Ordinal)
+                             && groupMembers.TryGetValue(kill.KillTargetId, out var members))
+                    {
+                        foreach (var id in members)
+                            set.Add(id);
+                    }
+                }
+            }
+        }
+
+        return set;
     }
 
     /// <summary>
@@ -396,6 +436,10 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
     /// </summary>
     public bool IsTowerDefEventNpc(uint npcTemplateId) =>
         IsLoaded && npcTemplateId != 0 && _priorityNpcTemplateIds.Contains(npcTemplateId);
+
+    /// <summary>True when compact lists this NPC as a tower kill-quota target (Lusca 13703).</summary>
+    public bool IsTowerDefKillQuotaNpc(uint npcTemplateId) =>
+        IsLoaded && npcTemplateId != 0 && _killQuotaNpcTemplateIds.Contains(npcTemplateId);
 
     /// <summary>
     /// Direct <c>Npc</c> members of a tower portal/wave spawner template (e.g. 9846 → 8828).

--- a/AAEmu.Game/GameService.cs
+++ b/AAEmu.Game/GameService.cs
@@ -45,6 +45,7 @@ public sealed class GameService : IHostedService, IDisposable
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         Logger.Info("Starting daemon: AAEmu.Game");
+        Models.Game.StreamAoi.StreamAoiTable.ReplaceConfig(AppConfiguration.Instance.StreamAoi);
 
         // Check for updates
         using (var connection = MySQL.CreateConnection())

--- a/AAEmu.Game/Models/AppConfiguration.cs
+++ b/AAEmu.Game/Models/AppConfiguration.cs
@@ -2,6 +2,7 @@
 using AAEmu.Commons.Utils;
 using AAEmu.Game.IO;
 using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.StreamAoi;
 using AAEmu.Game.Models.Game.Expeditions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -67,6 +68,7 @@ public partial class AppConfiguration
     public UccConfig Ucc { get; set; } = new();
     public FeaturesConfig Features { get; set; } = new();
     public TowerDefsConfig TowerDefs { get; set; } = new();
+    public StreamAoiConfig StreamAoi { get; set; } = new();
     public InitialConfig InitialConfig { get; set; } = new();
     public LevelRestrictionConfig LevelRestrictions { get; set; } = new();
     public ScriptsConfig Scripts { get; set; } = new();

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -298,6 +298,13 @@ public partial class Character : Unit, ICharacter
         return StreamAoiTable.IsInside(slave.StreamAoiCategory, d2, alreadyStreamed: true);
     }
 
+    /// <summary>
+    /// Forced repaint (cinema end, teleport end): a hull that was streamed and is still inside
+    /// its exit band keeps that eligibility. Re-testing it as a fresh 225 m entry left a hull at
+    /// 230 m missing until the player walked back inside enter.
+    /// </summary>
+    public bool ShouldRepaintStreamedSlave(Slave slave) => TryKeepSlaveAcrossRegionLeave(slave);
+
     public void EnqueuePendingSlave(Slave slave)
     {
         if (slave == null || slave.ObjId == 0)

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -28,6 +28,7 @@ using AAEmu.Game.Models.Game.Skills.SkillControllers;
 using AAEmu.Game.Models.Game.Static;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Units.Static;
+using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Models.Game.World.Transform;
 using AAEmu.Game.Models.StaticValues;
 using AAEmu.Game.Utils;
@@ -53,10 +54,22 @@ public partial class Character : Unit, ICharacter
     private readonly ConcurrentDictionary<uint, Npc> _pendingMirrorSpawns = new();
 
     /// <summary>
+    /// Hulls waiting for SCUnitState — queued while loading or outside the Ship/Ambient enter band.
+    /// Equipment (Part) is never queued; it paints with region interest.
+    /// </summary>
+    private readonly ConcurrentDictionary<uint, Slave> _pendingSlaves = new();
+
+    /// <summary>
     /// ObjIds that already received SCUnitState and still count toward AAEMU_MIRROR_NPC_MAX.
     /// Freed on leave-view so walking recycles slots (lifetime counter Quit'd after first N).
     /// </summary>
     public ConcurrentDictionary<uint, byte> MirrorNpcStatesSentIds { get; } = new();
+
+    /// <summary>
+    /// Hull ObjIds that already received SCUnitState. Separate from NPC mirrors so
+    /// <see cref="WorldInstance.GetNpc"/> cannot drop a boat as a missing mirror.
+    /// </summary>
+    public ConcurrentDictionary<uint, byte> StreamedSlaveIds { get; } = new();
 
     /// <summary>In-view streamed mirror count (for cap checks).</summary>
     public int MirrorNpcStatesSentCount => MirrorNpcStatesSentIds.Count;
@@ -75,6 +88,8 @@ public partial class Character : Unit, ICharacter
         MirrorNpcStreamNotBeforeTick = 0;
         MirrorNpcStatesSentIds.Clear();
         _pendingMirrorSpawns.Clear();
+        StreamedSlaveIds.Clear();
+        _pendingSlaves.Clear();
     }
 
     /// <summary>Arm mirror interest after load complete (+ optional grace ms).</summary>
@@ -184,15 +199,15 @@ public partial class Character : Unit, ICharacter
         return dx * dx + dy * dy + dz * dz;
     }
 
-    private bool IsStillInRegionInterest(Npc npc)
+    private bool IsStillInRegionInterest(GameObject obj)
     {
-        if (npc?.Region == null || Region == null)
+        if (obj?.Region == null || Region == null)
             return false;
-        if (ReferenceEquals(npc.Region, Region))
+        if (ReferenceEquals(obj.Region, Region))
             return true;
         foreach (var n in Region.GetNeighbors())
         {
-            if (ReferenceEquals(n, npc.Region))
+            if (ReferenceEquals(n, obj.Region))
                 return true;
         }
 
@@ -245,6 +260,138 @@ public partial class Character : Unit, ICharacter
         }
 
         return remove.Count;
+    }
+
+    /// <summary>
+    /// True when this hull may receive SCUnitState now. Equipment (Part) is always inside.
+    /// Does not share the NPC MAX cap — boats are not mirrors.
+    /// </summary>
+    public bool CanStreamSlaveNow(Slave slave)
+    {
+        if (slave == null || slave.ObjId == 0)
+            return false;
+        if (!MirrorNpcStreamReady)
+            return false;
+        if (MirrorNpcStreamNotBeforeTick != 0 &&
+            Environment.TickCount64 < MirrorNpcStreamNotBeforeTick)
+            return false;
+        if (StreamedSlaveIds.ContainsKey(slave.ObjId))
+            return false;
+        var d2 = DistanceSq(Transform.World.Position, slave.Transform.World.Position);
+        return StreamAoiTable.IsInside(slave.StreamAoiCategory, d2, alreadyStreamed: false);
+    }
+
+    public void EnqueuePendingSlave(Slave slave)
+    {
+        if (slave == null || slave.ObjId == 0)
+            return;
+        if (StreamedSlaveIds.ContainsKey(slave.ObjId))
+            return;
+        _pendingSlaves.TryAdd(slave.ObjId, slave);
+    }
+
+    public void MarkSlaveStreamed(Slave slave)
+    {
+        if (slave == null || slave.ObjId == 0)
+            return;
+        StreamedSlaveIds.TryAdd(slave.ObjId, 0);
+        _pendingSlaves.TryRemove(slave.ObjId, out _);
+    }
+
+    public void ReleaseSlaveSlot(uint objId)
+    {
+        StreamedSlaveIds.TryRemove(objId, out _);
+        _pendingSlaves.TryRemove(objId, out _);
+    }
+
+    public bool HasPendingSlaves => !_pendingSlaves.IsEmpty;
+
+    /// <summary>
+    /// Hull-only leave: SCUnitsRemoved for the selectable unit. Does not walk
+    /// Transform.Children — sail/cannon doodads stay until region leave.
+    /// </summary>
+    public int CullStreamedSlavesBeyondAoi()
+    {
+        if (StreamedSlaveIds.IsEmpty)
+            return 0;
+
+        var origin = Transform.World.Position;
+        List<uint> remove = null;
+
+        foreach (var objId in StreamedSlaveIds.Keys)
+        {
+            var slave = ParentWorld?.GetSlaveByObjId(objId);
+            if (slave == null || slave.ObjId == 0)
+            {
+                (remove ??= []).Add(objId);
+                continue;
+            }
+
+            var d2 = DistanceSq(origin, slave.Transform.World.Position);
+            if (!StreamAoiTable.IsInside(slave.StreamAoiCategory, d2, alreadyStreamed: true))
+                (remove ??= []).Add(objId);
+        }
+
+        if (remove == null || remove.Count == 0)
+            return 0;
+
+        foreach (var objId in remove)
+        {
+            var slave = ParentWorld?.GetSlaveByObjId(objId);
+            ReleaseSlaveSlot(objId);
+            if (slave != null && IsStillInRegionInterest(slave))
+                EnqueuePendingSlave(slave);
+        }
+
+        for (var offset = 0; offset < remove.Count; offset += SCUnitsRemovedPacket.MaxCountPerPacket)
+        {
+            var length = Math.Min(SCUnitsRemovedPacket.MaxCountPerPacket, remove.Count - offset);
+            var batch = new uint[length];
+            remove.CopyTo(offset, batch, 0, length);
+            SendPacket(new SCUnitsRemovedPacket(batch));
+        }
+
+        return remove.Count;
+    }
+
+    /// <summary>Paint pending hulls that walked into their enter band (or finished load).</summary>
+    public int TryFlushPendingSlaves()
+    {
+        if (_pendingSlaves.IsEmpty || !MirrorNpcStreamReady)
+            return 0;
+        if (MirrorNpcStreamNotBeforeTick != 0 &&
+            Environment.TickCount64 < MirrorNpcStreamNotBeforeTick)
+            return 0;
+
+        List<Slave> ready = null;
+        foreach (var kv in _pendingSlaves)
+        {
+            var slave = kv.Value;
+            if (slave == null || slave.ObjId == 0 || !slave.IsVisible)
+            {
+                _pendingSlaves.TryRemove(kv.Key, out _);
+                continue;
+            }
+
+            if (StreamedSlaveIds.ContainsKey(slave.ObjId))
+            {
+                _pendingSlaves.TryRemove(kv.Key, out _);
+                continue;
+            }
+
+            if (!CanStreamSlaveNow(slave))
+                continue;
+
+            (ready ??= []).Add(slave);
+        }
+
+        if (ready == null)
+            return 0;
+
+        foreach (var slave in ready)
+            slave.SendUnitStateTo(this);
+
+        return ready.Count;
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -281,6 +281,23 @@ public partial class Character : Unit, ICharacter
         return StreamAoiTable.IsInside(slave.StreamAoiCategory, d2, alreadyStreamed: false);
     }
 
+    /// <summary>
+    /// Region leave batches SCUnitsRemoved for the cell. Keep a streamed hull that is still
+    /// inside its exit band (same idea as event-priority NPC mirrors). Equipment Parts always
+    /// leave with the cell.
+    /// </summary>
+    public bool TryKeepSlaveAcrossRegionLeave(Slave slave)
+    {
+        if (slave == null || slave.ObjId == 0)
+            return false;
+        if (slave.StreamAoiCategory == StreamAoiCategory.Part)
+            return false;
+        if (!StreamedSlaveIds.ContainsKey(slave.ObjId))
+            return false;
+        var d2 = DistanceSq(Transform.World.Position, slave.Transform.World.Position);
+        return StreamAoiTable.IsInside(slave.StreamAoiCategory, d2, alreadyStreamed: true);
+    }
+
     public void EnqueuePendingSlave(Slave slave)
     {
         if (slave == null || slave.ObjId == 0)

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -21,6 +21,7 @@ using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Items.Containers;
 using AAEmu.Game.Models.Game.Items.Templates;
 using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.StreamAoi;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Buffs;
 using AAEmu.Game.Models.Game.Skills.SkillControllers;
@@ -100,13 +101,7 @@ public partial class Character : Unit, ICharacter
             MirrorNpcStatesSentCount >= Npc.MirrorNpcMaxPerCharacter)
             return false;
         var d2 = DistanceSq(Transform.World.Position, npc.Transform.World.Position);
-        // Same Transform.ZoneId: event rifts must still paint / show on map so dedic fly-in
-        // movements can be relayed; ambient mirrors keep the short commercial soft AOI.
-        if (npc.IsMirrorStreamPriority &&
-            npc.Transform?.ZoneId != 0 &&
-            Transform?.ZoneId == npc.Transform.ZoneId)
-            return true;
-        return d2 <= npc.MirrorStreamAoiRadiusSq;
+        return StreamAoiTable.IsInside(npc.StreamAoiCategory, d2, alreadyStreamed: false);
     }
 
     /// <summary>Queue a zone mirror for later AOI enter / post-load flush.</summary>
@@ -162,14 +157,7 @@ public partial class Character : Unit, ICharacter
             }
 
             var d2 = DistanceSq(origin, npc.Transform.World.Position);
-            // Outside soft AOI: skip for send (still pending for when player walks closer).
-            // Priority event mirrors use the larger stream radius / same-zone rule.
-            var aoi = npc.IsMirrorStreamPriority
-                ? (npc.Transform?.ZoneId != 0 && Transform?.ZoneId == npc.Transform.ZoneId
-                    ? float.MaxValue
-                    : npc.MirrorStreamAoiRadiusSq)
-                : Npc.MirrorNpcAoiRadiusSq;
-            if (d2 > aoi)
+            if (d2 > StreamAoiTable.Band(npc.StreamAoiCategory).EnterSq)
                 continue;
 
             // Event rifts always beat ambient pending at equal-or-farther distance.
@@ -221,7 +209,6 @@ public partial class Character : Unit, ICharacter
             return 0;
 
         var origin = Transform.World.Position;
-        var aoiSq = Npc.MirrorNpcAoiRadiusSq;
         List<uint> remove = null;
 
         foreach (var objId in MirrorNpcStatesSentIds.Keys)
@@ -233,12 +220,8 @@ public partial class Character : Unit, ICharacter
                 continue;
             }
 
-            // Tower/event hellgates stay painted for the whole arm even if soft AOI thrash or a
-            // ZW move briefly poisons World position (seen: Grimghast 12911 flash + SCUnitsRemoved).
-            if (npc.IsMirrorStreamPriority)
-                continue;
-
-            if (DistanceSq(origin, npc.Transform.World.Position) > aoiSq)
+            var d2 = DistanceSq(origin, npc.Transform.World.Position);
+            if (!StreamAoiTable.IsInside(npc.StreamAoiCategory, d2, alreadyStreamed: true))
                 (remove ??= []).Add(objId);
         }
 
@@ -340,9 +323,7 @@ public partial class Character : Unit, ICharacter
 
         var origin = Transform.World.Position;
         var pD2 = DistanceSq(origin, priorityNpc.Transform.World.Position);
-        var sameZone = priorityNpc.Transform?.ZoneId != 0 &&
-                       Transform?.ZoneId == priorityNpc.Transform.ZoneId;
-        if (!sameZone && pD2 > priorityNpc.MirrorStreamAoiRadiusSq)
+        if (!StreamAoiTable.IsInside(priorityNpc.StreamAoiCategory, pD2, alreadyStreamed: false))
             return false;
 
         uint farthestId = 0;
@@ -3016,6 +2997,7 @@ public partial class Character : Unit, ICharacter
                         Hp = reader.GetInt32("hp"),
                         Mp = reader.GetInt32("mp")
                     };
+                    character.ModelParams.ClearUnusedVisualRaceOverride((byte)character.Race);
                     character._savedHp = character.Hp; // save for later
                     character._savedMp = character.Mp;
                     // character.LaborPower = reader.GetInt16("labor_power");
@@ -3136,6 +3118,7 @@ public partial class Character : Unit, ICharacter
                     character.AccessLevel = reader.GetInt32("access_level");
                     character.Race = (Race)reader.GetByte("race");
                     character.Gender = (Gender)reader.GetByte("gender");
+                    character.ModelParams.ClearUnusedVisualRaceOverride((byte)character.Race);
                     character.Level = reader.GetByte("level");
                     character.Experience = reader.GetInt32("experience");
                     character.RecoverableExp = reader.GetInt32("recoverable_exp");
@@ -3705,8 +3688,7 @@ public partial class Character : Unit, ICharacter
         // appearance
         ModelParams.Race = (byte)Race;
         ModelParams.Gender = (byte)Gender;
-        ModelParams.VisualRace = (byte)Race;
-        ModelParams.VisualGender = (byte)Gender;
+        ModelParams.ClearUnusedVisualRaceOverride((byte)Race);
         stream.Write(ModelParams);
         stream.Write((short)0);                                       // deadCount (i16)
         stream.Write(0L);                                            // deadTime

--- a/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
+++ b/AAEmu.Game/Models/Game/Gimmicks/Gimmick.cs
@@ -57,9 +57,19 @@ public class Gimmick : Unit
         return ToSpawnData().Write(stream);
     }
 
-    public GimmickSpawnData ToSpawnData()
+    public GimmickSpawnData ToSpawnData() => BuildSpawnData(Transform.World.Position);
+
+    /// <summary>WZ Create body — zone-local XY when local wire is on. SC still uses <see cref="ToSpawnData"/>.</summary>
+    public GimmickSpawnData ToZoneWireSpawnData()
     {
         var position = Transform.World.Position;
+        var zoneId = Transform?.ZoneId ?? 0;
+        position = ZoneCoordBoundary.ToZoneLocal(zoneId, position);
+        return BuildSpawnData(position);
+    }
+
+    private GimmickSpawnData BuildSpawnData(Vector3 position)
+    {
         return new GimmickSpawnData(
             ObjId,
             TemplateId,

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -17,6 +17,7 @@ using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Skills.SkillControllers;
 using AAEmu.Game.Models.Game.Skills.Static;
+using AAEmu.Game.Models.Game.StreamAoi;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.Units.Movements;
 using AAEmu.Game.Models.Game.Units.Static;
@@ -96,6 +97,12 @@ public partial class Npc : Unit
 
     /// <summary>Set from the actor model (fly_mode or MovementId 2): keeps the spawner's Z instead of terrain height.</summary>
     public bool CanFly { get; set; }
+
+    /// <summary>
+    /// WZNpcState for this unit used zone-local XYZ. ZWUnitMovements must be converted to world
+    /// for SC even when the process default is world-on-wire.
+    /// </summary>
+    public bool ZoneSimUsesLocalCoordinates { get; set; }
 
     /// <summary>
     /// The <c>flag</c> byte of the NPC id-type block in SCUnitState (0x097).
@@ -1074,7 +1081,9 @@ public partial class Npc : Unit
     /// <summary>
     /// AAEMU_DISABLE_MIRROR_NPC=1 | AAEMU_MIRROR_NPC_MAX=N (default 50; 0=unlimited) |
     /// AAEMU_MIRROR_NPC_BURST=N (0=flush all/tick) | AAEMU_MIRROR_NPC_INTERVAL_MS (0=off) |
-    /// AAEMU_MIRROR_NPC_AOI=metres | AAEMU_MIRROR_NPC_GRACE_MS
+    /// AAEMU_MIRROR_NPC_AOI=metres (ambient enter) | AAEMU_MIRROR_NPC_GRACE_MS |
+    /// AAEMU_MIRROR_LARGE_AOI_ENTER/_EXIT | AAEMU_MIRROR_SHIP_AOI_ENTER/_EXIT |
+    /// AAEMU_MIRROR_PRIORITY_AOI (event band)
     /// </summary>
     public static readonly bool DisableMirrorNpcStreaming =
         System.Environment.GetEnvironmentVariable("AAEMU_DISABLE_MIRROR_NPC") == "1";
@@ -1082,22 +1091,41 @@ public partial class Npc : Unit
     public static readonly int MirrorNpcMaxPerCharacter = ParseMirrorNpcMax();
     public static readonly int MirrorNpcImmediateBurst = ParseMirrorNpcBurst();
 
-    /// <summary>Squared soft interest radius for mirror SC (commercial AOI, not sticky region set).</summary>
-    public static readonly float MirrorNpcAoiRadiusSq = ParseMirrorNpcAoiRadiusSq();
+    /// <summary>Ambient enter squared (legacy name). Bands live in <see cref="StreamAoiTable"/>.</summary>
+    public static float MirrorNpcAoiRadiusSq =>
+        StreamAoiTable.Band(StreamAoiCategory.Ambient).EnterSq;
+
+    /// <summary>Event-band enter squared (legacy name).</summary>
+    public static float MirrorStreamPriorityAoiRadiusSq =>
+        StreamAoiTable.Band(StreamAoiCategory.Event).EnterSq;
 
     /// <summary>
-    /// Event/tower rifts fly and land far from the player’s ambient 100 m stream radius — they still
-    /// need SCUnitState so ZW→SC movement (fly-in) is visible on the map. Default 1.5 km; override
-    /// <c>AAEMU_MIRROR_PRIORITY_AOI</c> (metres).
-    /// </summary>
-    public static readonly float MirrorStreamPriorityAoiRadiusSq = ParseMirrorStreamPriorityAoiRadiusSq();
-
-    /// <summary>
-    /// Event NPCs from loaded tower-def relationships that must paint even when ambient mirrors
-    /// filled MAX first. Returns false until <see cref="TowerDefGameData"/> has loaded.
+    /// Event hellgates stay painted for fly-in. Large sea bosses steal MAX slots but cull at 248 m.
     /// </summary>
     public bool IsMirrorStreamPriority =>
-        IsZoneMirror && TowerDefGameData.Instance.IsTowerDefEventNpc(TemplateId);
+        StreamAoiCategory is StreamAoiCategory.Event or StreamAoiCategory.Large;
+
+    public StreamAoiCategory StreamAoiCategory
+    {
+        get
+        {
+            if (!IsZoneMirror)
+                return StreamAoiCategory.Ambient;
+            if (TowerDefGameData.Instance.IsTowerDefEventNpc(TemplateId))
+                return StreamAoiCategory.Event;
+            if (StreamAoiTable.IsLargeNpc(TemplateId, Template?.ModelId ?? 0))
+                return StreamAoiCategory.Large;
+            if (Template != null
+                && UsesPriorityStreamAsKillQuotaBoss(Template.NpcGradeId)
+                && TowerDefGameData.Instance.IsTowerDefKillQuotaNpc(TemplateId))
+                return StreamAoiCategory.Large;
+            return StreamAoiCategory.Ambient;
+        }
+    }
+
+    /// <summary>Boss grades whose tower kill-quota rows use the Large (225/248 m) band.</summary>
+    public static bool UsesPriorityStreamAsKillQuotaBoss(NpcGradeType grade) =>
+        grade is NpcGradeType.BossA or NpcGradeType.BossB or NpcGradeType.BossC or NpcGradeType.BossS;
 
     private static int ParseMirrorNpcMax()
     {
@@ -1115,29 +1143,8 @@ public partial class Npc : Unit
         return int.TryParse(raw, out var n) && n >= 0 ? n : 0;
     }
 
-    private static float ParseMirrorNpcAoiRadiusSq()
-    {
-        var raw = System.Environment.GetEnvironmentVariable("AAEMU_MIRROR_NPC_AOI");
-        var metres = 100f;
-        if (float.TryParse(raw, System.Globalization.NumberStyles.Float,
-                System.Globalization.CultureInfo.InvariantCulture, out var n) && n >= 20f)
-            metres = n;
-        return metres * metres;
-    }
-
-    private static float ParseMirrorStreamPriorityAoiRadiusSq()
-    {
-        var raw = System.Environment.GetEnvironmentVariable("AAEMU_MIRROR_PRIORITY_AOI");
-        var metres = 1500f;
-        if (float.TryParse(raw, System.Globalization.NumberStyles.Float,
-                System.Globalization.CultureInfo.InvariantCulture, out var n) && n >= 50f)
-            metres = n;
-        return metres * metres;
-    }
-
-    /// <summary>AOI for this mirror’s soft stream (priority event NPCs use a larger radius).</summary>
-    public float MirrorStreamAoiRadiusSq =>
-        IsMirrorStreamPriority ? MirrorStreamPriorityAoiRadiusSq : MirrorNpcAoiRadiusSq;
+    /// <summary>Enter-radius squared for this mirror’s category.</summary>
+    public float MirrorStreamAoiRadiusSq => StreamAoiTable.Band(StreamAoiCategory).EnterSq;
 
     public override void AddVisibleObject(Character character)
     {
@@ -1247,16 +1254,6 @@ public partial class Npc : Unit
 
     public override void RemoveVisibleObject(Character character)
     {
-        // Soft interest leave must not despawn tower / event rifts. True despawn goes through
-        // Hide/Delete (IsVisible=false) after ZWRemove, which is the only path that should SC-remove them.
-        if (IsZoneMirror && WorldIntegration.ZoneAuthority && IsMirrorStreamPriority && IsVisible)
-        {
-            Logger.Debug(
-                "Skip soft SCUnitsRemoved for priority mirror bc={0} tpl={1} char={2}",
-                ObjId, TemplateId, character?.Name);
-            return;
-        }
-
         if (IsZoneMirror && WorldIntegration.ZoneAuthority)
             character.ReleaseMirrorNpcSlot(ObjId);
 
@@ -1676,19 +1673,15 @@ public partial class Npc : Unit
     }
 
     /// <summary>
-    /// ZoneAuthority: dedic rarely starts plot_only OnSpawn for tower stage units (e.g. skill
-    /// 15298 on tpl 8830 → plot summons 8826/8834). World runs those plots so army packs appear.
-    /// Suppresses WZ skill relay so dedic does not dual-fire. Kill: <c>AAEMU_DISABLE_ONSPAWN_PLOTS=1</c>.
-    /// Gated to priority/event mirrors — not ambient plot_only on_spawn (318 rows).
+    /// ZoneAuthority: World runs OnSpawn plot graphs on tower-priority mirrors (Crimson 15298
+    /// plot_only, Lusca 29515/29320 plot with plot_only false) so army SpawnEffects fire when
+    /// the dedic is silent. When the dedic already fires OnSpawn (e.g. Grimghast), that is the
+    /// zone path; World still suppresses WZ skill relay so this fill does not dual-start the
+    /// same graph on the zone. Gated to priority/event mirrors.
     /// </summary>
     public void CastOnSpawnPlotSkills()
     {
         if (!WorldIntegration.ZoneAuthority)
-            return;
-        if (string.Equals(
-                Environment.GetEnvironmentVariable("AAEMU_DISABLE_ONSPAWN_PLOTS"),
-                "1",
-                StringComparison.Ordinal))
             return;
         if (!IsZoneMirror || !IsMirrorStreamPriority)
             return;
@@ -1703,8 +1696,13 @@ public partial class Npc : Unit
             var skill = SkillManager.Instance.GetNpSkillTemplate(npcSkill);
             if (skill?.Template == null)
                 continue;
-            // Only true plot graphs. plot_only with no plot is a no-op for army work.
-            if (skill.Template.Plot == null || !skill.Template.PlotOnly)
+            if (!OnSpawnPlotWorldGate.ShouldRun(
+                    zoneAuthority: true,
+                    isZoneMirror: true,
+                    isPriorityMirror: true,
+                    hasPlot: skill.Template.Plot != null,
+                    plotOnly: skill.Template.PlotOnly,
+                    directSkillEffectCount: skill.Template.Effects?.Count ?? 0))
                 continue;
 
             if (Cooldowns.CheckCooldown(skill.Id))
@@ -1712,9 +1710,10 @@ public partial class Npc : Unit
             if (skill.Template.CooldownTime == 0)
                 Cooldowns.AddCooldown(skill.Id, uint.MaxValue);
 
-            // skill_use_param1: delay seconds before OnSpawn graph (Crimson stage uses 1.0).
+            // skill_use_param1: delay seconds before OnSpawn graph (Crimson / Lusca stage use 1.0).
             var delaySec = npcSkill.SkillUseParam1;
             skill.SuppressZoneSkillRelay = true;
+            skill.ForcePlotGraphOnly = true;
             var caster = SkillCaster.GetByType(SkillCasterType.Unit);
             caster.ObjId = ObjId;
             var target = SkillCastTarget.GetByType(SkillCastTargetType.Unit);
@@ -1728,14 +1727,14 @@ public partial class Npc : Unit
                 {
                     var result = skill.Use(this, caster, target, null, true, out _);
                     Logger.Info(
-                        "OnSpawn plot_only Use bc={0} tpl={1} skill={2} plot={3} result={4}",
+                        "OnSpawn plot Use bc={0} tpl={1} skill={2} plot={3} result={4}",
                         ObjId, TemplateId, skill.Id, skill.Template.Plot?.Id ?? 0, result);
                 }
                 catch (Exception ex)
                 {
                     Logger.Warn(
                         ex,
-                        "OnSpawn plot_only failed bc={0} tpl={1} skill={2}",
+                        "OnSpawn plot failed bc={0} tpl={1} skill={2}",
                         ObjId, TemplateId, skill.Id);
                 }
             }
@@ -1752,7 +1751,7 @@ public partial class Npc : Unit
                     }
                     catch (Exception ex)
                     {
-                        Logger.Warn(ex, "OnSpawn plot_only delay fire bc={0} skill={1}", ObjId, skill.Id);
+                        Logger.Warn(ex, "OnSpawn plot delay fire bc={0} skill={1}", ObjId, skill.Id);
                     }
                 });
             }
@@ -1767,7 +1766,7 @@ public partial class Npc : Unit
         if (started > 0)
         {
             Logger.Info(
-                "OnSpawn plot_only scheduled bc={0} tpl={1} count={2}",
+                "OnSpawn plot scheduled bc={0} tpl={1} count={2}",
                 ObjId, TemplateId, started);
         }
     }

--- a/AAEmu.Game/Models/Game/NPChar/OnSpawnPlotWorldGate.cs
+++ b/AAEmu.Game/Models/Game/NPChar/OnSpawnPlotWorldGate.cs
@@ -1,0 +1,25 @@
+namespace AAEmu.Game.Models.Game.NPChar;
+
+/// <summary>
+/// When to World-run an OnSpawn plot graph under ZoneAuthority (dedic is silent).
+/// Restricted to tower-priority zone mirrors. A plot id is required; <c>plot_only</c> is not —
+/// Lusca stage skills attach a plot with plot_only false and no direct skill_effects.
+/// Skills that still have direct skill_effects keep the old skip (e.g. Crimson seed open FX).
+/// </summary>
+public static class OnSpawnPlotWorldGate
+{
+    public static bool ShouldRun(
+        bool zoneAuthority,
+        bool isZoneMirror,
+        bool isPriorityMirror,
+        bool hasPlot,
+        bool plotOnly,
+        int directSkillEffectCount)
+    {
+        if (!zoneAuthority || !isZoneMirror || !isPriorityMirror || !hasPlot)
+            return false;
+        if (plotOnly)
+            return true;
+        return directSkillEffectCount <= 0;
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnEffect.cs
@@ -1,12 +1,13 @@
-﻿using AAEmu.Game.Core.Packets;
+﻿using System.Numerics;
+using AAEmu.Game.Core.Packets;
 using AAEmu.Game.Core.Managers.UnitManagers;
-using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills.Effects.Enums;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Utils;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects;
@@ -29,6 +30,32 @@ public class SpawnEffect : EffectTemplate
     public bool EnableRayCast { get; set; } = true;
 
     public override bool OnActionTime => false;
+
+    /// <summary>
+    /// spawn_effects.pos_dir: 1 = target, 2 = caster. 0/3 have no separate unit — use target then caster.
+    /// </summary>
+    public static BaseUnit ResolvePositionUnit(uint posDirId, BaseUnit caster, BaseUnit target) =>
+        posDirId switch
+        {
+            1 => target,
+            2 => caster,
+            0 or 3 => target ?? caster,
+            _ => null
+        };
+
+    /// <summary>
+    /// spawn_effects.ori_dir: 1 = target, 2 = caster. 0/3 = plot facing (keep the position unit).
+    /// Lusca army rows use ori_dir 3 with pos_dir 1 and zero offset.
+    /// </summary>
+    public static BaseUnit ResolveOrientationUnit(
+        uint oriDirId, BaseUnit caster, BaseUnit target, BaseUnit positionUnit) =>
+        oriDirId switch
+        {
+            1 => target,
+            2 => caster,
+            0 or 3 => positionUnit,
+            _ => null
+        };
 
     public override void Apply(BaseUnit caster, SkillCaster casterObj, BaseUnit target, SkillCastTarget targetObj,
         CastAction castObj, EffectSource source, SkillObject skillObject, DateTime time,
@@ -53,20 +80,9 @@ public class SpawnEffect : EffectTemplate
                         return;
                     }
 
-                    // dir id 1 = relative to target/spawner.
-                    // dir id 2 = relative to caster.
-                    var positionRelativeToUnit = PosDirId switch
-                    {
-                        1 => target,
-                        2 => caster,
-                        _ => null
-                    };
-                    var orientationRelativeToUnit = OriDirId switch
-                    {
-                        1 => target,
-                        2 => caster,
-                        _ => null
-                    };
+                    var positionRelativeToUnit = ResolvePositionUnit(PosDirId, caster, target);
+                    var orientationRelativeToUnit = ResolveOrientationUnit(
+                        OriDirId, caster, target, positionRelativeToUnit);
 
                     if (positionRelativeToUnit == null || orientationRelativeToUnit == null)
                     {
@@ -132,18 +148,9 @@ public class SpawnEffect : EffectTemplate
             return;
         }
 
-        var positionRelativeToUnit = PosDirId switch
-        {
-            1 => target,
-            2 => caster,
-            _ => null
-        };
-        var orientationRelativeToUnit = OriDirId switch
-        {
-            1 => target,
-            2 => caster,
-            _ => null
-        };
+        var positionRelativeToUnit = ResolvePositionUnit(PosDirId, caster, target);
+        var orientationRelativeToUnit = ResolveOrientationUnit(
+            OriDirId, caster, target, positionRelativeToUnit);
         if (positionRelativeToUnit?.Transform == null || orientationRelativeToUnit?.Transform == null)
         {
             Logger.Warn($"SpawnEffect: unhandled PosDirId {PosDirId} or OriDirId {OriDirId}.");
@@ -184,6 +191,9 @@ public class SpawnEffect : EffectTemplate
         if (UseSummonerFaction && caster is Unit summoner)
             npc.Faction = summoner.Faction;
 
+        Logger.Info(
+            "SpawnEffect npc={0} world=({1:F1},{2:F1},{3:F1}) posDir={4} oriDir={5}",
+            templateId, x, y, z, PosDirId, OriDirId);
         npc.IsZoneMirror = true;
         npc.Spawn();
         if (!WorldIntegration.PublishNpcSpawn(
@@ -203,6 +213,7 @@ public class SpawnEffect : EffectTemplate
 
     /// <summary>
     /// Floor Z for ground army (Crimson balls land then emerge). Aerial Z kept for fliers.
+    /// Delegates to <see cref="TerrainFloor"/> — heightmap sample + snap caps, never GeoData.
     /// </summary>
     private float ResolveSpawnZ(BaseUnit anchor, float x, float y, float rawZ, bool canFly)
     {
@@ -223,23 +234,15 @@ public class SpawnEffect : EffectTemplate
         if (zoneId == 0)
             return rawZ;
 
-        var ground = WorldManager.Instance.GetReferenceHeight(null, x, y, rawZ, zoneId);
+        var world = anchor?.ParentWorld;
+        var ground = TerrainFloor.SampleHeightmap(world, x, y);
         if (ground <= 0f)
-            ground = WorldManager.Instance.GetHeight(zoneId, x, y, rawZ);
+            ground = TerrainFloor.SampleHeightmap(zoneId, x, y);
 
-        if (ground <= 0f)
-            return rawZ;
+        var probe = new Vector3(x, y, rawZ);
+        var overWater = TerrainFloor.TryWaterSurface(world, probe, out var waterZ);
 
-        // Only correct obvious air spawns (rift is typically +40–60 m).
-        if (rawZ > ground + 3f)
-        {
-            Logger.Debug(
-                "SpawnEffect terrain snap SubType={0} rawZ={1:F1} → ground={2:F1} @({3:F1},{4:F1})",
-                SubType, rawZ, ground, x, y);
-            return ground;
-        }
-
-        return rawZ;
+        return TerrainFloor.ChooseUnitFloorZ(rawZ, ground, overWater, waterZ, SubType);
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTargetInfo.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTargetInfo.cs
@@ -328,26 +328,61 @@ public class PlotTargetInfo
     {
         var offsetM = heightOffsetRaw / 1000f;
         var anchorZ = previous?.Transform?.World.Position.Z ?? 0f;
-        var raised = anchorZ + offsetM;
-        var ground = WorldManager.Instance.GetHeight(posUnit.Transform);
-        if (ground <= 0f)
+        var pos = posUnit?.Transform?.World.Position ?? default;
+        var world = previous?.ParentWorld ?? posUnit?.ParentWorld;
+        var ground = TerrainFloor.SampleHeightmap(world, pos.X, pos.Y);
+        if (ground <= 0f && posUnit?.Transform != null)
+            ground = TerrainFloor.SampleHeightmap(posUnit.Transform.ZoneId, pos.X, pos.Y);
+
+        var waterSurfaceZ = 0f;
+        var overWater = false;
+        if (world != null && posUnit?.Transform != null)
+        {
+            // Prefer the caster's altitude when probing water so a glider over open sea is not
+            // classified from a seabed-snapped marker.
+            var probe = previous?.Transform != null
+                ? new System.Numerics.Vector3(pos.X, pos.Y, previous.Transform.World.Position.Z)
+                : pos;
+            overWater = TerrainFloor.TryWaterSurface(world, probe, out waterSurfaceZ);
+        }
+
+        return ChoosePlotAreaHeight(
+            anchorZ,
+            ground,
+            offsetM,
+            previous is Npc { CanFly: true },
+            overWater,
+            waterSurfaceZ);
+    }
+
+    /// <summary>
+    /// Pure floor pick for plot Area / RandomArea markers.
+    /// Flying NPC portals snap down onto terrain/water. Characters (glider nitro, etc.) keep
+    /// altitude + small HeightOffset — do not treat "high above seabed/heightmap" as a portal.
+    /// </summary>
+    public static float ChoosePlotAreaHeight(
+        float anchorZ,
+        float ground,
+        float offsetMetres,
+        bool previousIsFlyingNpc,
+        bool overWater = false,
+        float waterSurfaceZ = 0f)
+    {
+        var raised = anchorZ + offsetMetres;
+        var floor = ground;
+        if (overWater && waterSurfaceZ > ground + 1f)
+            floor = waterSurfaceZ;
+        if (floor <= 0f)
             return raised;
 
-        // Typical retail RandomArea after portal: |offset| 300–500 m is "search down from sky"
-        // rather than place 500 m above the anchor.
-        if (Math.Abs(offsetM) >= 100f)
-            return ground;
+        // Typical retail RandomArea after portal: |offset| 300–500 m is "search down from sky".
+        if (Math.Abs(offsetMetres) >= 100f)
+            return floor;
 
-        // Flying portal / synthetic previous keep Math.Max only for shallow lifts; otherwise land.
-        var previousIsAerial = previous is Npc { CanFly: true }
-                               || (previous != null
-                                   && previous.ObjId != uint.MaxValue
-                                   && ground > 0f
-                                   && anchorZ > ground + 8f);
-        if (previousIsAerial && raised > ground + 2f)
-            return ground;
+        if (previousIsFlyingNpc && raised > floor + 2f)
+            return floor;
 
-        return Math.Max(raised, ground);
+        return Math.Max(raised, floor);
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTicketGate.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTicketGate.cs
@@ -1,0 +1,20 @@
+namespace AAEmu.Game.Models.Game.Skills.Plots.Tree;
+
+/// <summary>
+/// Plot event <c>tickets</c> is a max visit count on self-next loops.
+/// tickets &lt;= 0 stays uncapped. tickets == 1 on a self-next means one visit (stops a rotate
+/// loop). tickets == 1 without a self-next is not a cap — several parents can enqueue the same
+/// spawn event (Lusca 1827: three rings merge into one SpawnEffect node).
+/// tickets &gt;= 2 always caps at that many visits.
+/// </summary>
+public static class PlotTicketGate
+{
+    public static bool IsExhausted(int visitCount, int maxTickets, bool selfLoop = false)
+    {
+        if (maxTickets <= 0)
+            return false;
+        if (maxTickets == 1 && !selfLoop)
+            return false;
+        return visitCount > maxTickets;
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTree.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTree.cs
@@ -70,8 +70,9 @@ public class PlotTree(uint plotId)
                     else
                         state.Tickets.TryAdd(node.Event.Id, 1);
 
-                    //Check if we hit max tickets
-                    if (state.Tickets[node.Event.Id] > node.Event.Tickets && node.Event.Tickets > 1)
+                    var selfLoop = node.Children.Exists(c => c.Event.Id == node.Event.Id);
+                    if (PlotTicketGate.IsExhausted(
+                            state.Tickets[node.Event.Id], node.Event.Tickets, selfLoop))
                     {
                         continue;
                     }

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -61,6 +61,12 @@ public class Skill
     public bool SuppressZoneSkillRelay { get; set; }
 
     /// <summary>
+    /// World OnSpawn fill: run the plot graph and return without Cast(), same as plot_only.
+    /// Lusca stage skills have a plot with plot_only false and empty skill_effects.
+    /// </summary>
+    public bool ForcePlotGraphOnly { get; set; }
+
+    /// <summary>
     /// Multiplier that can be added as an additional modifier to casting times
     /// </summary>
     public float CastTimeMultiplier { get; set; } = 1f;
@@ -237,11 +243,11 @@ public class Skill
         // If skill uses Plots, then start the plot
         if (Template.Plot != null)
         {
-            if (Template.PlotOnly)
+            if (Template.PlotOnly || ForcePlotGraphOnly)
             {
-                // plot_only returns before Cast() — apply start costs here. GCD for cast-time plot_only
-                // is applied when the plot leaves its casting edge (PlotNode → ApplyPlotOnlyFireCosts).
-                // Zone needs WZSkillStarted now (Cast never runs).
+                // plot_only (and World OnSpawn fill) returns before Cast() — apply start costs here.
+                // GCD for cast-time plot_only is applied when the plot leaves its casting edge
+                // (PlotNode → ApplyPlotOnlyFireCosts). Zone needs WZSkillStarted now (Cast never runs).
                 RelayZoneSkillStartedIfNeeded(casterCaster, targetCaster, skillObject);
                 ConsumeMana(caster);
                 if (Template.CastingTime <= 0)

--- a/AAEmu.Game/Models/Game/Skills/ZoneAuthorityCombat.cs
+++ b/AAEmu.Game/Models/Game/Skills/ZoneAuthorityCombat.cs
@@ -201,7 +201,7 @@ public static class ZoneAuthorityCombat
         if (world == null)
             return false;
 
-        var npc = world.GetNpc(objId);
+        var npc = world.GetNpc(objId) ?? WorldIntegration.FindUnitAcrossWorlds(objId) as Npc;
         if (npc == null)
         {
             // Player ClearCombat (common) — relay SC only; NPC HP restore waits for 11503 / NPC ClearCombat.
@@ -237,6 +237,32 @@ public static class ZoneAuthorityCombat
         Logger.Info("ZoneAuthority leash heal npc={0} hp {1}→{2} mp {3}→{4}",
             objId, beforeHp, npc.Hp, beforeMp, npc.Mp);
         return true;
+    }
+
+    /// <summary>
+    /// Unit the dedicate can put on an NPC aggro table. Cannon/equipment slaves are not zone
+    /// combat actors; their owner (or hull) is.
+    /// </summary>
+    public static uint ResolveZoneCombatActorBc(BaseUnit caster)
+    {
+        if (caster == null || caster.ObjId == 0)
+            return 0;
+        if (caster is Character)
+            return caster.ObjId;
+
+        var owner = caster.GetOwnerCharacter();
+        if (owner?.ObjId > 0)
+            return owner.ObjId;
+
+        if (caster is Slave slave)
+        {
+            if (slave.Transform?.Parent?.GameObject is Slave hull && hull.ObjId != 0)
+                return hull.ObjId;
+            if (slave.Template?.IsABoat() == true)
+                return slave.ObjId;
+        }
+
+        return caster.ObjId;
     }
 
     private static int EstimateDamage(SkillTemplate template, Unit caster, Unit target)

--- a/AAEmu.Game/Models/Game/Slaves/SlaveTemplate.cs
+++ b/AAEmu.Game/Models/Game/Slaves/SlaveTemplate.cs
@@ -1,4 +1,5 @@
 ﻿using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.StreamAoi;
 using AAEmu.Game.Models.StaticValues;
 
 namespace AAEmu.Game.Models.Game.Slaves;
@@ -54,5 +55,21 @@ public class SlaveTemplate
     public bool IsClientDrivenLandVehicle()
     {
         return SlaveKind is SlaveKind.Tank or SlaveKind.Machine or SlaveKind.SiegeWeapon;
+    }
+
+    /// <summary>
+    /// Hulls use Ship. Equipment slaves (sails/cannons) are Part — they must not Ambient-cull
+    /// at 105 m while the hull stays to 248 m. Doodad sails are not this type.
+    /// </summary>
+    public StreamAoiCategory StreamAoiCategory
+    {
+        get
+        {
+            if (IsABoat() || SlaveKind == SlaveKind.Leviathan)
+                return StreamAoiCategory.Ship;
+            if (SlaveKind == SlaveKind.SlaveEquipment)
+                return StreamAoiCategory.Part;
+            return StreamAoiCategory.Ambient;
+        }
     }
 }

--- a/AAEmu.Game/Models/Game/StreamAoi/StreamAoi.cs
+++ b/AAEmu.Game/Models/Game/StreamAoi/StreamAoi.cs
@@ -1,0 +1,137 @@
+using System.Globalization;
+
+namespace AAEmu.Game.Models.Game.StreamAoi;
+
+/// <summary>
+/// Category radii for mirror SC. Env overrides keep the old kill-switches.
+/// <c>AAEMU_MIRROR_NPC_AOI</c> ambient enter (exit = enter+5 when unset).
+/// <c>AAEMU_MIRROR_LARGE_AOI_ENTER</c> / <c>_EXIT</c>.
+/// <c>AAEMU_MIRROR_SHIP_AOI_ENTER</c> / <c>_EXIT</c>.
+/// <c>AAEMU_MIRROR_PRIORITY_AOI</c> event enter+exit.
+/// </summary>
+public static class StreamAoiTable
+{
+    private static StreamAoiConfig _config = CreateDefault();
+    private static HashSet<uint> _largeTemplates = [.._config.LargeNpcTemplateIds];
+    private static HashSet<uint> _largeModels = [.._config.LargeModelIds];
+
+    public static StreamAoiConfig Config => _config;
+
+    public static void ReplaceConfig(StreamAoiConfig config)
+    {
+        _config = Normalize(config ?? CreateDefault());
+        _largeTemplates = [.._config.LargeNpcTemplateIds ?? []];
+        _largeModels = [.._config.LargeModelIds ?? []];
+        ApplyEnvOverrides(_config);
+    }
+
+    public static StreamAoiConfig CreateDefault()
+    {
+        var cfg = new StreamAoiConfig();
+        ApplyEnvOverrides(cfg);
+        return cfg;
+    }
+
+    public static StreamAoiBand Band(StreamAoiCategory category) =>
+        category switch
+        {
+            StreamAoiCategory.Large => _config.Large,
+            StreamAoiCategory.Ship => _config.Ship,
+            StreamAoiCategory.Event => _config.Event,
+            _ => _config.Ambient
+        };
+
+    public static bool IsInside(StreamAoiCategory category, float distanceSq, bool alreadyStreamed)
+    {
+        // Retail: hull unselects at Ship exit; sails/cannons stay until the region drops.
+        if (category == StreamAoiCategory.Part)
+            return true;
+
+        var band = Band(category);
+        return distanceSq <= (alreadyStreamed ? band.ExitSq : band.EnterSq);
+    }
+
+    public static bool IsLargeNpc(uint templateId, uint modelId) =>
+        (templateId != 0 && _largeTemplates.Contains(templateId))
+        || (modelId != 0 && _largeModels.Contains(modelId));
+
+    /// <summary>
+    /// Linear map of a measured reference onto another height. Not used as live metres
+    /// (sea hulls and bosses share the measured 225/248 band).
+    /// </summary>
+    public static StreamAoiBand InterpolateHeight(
+        float heightMetres,
+        float referenceHeight,
+        StreamAoiBand reference,
+        StreamAoiBand ambient,
+        float personHeight = 1.8f)
+    {
+        if (heightMetres <= personHeight || referenceHeight <= personHeight)
+            return ambient.Clone();
+
+        var t = (heightMetres - personHeight) / (referenceHeight - personHeight);
+        t = Math.Clamp(t, 0f, 1f);
+        return new StreamAoiBand
+        {
+            EnterMetres = ambient.EnterMetres + (reference.EnterMetres - ambient.EnterMetres) * t,
+            ExitMetres = ambient.ExitMetres + (reference.ExitMetres - ambient.ExitMetres) * t
+        };
+    }
+
+    private static StreamAoiConfig Normalize(StreamAoiConfig cfg)
+    {
+        cfg.Ambient = ClampBand(cfg.Ambient, 105f, 110f, minEnter: 20f);
+        cfg.Large = ClampBand(cfg.Large, 225f, 248f, minEnter: 50f);
+        cfg.Ship = ClampBand(cfg.Ship, 225f, 248f, minEnter: 50f);
+        cfg.Event = ClampBand(cfg.Event, 700f, 700f, minEnter: 50f);
+        cfg.LargeNpcTemplateIds ??= [];
+        cfg.LargeModelIds ??= [];
+        return cfg;
+    }
+
+    private static StreamAoiBand ClampBand(StreamAoiBand band, float enter, float exit, float minEnter)
+    {
+        band ??= new StreamAoiBand { EnterMetres = enter, ExitMetres = exit };
+        if (band.EnterMetres < minEnter)
+            band.EnterMetres = enter;
+        if (band.ExitMetres < band.EnterMetres)
+            band.ExitMetres = band.EnterMetres;
+        return band;
+    }
+
+    private static void ApplyEnvOverrides(StreamAoiConfig cfg)
+    {
+        if (TryMetres("AAEMU_MIRROR_NPC_AOI", 20f, out var ambientEnter))
+        {
+            cfg.Ambient.EnterMetres = ambientEnter;
+            if (!TryMetres("AAEMU_MIRROR_NPC_AOI_EXIT", 20f, out var ambientExit))
+                ambientExit = ambientEnter + 5f;
+            cfg.Ambient.ExitMetres = Math.Max(ambientExit, cfg.Ambient.EnterMetres);
+        }
+
+        if (TryMetres("AAEMU_MIRROR_LARGE_AOI_ENTER", 50f, out var largeEnter))
+            cfg.Large.EnterMetres = largeEnter;
+        if (TryMetres("AAEMU_MIRROR_LARGE_AOI_EXIT", 50f, out var largeExit))
+            cfg.Large.ExitMetres = Math.Max(largeExit, cfg.Large.EnterMetres);
+
+        if (TryMetres("AAEMU_MIRROR_SHIP_AOI_ENTER", 50f, out var shipEnter))
+            cfg.Ship.EnterMetres = shipEnter;
+        if (TryMetres("AAEMU_MIRROR_SHIP_AOI_EXIT", 50f, out var shipExit))
+            cfg.Ship.ExitMetres = Math.Max(shipExit, cfg.Ship.EnterMetres);
+
+        if (TryMetres("AAEMU_MIRROR_PRIORITY_AOI", 50f, out var eventMetres))
+        {
+            cfg.Event.EnterMetres = eventMetres;
+            cfg.Event.ExitMetres = eventMetres;
+        }
+    }
+
+    private static bool TryMetres(string env, float min, out float metres)
+    {
+        metres = 0f;
+        var raw = Environment.GetEnvironmentVariable(env);
+        return !string.IsNullOrEmpty(raw)
+               && float.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out metres)
+               && metres >= min;
+    }
+}

--- a/AAEmu.Game/Models/Game/StreamAoi/StreamAoiBand.cs
+++ b/AAEmu.Game/Models/Game/StreamAoi/StreamAoiBand.cs
@@ -1,0 +1,13 @@
+namespace AAEmu.Game.Models.Game.StreamAoi;
+
+/// <summary>Enter (approach) vs exit (leave) metres — sticky hysteresis.</summary>
+public sealed class StreamAoiBand
+{
+    public float EnterMetres { get; set; }
+    public float ExitMetres { get; set; }
+
+    public float EnterSq => EnterMetres * EnterMetres;
+    public float ExitSq => ExitMetres * ExitMetres;
+
+    public StreamAoiBand Clone() => new() { EnterMetres = EnterMetres, ExitMetres = ExitMetres };
+}

--- a/AAEmu.Game/Models/Game/StreamAoi/StreamAoiCategory.cs
+++ b/AAEmu.Game/Models/Game/StreamAoi/StreamAoiCategory.cs
@@ -1,0 +1,35 @@
+namespace AAEmu.Game.Models.Game.StreamAoi;
+
+/// <summary>
+/// Soft SCUnitState interest bands. Region neighborhood is still the coarse pool;
+/// these radii decide paint vs <c>SCUnitsRemoved</c>.
+/// </summary>
+public enum StreamAoiCategory : byte
+{
+    /// <summary>
+    /// Players, farm haulers, and normal NPCs. Measured: appear ~105 m, gone ~110 m.
+    /// </summary>
+    Ambient = 0,
+
+    /// <summary>
+    /// Sea bosses (Kraken / Leviathan NPC). Same band as ships: appear ~225 m, gone ~248 m.
+    /// </summary>
+    Large = 1,
+
+    /// <summary>
+    /// Sea hulls (schooner, clipper, other boats). Appear ~225 m, gone ~248 m.
+    /// Selectable Slave only — attached sail/cannon doodads stream separately.
+    /// </summary>
+    Ship = 2,
+
+    /// <summary>
+    /// Tower hellgates / event seeds. Appear/gone ~700 m.
+    /// </summary>
+    Event = 3,
+
+    /// <summary>
+    /// Post-1.7 ship parts (sail/cannon doodads and SlaveKind equipment). Not the selectable hull.
+    /// Soft unit AOI does not apply — they linger after the hull unselects until region leave.
+    /// </summary>
+    Part = 4
+}

--- a/AAEmu.Game/Models/Game/StreamAoi/StreamAoiConfig.cs
+++ b/AAEmu.Game/Models/Game/StreamAoi/StreamAoiConfig.cs
@@ -1,0 +1,16 @@
+namespace AAEmu.Game.Models.Game.StreamAoi;
+
+/// <summary>Bind from <c>Configurations/StreamAoi.json</c> under <c>StreamAoi</c>.</summary>
+public sealed class StreamAoiConfig
+{
+    public StreamAoiBand Ambient { get; set; } = new() { EnterMetres = 105f, ExitMetres = 110f };
+    public StreamAoiBand Large { get; set; } = new() { EnterMetres = 225f, ExitMetres = 248f };
+    public StreamAoiBand Ship { get; set; } = new() { EnterMetres = 225f, ExitMetres = 248f };
+    public StreamAoiBand Event { get; set; } = new() { EnterMetres = 700f, ExitMetres = 700f };
+
+    /// <summary>World Kraken / Leviathan templates measured on EU (optional extras).</summary>
+    public List<uint> LargeNpcTemplateIds { get; set; } = [7607, 14915];
+
+    /// <summary>compact <c>models.id</c> for those bosses (Kraken 897, Leviathan 530).</summary>
+    public List<uint> LargeModelIds { get; set; } = [897, 530];
+}

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -723,6 +723,28 @@ public class Slave : Unit
     }
 
     /// <summary>
+    /// Cinema / teleport resend. The client dropped what it had, so the slot is released and
+    /// the hull is sent again — at exit-band eligibility when it was already streamed and is
+    /// still inside that band, otherwise through the normal enter-band path.
+    /// </summary>
+    public void ResendVisibleObject(Character character)
+    {
+        if (character == null)
+            return;
+
+        var repaint = character.ShouldRepaintStreamedSlave(this);
+        character.ReleaseSlaveSlot(ObjId);
+        if (!repaint)
+        {
+            AddVisibleObject(character);
+            return;
+        }
+
+        SendUnitStateTo(character);
+        base.AddVisibleObject(character);
+    }
+
+    /// <summary>
     /// Hull SCUnitState + points + slave-state + faction. Marks the character's slave stream
     /// slot. Does not walk children.
     /// </summary>

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -18,6 +18,7 @@ using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Slaves;
 using AAEmu.Game.Models.Game.Static;
+using AAEmu.Game.Models.Game.StreamAoi;
 using AAEmu.Game.Models.Game.Units.Static;
 using AAEmu.Game.Models.StaticValues;
 
@@ -37,6 +38,14 @@ public class Slave : Unit
     public uint BondingObjId { get; set; } = 0;
 
     public SlaveTemplate Template { get; set; }
+
+    /// <summary>
+    /// Sea hulls (and player Leviathan kind) use Ship 225/248. Farm haulers use Ambient.
+    /// SlaveKind equipment (sails/cannons as units) is Part: no soft unit cull. Doodad sails
+    /// are not slaves — they stay until region leave. SC cull is not wired for hulls yet.
+    /// </summary>
+    public StreamAoiCategory StreamAoiCategory =>
+        Template?.StreamAoiCategory ?? StreamAoiCategory.Ambient;
     // public Character Driver { get; set; }
     public Character Summoner { get; set; }
     public BaseUnitType OwnerType { get; init; }
@@ -729,6 +738,8 @@ public class Slave : Unit
 
     public override void RemoveVisibleObject(Character character)
     {
+        // Region leave: base walks Transform.Children (sails/cannons). Soft Ship-band cull
+        // of the selectable hull must not use this path — those doodads linger commercially.
         base.RemoveVisibleObject(character);
 
         character.SendPacket(new SCUnitsRemovedPacket([ObjId]));

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -42,7 +42,7 @@ public class Slave : Unit
     /// <summary>
     /// Sea hulls (and player Leviathan kind) use Ship 225/248. Farm haulers use Ambient.
     /// SlaveKind equipment (sails/cannons as units) is Part: no soft unit cull. Doodad sails
-    /// are not slaves — they stay until region leave. SC cull is not wired for hulls yet.
+    /// are not slaves — they stay until region leave.
     /// </summary>
     public StreamAoiCategory StreamAoiCategory =>
         Template?.StreamAoiCategory ?? StreamAoiCategory.Ambient;
@@ -712,6 +712,27 @@ public class Slave : Unit
 
     public override void AddVisibleObject(Character character)
     {
+        if (character.CanStreamSlaveNow(this))
+            SendUnitStateTo(character);
+        else
+            character.EnqueuePendingSlave(this);
+
+        // Children (sail doodads, equipment slaves) still paint with region interest.
+        // Soft hull cull must not reverse that via RemoveVisibleObject.
+        base.AddVisibleObject(character);
+    }
+
+    /// <summary>
+    /// Hull SCUnitState + points + slave-state + faction. Marks the character's slave stream
+    /// slot. Does not walk children.
+    /// </summary>
+    public void SendUnitStateTo(Character character)
+    {
+        if (character == null || ObjId == 0)
+            return;
+        if (character.StreamedSlaveIds.ContainsKey(ObjId))
+            return;
+
         character.SendPacket(new SCUnitStatePacket(this));
         character.SendPacket(new SCUnitPointsPacket(ObjId, Hp, Mp));
         character.SendPacket(new SCSlaveStatePacket(ObjId, TlId, Summoner?.Name ?? string.Empty, Summoner?.ObjId ?? 0, Id));
@@ -723,7 +744,7 @@ public class Slave : Unit
             character.SendPacket(new SCUnitFactionChangedPacket(
                 ObjId, Name ?? "", FactionsEnum.Invalid, Faction.Id, false));
 
-        base.AddVisibleObject(character);
+        character.MarkSlaveStreamed(this);
 
         foreach (var ati in AttachedCharacters)
         {
@@ -738,6 +759,8 @@ public class Slave : Unit
 
     public override void RemoveVisibleObject(Character character)
     {
+        character.ReleaseSlaveSlot(ObjId);
+
         // Region leave: base walks Transform.Children (sails/cannons). Soft Ship-band cull
         // of the selectable hull must not use this path — those doodads linger commercially.
         base.RemoveVisibleObject(character);

--- a/AAEmu.Game/Models/Game/Units/UnitCustomModelParams.cs
+++ b/AAEmu.Game/Models/Game/Units/UnitCustomModelParams.cs
@@ -194,6 +194,20 @@ public class UnitCustomModelParams : PacketMarshaler
         return this;
     }
 
+    /// <summary>
+    /// Visual race is a race-change override. Unused means 0. Copying the real race is an active
+    /// override, and the client treats the character as transformed.
+    /// </summary>
+    public void ClearUnusedVisualRaceOverride(byte originRace)
+    {
+        if (VisualRace != 0 && VisualRace != originRace)
+            return;
+
+        VisualRace = 0;
+        VisualGender = 0;
+        VisualRaceExpiredTime = 0;
+    }
+
     public override void Read(PacketStream stream)
     {
         SetType((UnitCustomModelType)stream.ReadByte()); // ext

--- a/AAEmu.Game/Models/Game/World/Region.cs
+++ b/AAEmu.Game/Models/Game/World/Region.cs
@@ -217,6 +217,12 @@ public class Region(WorldInstance worldInstance, int x, int y, uint zoneKey)
                 // Ambient mirrors: free MAX slots so walking recycles interest capacity.
                 if (t is Npc { IsZoneMirror: true } mirror)
                     character1.ReleaseMirrorNpcSlot(mirror.ObjId);
+                if (t is Slave slave)
+                {
+                    if (character1.TryKeepSlaveAcrossRegionLeave(slave))
+                        continue;
+                    character1.ReleaseSlaveSlot(slave.ObjId);
+                }
                 unitIds.Add(t.ObjId);
             }
 

--- a/AAEmu.Game/Models/Game/World/TerrainFloor.cs
+++ b/AAEmu.Game/Models/Game/World/TerrainFloor.cs
@@ -1,0 +1,158 @@
+using System.Numerics;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Models;
+using NLog;
+
+namespace AAEmu.Game.Models.Game.World;
+
+/// <summary>
+/// Unit placement floor policy. Sample the XY heightmap, then snap with lift/drop caps.
+/// Do not use <c>GeoData.GetHeight</c> for standing units — that picks the nearest .bai node in
+/// 3D space, so a high probe (stage/rift) snaps to cliff lips and units bounce.
+/// Requires <c>HeightMapsEnable</c> (set true in Config.Local.json for this stack).
+/// </summary>
+public static class TerrainFloor
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    /// <summary>Dedicate spawn points sit slightly above the sampled floor.</summary>
+    public const float ClearanceMetres = 0.4f;
+
+    /// <summary>Within this band of ground, sit on the floor (+ clearance).</summary>
+    public const float NearBandMetres = 3f;
+
+    /// <summary>Max lift onto a sampled floor; larger gaps are cliff / bad samples.</summary>
+    public const float MaxUpwardSnapMetres = 8f;
+
+    /// <summary>Longest drop from a portal/rift ball onto terrain; deeper keeps raw Z.</summary>
+    public const float MaxDownwardSnapMetres = 12f;
+
+    /// <summary>Water must clear the seabed by this much before we prefer the surface.</summary>
+    public const float WaterAboveSeabedMetres = 1f;
+
+    /// <summary>
+    /// Heightmap-only sample at continent XY. Returns 0 when heightmaps are off or missing.
+    /// </summary>
+    public static float SampleHeightmap(WorldInstance world, float x, float y)
+    {
+        if (world == null || !AppConfiguration.Instance.HeightMapsEnable)
+            return 0f;
+        try
+        {
+            return world.GetHeight(x, y);
+        }
+        catch
+        {
+            return 0f;
+        }
+    }
+
+    /// <summary>
+    /// Heightmap-only sample via the world template that owns <paramref name="zoneId"/>.
+    /// </summary>
+    public static float SampleHeightmap(uint zoneId, float x, float y)
+    {
+        if (zoneId == 0 || !AppConfiguration.Instance.HeightMapsEnable)
+            return 0f;
+        try
+        {
+            var template = WorldManager.Instance.GetWorldTemplateByZoneKey(zoneId);
+            return template?.GetHeight(x, y) ?? 0f;
+        }
+        catch
+        {
+            return 0f;
+        }
+    }
+
+    /// <summary>
+    /// True when the probe is over water and a surface Z is available (not the seabed).
+    /// Open ocean: heightmap is the seabed below <c>OceanLevel</c>. Event plots (Lusca) often
+    /// place markers above the plane (~120) so <c>IsWater(rawZ)</c> is false — do not clamp Z
+    /// into <c>IsWater</c> (ocean is a global plane and would mark dry land as water).
+    /// </summary>
+    public static bool TryWaterSurface(WorldInstance world, Vector3 probe, out float waterSurfaceZ)
+    {
+        waterSurfaceZ = 0f;
+        if (world == null)
+            return false;
+
+        var ocean = world.Template?.OceanLevel ?? world.Water?.OceanLevel ?? 0f;
+
+        if (world.IsWater(probe))
+        {
+            waterSurfaceZ = world.Water?.GetWaterSurface(probe, out _) ?? ocean;
+            return waterSurfaceZ > 0f;
+        }
+
+        // Plot above the ocean plane: treat as open sea only when heightmap is clearly seabed.
+        if (ocean <= 0f)
+            return false;
+        var ground = SampleHeightmap(world, probe.X, probe.Y);
+        if (ground <= 0f || ground >= ocean - WaterAboveSeabedMetres)
+            return false;
+
+        waterSurfaceZ = ocean;
+        return true;
+    }
+
+    /// <summary>
+    /// Pure snap: near-band sit, mild underground lift, short drop, water surface, else keep raw.
+    /// Never invent a floor from stage/caster altitude — pass heightmap (or 0) as <paramref name="ground"/>.
+    /// </summary>
+    /// <param name="logTag">Optional id for Info logs (e.g. SpawnEffect SubType).</param>
+    public static float ChooseUnitFloorZ(
+        float rawZ,
+        float ground,
+        bool overWater,
+        float waterSurfaceZ,
+        uint logTag = 0)
+    {
+        if (ground <= 0f)
+            return rawZ;
+
+        if (overWater && waterSurfaceZ > ground + WaterAboveSeabedMetres)
+        {
+            Logger.Info(
+                "TerrainFloor water snap tag={0} rawZ={1:F1} ground={2:F1} → water={3:F1}",
+                logTag, rawZ, ground, waterSurfaceZ);
+            return OnFloor(waterSurfaceZ);
+        }
+
+        if (rawZ >= ground - NearBandMetres && rawZ <= ground + NearBandMetres)
+            return OnFloor(ground);
+
+        if (rawZ < ground - NearBandMetres)
+        {
+            var lift = ground - rawZ;
+            if (lift > MaxUpwardSnapMetres)
+            {
+                Logger.Info(
+                    "TerrainFloor keep raw tag={0} rawZ={1:F1} ignored ground={2:F1} (lift {3:F1} m > {4:F0} m)",
+                    logTag, rawZ, ground, lift, MaxUpwardSnapMetres);
+                return OnFloor(rawZ);
+            }
+
+            Logger.Info(
+                "TerrainFloor lift tag={0} rawZ={1:F1} → ground={2:F1}",
+                logTag, rawZ, ground);
+            return OnFloor(ground);
+        }
+
+        var drop = rawZ - ground;
+        if (drop <= MaxDownwardSnapMetres)
+        {
+            Logger.Info(
+                "TerrainFloor drop tag={0} rawZ={1:F1} → ground={2:F1}",
+                logTag, rawZ, ground);
+            return OnFloor(ground);
+        }
+
+        Logger.Info(
+            "TerrainFloor keep raw tag={0} rawZ={1:F1} ignored ground={2:F1} (drop {3:F1} m > {4:F0} m)",
+            logTag, rawZ, ground, drop, MaxDownwardSnapMetres);
+        return rawZ;
+    }
+
+    private static float OnFloor(float ground) => ground + ClearanceMetres;
+}

--- a/AAEmu.Game/Models/Tasks/Network/MirrorSpawnStreamTask.cs
+++ b/AAEmu.Game/Models/Tasks/Network/MirrorSpawnStreamTask.cs
@@ -46,6 +46,8 @@ public class MirrorSpawnStreamTask : Task
 
                 // Leave-view first (beyond soft AOI) — frees MAX slots before we try to send.
                 character.CullStreamedMirrorsBeyondAoi();
+                character.CullStreamedSlavesBeyondAoi();
+                character.TryFlushPendingSlaves();
 
                 // At cap: nearer pending first, then event/tower priority rifts (steal ambient slot).
                 if (Npc.MirrorNpcMaxPerCharacter > 0 &&

--- a/AAEmu.Game/Program.cs
+++ b/AAEmu.Game/Program.cs
@@ -452,6 +452,7 @@ public static class Program
     {
         var configurationRoot = BuildConfiguration(_launchArgs);
         configurationRoot.Bind(AppConfiguration.Instance);
+        Models.Game.StreamAoi.StreamAoiTable.ReplaceConfig(AppConfiguration.Instance.StreamAoi);
     }
 
     private static IConfigurationRoot BuildConfiguration(string[] args)

--- a/AAEmu.Game/WorldIntegration.cs
+++ b/AAEmu.Game/WorldIntegration.cs
@@ -286,7 +286,7 @@ public static class WorldIntegration
     public static Action<CastAction, SkillCaster, uint, HealType, HealHitType, long, uint, bool>
         RelayUnitHealedToZone { get; set; }
 
-    /// <summary>WZKnockBackUnit (0x033). Args: unit bc, world pos xyz.</summary>
+    /// <summary>WZKnockBackUnit (0x033). Args: unit bc, continent xyz (WZ boundary rewrites to zone-local).</summary>
     public static Action<uint, float, float, float> RelayKnockBackToZone { get; set; }
 
     /// <summary>
@@ -625,19 +625,36 @@ public static class WorldIntegration
         return stream.GetBytes();
     }
 
-    /// <summary>Returns a zone-local placement only when local Zone wire coordinates are enabled.</summary>
-    private static Vector3? ResolveWzPlacement(Unit unit, Vector3? zoneLocal = null)
+    /// <summary>
+    /// Zone-local XYZ for WZ UnitState. World <see cref="Unit.Transform"/> stays continent (SC).
+    /// <paramref name="zoneLocal"/> is already zone-local (ZWSpawnNpc or ConvertToLocal) — never convert it again.
+    /// </summary>
+    private static Vector3? ResolveWzPlacement(Unit unit, Vector3? zoneLocal = null, bool forceLocal = false)
     {
-        if (!ZoneAuthority || !ZoneCoordBoundary.UseLocalOnZoneWire || unit?.Transform == null)
+        if (unit?.Transform == null)
             return null;
 
-        if (zoneLocal.HasValue)
+        if (WzCoordPolicy.KeepContinentOnLiveWz(unit) && !forceLocal)
+            return null;
+
+        // Already local. Using Transform.World here would subtract origin a second time and drop the unit off the mesh.
+        if (zoneLocal.HasValue && (forceLocal || ZoneCoordBoundary.UseLocalOnZoneWire))
+        {
+            if (unit is Npc npc)
+                npc.ZoneSimUsesLocalCoordinates = true;
             return zoneLocal;
+        }
+
+        if (!ZoneAuthority || !ZoneCoordBoundary.UseLocalOnZoneWire)
+            return null;
 
         var zoneId = unit.Transform.ZoneId;
         if (zoneId == 0)
             return null;
 
+        if (unit is Npc localNpc)
+            localNpc.ZoneSimUsesLocalCoordinates = true;
+        // Continent Transform → one origin subtract. Z is unchanged (no height remap on this path).
         return ZoneManager.Instance.ConvertToLocalCoordinates(zoneId, unit.Transform.World.Position);
     }
 
@@ -723,18 +740,22 @@ public static class WorldIntegration
         }
 
         npc.IsZoneMirror = true;
+        // Continent on WZ, same as the player. Dedicate subtracts origin for sectors.
+        // Sending zone-local here made Crimson army Create start `invalid sector pos` and fall through.
         var body = BuildWzNpcStateBody(
             npc,
             WorldAuthoredNpcSpawn with { Reason = reason, SpawnAction = spawnAction },
             creator,
             lifeTime,
             despawnOnCreatorDeath,
-            useSummonerAggroTarget);
+            useSummonerAggroTarget,
+            zoneLocalPlacement: null,
+            forceLocalPlacement: false);
         if (body is not { Length: > 0 }
             || RelayNpcSpawnToZone?.Invoke(new WorldNpcSpawnRequest(zoneId, npc.ObjId, body)) != true)
             return false;
 
-        // Same OnSpawn plot_only path as ZW mirrors (tower stage 8830 → army). Safe: zone skill
+        // Same OnSpawn plot path as ZW mirrors (tower stage → army SpawnEffect). Safe: zone skill
         // relay suppressed inside CastOnSpawnPlotSkills.
         npc.CastOnSpawnPlotSkills();
         return true;
@@ -963,7 +984,8 @@ public static class WorldIntegration
             0f,
             false,
             false,
-            zoneLocal);
+            zoneLocal,
+            forceLocalPlacement: ZoneCoordBoundary.UseLocalOnZoneWire && zoneLocal.HasValue);
     }
 
     private static byte[] BuildWzNpcStateBody(
@@ -983,7 +1005,8 @@ public static class WorldIntegration
         float lifeTime,
         bool despawnOnCreatorDeath,
         bool useSummonerAggroTarget,
-        Vector3? zoneLocalPlacement = null)
+        Vector3? zoneLocalPlacement = null,
+        bool forceLocalPlacement = false)
     {
         var stream = new PacketStream();
 
@@ -1040,9 +1063,10 @@ public static class WorldIntegration
                 return null;
         }
 
-        // UnitState and buffs; the optional override is active only in local-wire mode.
+        // Dedicate spawn/nav/sectors are zone-local. World Transform stays continent for SC;
+        // MovementRelay lifts ZW moves when ZoneSimUsesLocalCoordinates is set.
         new SCUnitStatePacket(npc).WriteWzUnitStateAndBuffs(
-            stream, ResolveWzPlacement(npc, zoneLocalPlacement));
+            stream, ResolveWzPlacement(npc, zoneLocalPlacement, forceLocalPlacement));
 
         stream.Write(metadata.SpawningEffectTime);
 
@@ -1182,7 +1206,7 @@ public static class WorldIntegration
             // Ghost-army OnSpawn is fire_anim-only (no buffs) — SC SkillFired, never Skill.Use/WZ.
             // After UnitState: client must already know the bc for fire_anim attach.
             npc.CastOnSpawnAnimationSkills();
-            // Tower stage portals: plot_only OnSpawn (15298 → army SpawnEffect). Dedic is silent;
+            // Tower stage portals: OnSpawn plot graphs (army SpawnEffect). Dedic is silent;
             // World graph with zone skill relay suppressed (see CastOnSpawnPlotSkills).
             npc.CastOnSpawnPlotSkills();
 

--- a/AAEmu.UnitTests/Game/Core/Managers/BoatSpawnPlacementTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/BoatSpawnPlacementTests.cs
@@ -1,0 +1,62 @@
+using System.Numerics;
+
+using AAEmu.Game.Core.Managers;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class BoatSpawnPlacementTests
+{
+    [Test]
+    public async Task ForwardDot_AheadIsPositive()
+    {
+        var caster = new Vector3(0f, 0f, 100f);
+        // yaw 0 → forward is +Y
+        var ahead = new Vector3(0f, 10f, 100f);
+        await Assert.That(SlaveManager.BoatSpawnForwardDot(caster, 0f, ahead)).IsGreaterThan(0.9f);
+    }
+
+    [Test]
+    public async Task ForwardDot_BehindIsNegative()
+    {
+        var caster = new Vector3(0f, 0f, 100f);
+        var behind = new Vector3(0f, -10f, 100f);
+        await Assert.That(SlaveManager.BoatSpawnForwardDot(caster, 0f, behind)).IsLessThan(-0.9f);
+    }
+
+    [Test]
+    public async Task SurfaceAboveCaster_RejectedAsSkyLake()
+    {
+        await Assert.That(SlaveManager.IsBoatSurfaceAllowed(
+            casterZ: 120f, surfaceZ: 200f, floorZ: 150f, minDepth: 5f)).IsFalse();
+    }
+
+    [Test]
+    public async Task DeepWaterNearCaster_Allowed()
+    {
+        await Assert.That(SlaveManager.IsBoatSurfaceAllowed(
+            casterZ: 120f, surfaceZ: 100f, floorZ: 80f, minDepth: 5f)).IsTrue();
+    }
+
+    [Test]
+    public async Task OceanWhileSlightlyUnderSurface_Allowed()
+    {
+        // Swimming: caster Z can sit below the ocean plane.
+        await Assert.That(SlaveManager.IsBoatSurfaceAllowed(
+            casterZ: 95f, surfaceZ: 100f, floorZ: 80f, minDepth: 5f)).IsTrue();
+    }
+
+    [Test]
+    public async Task ShallowWater_Rejected()
+    {
+        await Assert.That(SlaveManager.IsBoatSurfaceAllowed(
+            casterZ: 120f, surfaceZ: 100f, floorZ: 98f, minDepth: 5f)).IsFalse();
+    }
+
+    [Test]
+    public async Task Score_PrefersAheadOverBehind()
+    {
+        var ahead = SlaveManager.ScoreBoatSpawnCandidate(1f, 10f, 10f);
+        var behind = SlaveManager.ScoreBoatSpawnCandidate(-1f, 10f, 10f);
+        await Assert.That(ahead).IsGreaterThan(behind);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/World/ZoneCoordBoundaryTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/World/ZoneCoordBoundaryTests.cs
@@ -1,0 +1,57 @@
+using System.Numerics;
+
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Models.Game.Units.Movements;
+
+namespace AAEmu.UnitTests.Game.Core.Managers.World;
+
+public class ZoneCoordBoundaryTests
+{
+    [Test]
+    public async Task ToZoneLocal_ZoneIdZero_DoesNotRewriteContinent()
+    {
+        var continent = new Vector3(15125.4f, 11437.2f, 172.1f);
+        var got = ZoneCoordBoundary.ToZoneLocal(0, continent, force: true);
+        await Assert.That(got).IsEqualTo(continent);
+    }
+
+    [Test]
+    public async Task HelmRequest_IsNotTreatedAsASpatialPosition()
+    {
+        await Assert.That(ZoneCoordBoundary.CarriesSpatialPosition(new ShipRequestMoveType())).IsFalse();
+        var actor = new UnitMoveType { X = 15125f, Y = 11437f, Z = 172f };
+        await Assert.That(ZoneCoordBoundary.CarriesSpatialPosition(actor)).IsTrue();
+        ZoneCoordBoundary.ShiftWorldToLocal(0, actor);
+        await Assert.That(actor.X).IsEqualTo(15125f);
+        await Assert.That(actor.Y).IsEqualTo(11437f);
+    }
+
+    [Test]
+    public async Task UnsetEnv_DefaultsToContinentOnZoneWire()
+    {
+        await Assert.That(ZoneCoordBoundary.ResolveUseLocalOnZoneWire(null, null)).IsFalse();
+        await Assert.That(ZoneCoordBoundary.ResolveUseLocalOnZoneWire("0", "1")).IsTrue();
+        await Assert.That(ZoneCoordBoundary.ResolveUseLocalOnZoneWire(null, "1")).IsTrue();
+    }
+
+    [Test]
+    public async Task WorldEquals1_ForcesContinentOnWire()
+    {
+        await Assert.That(ZoneCoordBoundary.ResolveUseLocalOnZoneWire("1", null)).IsFalse();
+        await Assert.That(ZoneCoordBoundary.ResolveUseLocalOnZoneWire("1", "1")).IsFalse();
+    }
+
+    [Test]
+    public async Task LocalEquals0_ForcesContinentOnWire()
+    {
+        await Assert.That(ZoneCoordBoundary.ResolveUseLocalOnZoneWire(null, "0")).IsFalse();
+    }
+
+    [Test]
+    public async Task RetailLiveWire_IsContinentUnlessDebugEnv()
+    {
+        await Assert.That(ZoneCoordBoundary.ResolveUseLocalOnZoneWire(null, null)).IsFalse();
+        await Assert.That(WzCoordPolicy.DebugRewriteLiveToZoneLocal)
+            .IsEqualTo(ZoneCoordBoundary.UseLocalOnZoneWire);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/NPChar/NpcTowerDefKillQuotaTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/NPChar/NpcTowerDefKillQuotaTests.cs
@@ -25,4 +25,12 @@ public class NpcTowerDefKillQuotaTests
         var npc = new Npc { TemplateId = 0 };
         await Assert.That(npc.TryConsumeTowerDefKillQuotaNotification(out _)).IsFalse();
     }
+
+    [Test]
+    public async Task LuscaGrade_UsesPriorityStream()
+    {
+        await Assert.That(Npc.UsesPriorityStreamAsKillQuotaBoss(NpcGradeType.BossC)).IsTrue();
+        await Assert.That(Npc.UsesPriorityStreamAsKillQuotaBoss(NpcGradeType.Normal)).IsFalse();
+        await Assert.That(Npc.UsesPriorityStreamAsKillQuotaBoss(NpcGradeType.Elite)).IsFalse();
+    }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/NPChar/OnSpawnPlotWorldGateTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/NPChar/OnSpawnPlotWorldGateTests.cs
@@ -1,0 +1,78 @@
+using AAEmu.Game.Models.Game.NPChar;
+
+namespace AAEmu.UnitTests.Game.Models.Game.NPChar;
+
+public class OnSpawnPlotWorldGateTests
+{
+    [Test]
+    public async Task CrimsonStage_PlotOnly_Runs()
+    {
+        await Assert.That(OnSpawnPlotWorldGate.ShouldRun(
+            zoneAuthority: true,
+            isZoneMirror: true,
+            isPriorityMirror: true,
+            hasPlot: true,
+            plotOnly: true,
+            directSkillEffectCount: 0)).IsTrue();
+    }
+
+    [Test]
+    public async Task LuscaStage_PlotWithoutPlotOnly_Runs()
+    {
+        await Assert.That(OnSpawnPlotWorldGate.ShouldRun(
+            zoneAuthority: true,
+            isZoneMirror: true,
+            isPriorityMirror: true,
+            hasPlot: true,
+            plotOnly: false,
+            directSkillEffectCount: 0)).IsTrue();
+    }
+
+    [Test]
+    public async Task SeedOpenFx_PlotPlusDirectEffects_Skipped()
+    {
+        await Assert.That(OnSpawnPlotWorldGate.ShouldRun(
+            zoneAuthority: true,
+            isZoneMirror: true,
+            isPriorityMirror: true,
+            hasPlot: true,
+            plotOnly: false,
+            directSkillEffectCount: 1)).IsFalse();
+    }
+
+    [Test]
+    public async Task Recruiter_NoPlot_Skipped()
+    {
+        await Assert.That(OnSpawnPlotWorldGate.ShouldRun(
+            zoneAuthority: true,
+            isZoneMirror: true,
+            isPriorityMirror: true,
+            hasPlot: false,
+            plotOnly: false,
+            directSkillEffectCount: 14)).IsFalse();
+    }
+
+    [Test]
+    public async Task AmbientNpc_NotPriority_Skipped()
+    {
+        await Assert.That(OnSpawnPlotWorldGate.ShouldRun(
+            zoneAuthority: true,
+            isZoneMirror: true,
+            isPriorityMirror: false,
+            hasPlot: true,
+            plotOnly: false,
+            directSkillEffectCount: 0)).IsFalse();
+    }
+
+    [Test]
+    public async Task WithoutZoneAuthority_Skipped()
+    {
+        await Assert.That(OnSpawnPlotWorldGate.ShouldRun(
+            zoneAuthority: false,
+            isZoneMirror: true,
+            isPriorityMirror: true,
+            hasPlot: true,
+            plotOnly: true,
+            directSkillEffectCount: 0)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/Effects/SpawnEffectRelativeTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/Effects/SpawnEffectRelativeTests.cs
@@ -1,0 +1,38 @@
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.Skills.Effects;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills.Effects;
+
+public class SpawnEffectRelativeTests
+{
+    [Test]
+    public async Task PosDirTarget_OriDirPlotFacing_UsesTargetForBoth()
+    {
+        var caster = new Npc();
+        var target = new Npc();
+        var pos = SpawnEffect.ResolvePositionUnit(1, caster, target);
+        var ori = SpawnEffect.ResolveOrientationUnit(3, caster, target, pos);
+        await Assert.That(pos).IsEqualTo(target);
+        await Assert.That(ori).IsEqualTo(target);
+    }
+
+    [Test]
+    public async Task OriDirCaster_UsesCaster()
+    {
+        var caster = new Npc();
+        var target = new Npc();
+        var pos = SpawnEffect.ResolvePositionUnit(1, caster, target);
+        var ori = SpawnEffect.ResolveOrientationUnit(2, caster, target, pos);
+        await Assert.That(ori).IsEqualTo(caster);
+    }
+
+    [Test]
+    public async Task UnknownDir_ReturnsNull()
+    {
+        var caster = new Npc();
+        var target = new Npc();
+        await Assert.That(SpawnEffect.ResolvePositionUnit(99, caster, target)).IsNull();
+        await Assert.That(SpawnEffect.ResolveOrientationUnit(99, caster, target, target)).IsNull();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/Plots/PlotAreaHeightTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/Plots/PlotAreaHeightTests.cs
@@ -1,0 +1,49 @@
+using AAEmu.Game.Models.Game.Skills.Plots.Tree;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills.Plots;
+
+public class PlotAreaHeightTests
+{
+    [Test]
+    public async Task GliderNitro_OverLand_KeepsAltitudePlusOffset()
+    {
+        // Skill 13435 plot 38: HeightOffset 10 m. Must not snap a gliding character to terrain.
+        await Assert.That(PlotTargetInfo.ChoosePlotAreaHeight(
+            anchorZ: 150f, ground: 140f, offsetMetres: 10f, previousIsFlyingNpc: false))
+            .IsEqualTo(160f);
+    }
+
+    [Test]
+    public async Task GliderNitro_OverSea_DoesNotSnapToSeabed()
+    {
+        await Assert.That(PlotTargetInfo.ChoosePlotAreaHeight(
+            anchorZ: 110f, ground: 37f, offsetMetres: 10f, previousIsFlyingNpc: false,
+            overWater: true, waterSurfaceZ: 100f))
+            .IsEqualTo(120f);
+    }
+
+    [Test]
+    public async Task FlyingPortalNpc_SnapsToTerrain()
+    {
+        await Assert.That(PlotTargetInfo.ChoosePlotAreaHeight(
+            anchorZ: 172f, ground: 119f, offsetMetres: 10f, previousIsFlyingNpc: true))
+            .IsEqualTo(119f);
+    }
+
+    [Test]
+    public async Task LargeRayDropOffset_LandsOnFloor()
+    {
+        await Assert.That(PlotTargetInfo.ChoosePlotAreaHeight(
+            anchorZ: 500f, ground: 119f, offsetMetres: 500f, previousIsFlyingNpc: false))
+            .IsEqualTo(119f);
+    }
+
+    [Test]
+    public async Task LargeRayDrop_OverWater_UsesSurface()
+    {
+        await Assert.That(PlotTargetInfo.ChoosePlotAreaHeight(
+            anchorZ: 500f, ground: 37f, offsetMetres: 500f, previousIsFlyingNpc: false,
+            overWater: true, waterSurfaceZ: 100f))
+            .IsEqualTo(100f);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/Plots/Tree/PlotTicketGateTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/Plots/Tree/PlotTicketGateTests.cs
@@ -1,0 +1,34 @@
+using AAEmu.Game.Models.Game.Skills.Plots.Tree;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills.Plots.Tree;
+
+public class PlotTicketGateTests
+{
+    [Test]
+    public async Task TicketsOne_SelfLoopStopsAfterFirstVisit()
+    {
+        await Assert.That(PlotTicketGate.IsExhausted(1, 1, selfLoop: true)).IsFalse();
+        await Assert.That(PlotTicketGate.IsExhausted(2, 1, selfLoop: true)).IsTrue();
+    }
+
+    [Test]
+    public async Task TicketsOne_WithoutSelfLoop_AllowsMergedVisits()
+    {
+        await Assert.That(PlotTicketGate.IsExhausted(1, 1, selfLoop: false)).IsFalse();
+        await Assert.That(PlotTicketGate.IsExhausted(5, 1, selfLoop: false)).IsFalse();
+    }
+
+    [Test]
+    public async Task TicketsTwo_AllowsTwoVisits()
+    {
+        await Assert.That(PlotTicketGate.IsExhausted(1, 2)).IsFalse();
+        await Assert.That(PlotTicketGate.IsExhausted(2, 2)).IsFalse();
+        await Assert.That(PlotTicketGate.IsExhausted(3, 2)).IsTrue();
+    }
+
+    [Test]
+    public async Task TicketsZero_Uncapped()
+    {
+        await Assert.That(PlotTicketGate.IsExhausted(99, 0)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/ZoneAuthorityCombatTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/ZoneAuthorityCombatTests.cs
@@ -55,9 +55,8 @@ public class ZoneAuthorityCombatTests
     }
 
     [Test]
-    public async Task IsLeashResetSkill_EmptyOrNull_IsNotALeashReset()
+    public async Task ResolveZoneCombatActorBc_Null_IsZero()
     {
-        await Assert.That(ZoneAuthorityCombat.IsLeashResetSkill(Skill())).IsFalse();
-        await Assert.That(ZoneAuthorityCombat.IsLeashResetSkill(null)).IsFalse();
+        await Assert.That(ZoneAuthorityCombat.ResolveZoneCombatActorBc(null)).IsEqualTo(0u);
     }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/StreamAoi/SlaveStreamAoiTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/StreamAoi/SlaveStreamAoiTests.cs
@@ -108,6 +108,39 @@ public class SlaveStreamAoiTests
         world.Dispose();
     }
 
+    [Test]
+    public async Task TryKeepSlaveAcrossRegionLeave_KeepsStreamedHullInsideExit()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var (character, hull, world) = CreateShipAt(200f);
+        character.ArmMirrorNpcStream();
+        character.MarkSlaveStreamed(hull);
+
+        await Assert.That(character.TryKeepSlaveAcrossRegionLeave(hull)).IsTrue();
+
+        hull.Transform.Local.SetPosition(249f, 0f, 0f);
+        await Assert.That(character.TryKeepSlaveAcrossRegionLeave(hull)).IsFalse();
+
+        character.ReleaseSlaveSlot(hull.ObjId);
+        hull.Transform.Local.SetPosition(200f, 0f, 0f);
+        await Assert.That(character.CanStreamSlaveNow(hull)).IsTrue();
+
+        world.Dispose();
+    }
+
+    [Test]
+    public async Task TryKeepSlaveAcrossRegionLeave_DropsEquipmentParts()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var (character, part, world) = CreateSlaveAt(50f, SlaveKind.SlaveEquipment);
+        character.ArmMirrorNpcStream();
+        character.MarkSlaveStreamed(part);
+
+        await Assert.That(character.TryKeepSlaveAcrossRegionLeave(part)).IsFalse();
+
+        world.Dispose();
+    }
+
     private static (Character character, Slave slave, WorldInstance world) CreateShipAt(float x) =>
         CreateSlaveAt(x, SlaveKind.MerchantShip);
 

--- a/AAEmu.UnitTests/Game/Models/Game/StreamAoi/SlaveStreamAoiTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/StreamAoi/SlaveStreamAoiTests.cs
@@ -129,6 +129,28 @@ public class SlaveStreamAoiTests
     }
 
     [Test]
+    public async Task ShouldRepaintStreamedSlave_KeepsExitBandForAStreamedHull()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var (character, hull, world) = CreateShipAt(230f);
+        character.ArmMirrorNpcStream();
+
+        // Not streamed yet: 230 m is past enter, so a resend must not paint it.
+        await Assert.That(character.ShouldRepaintStreamedSlave(hull)).IsFalse();
+        await Assert.That(character.CanStreamSlaveNow(hull)).IsFalse();
+
+        // Streamed before the cinema and still inside exit: repaint.
+        character.MarkSlaveStreamed(hull);
+        await Assert.That(character.ShouldRepaintStreamedSlave(hull)).IsTrue();
+
+        // Past exit: gone either way.
+        hull.Transform.Local.SetPosition(249f, 0f, 0f);
+        await Assert.That(character.ShouldRepaintStreamedSlave(hull)).IsFalse();
+
+        world.Dispose();
+    }
+
+    [Test]
     public async Task TryKeepSlaveAcrossRegionLeave_DropsEquipmentParts()
     {
         StreamAoiTable.ReplaceConfig(new StreamAoiConfig());

--- a/AAEmu.UnitTests/Game/Models/Game/StreamAoi/SlaveStreamAoiTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/StreamAoi/SlaveStreamAoiTests.cs
@@ -1,0 +1,155 @@
+using System.Reflection;
+
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Slaves;
+using AAEmu.Game.Models.Game.StreamAoi;
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.World;
+using AAEmu.Game.Models.Game.World.Xml;
+
+namespace AAEmu.UnitTests.Game.Models.Game.StreamAoi;
+
+public class SlaveStreamAoiTests
+{
+    [Test]
+    public async Task CanStreamSlaveNow_ShipUsesEnterBand()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var (character, hull, world) = CreateShipAt(224f);
+        character.ArmMirrorNpcStream();
+
+        await Assert.That(character.CanStreamSlaveNow(hull)).IsTrue();
+
+        hull.Transform.Local.SetPosition(226f, 0f, 0f);
+        await Assert.That(character.CanStreamSlaveNow(hull)).IsFalse();
+        world.Dispose();
+    }
+
+    [Test]
+    public async Task CullStreamedSlavesBeyondAoi_UnselectsHullPastShipExit()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var (character, hull, world) = CreateShipAt(247f);
+        character.ArmMirrorNpcStream();
+        character.MarkSlaveStreamed(hull);
+
+        await Assert.That(character.CullStreamedSlavesBeyondAoi()).IsEqualTo(0);
+        await Assert.That(character.StreamedSlaveIds.ContainsKey(hull.ObjId)).IsTrue();
+
+        hull.Transform.Local.SetPosition(249f, 0f, 0f);
+        await Assert.That(character.CullStreamedSlavesBeyondAoi()).IsEqualTo(1);
+        await Assert.That(character.StreamedSlaveIds.ContainsKey(hull.ObjId)).IsFalse();
+        // No region neighbours in this fixture — do not re-queue.
+        await Assert.That(character.HasPendingSlaves).IsFalse();
+
+        world.Dispose();
+    }
+
+    [Test]
+    public async Task CullStreamedSlavesBeyondAoi_LeavesEquipmentParts()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var (character, part, world) = CreateSlaveAt(10_000f, SlaveKind.SlaveEquipment);
+        character.ArmMirrorNpcStream();
+        character.MarkSlaveStreamed(part);
+
+        await Assert.That(character.CullStreamedSlavesBeyondAoi()).IsEqualTo(0);
+        await Assert.That(character.StreamedSlaveIds.ContainsKey(part.ObjId)).IsTrue();
+
+        world.Dispose();
+    }
+
+    [Test]
+    public async Task CullStreamedSlavesBeyondAoi_HaulerUsesAmbientExit()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var (character, hauler, world) = CreateSlaveAt(109f, SlaveKind.Machine);
+        character.ArmMirrorNpcStream();
+        character.MarkSlaveStreamed(hauler);
+
+        await Assert.That(character.CullStreamedSlavesBeyondAoi()).IsEqualTo(0);
+
+        hauler.Transform.Local.SetPosition(111f, 0f, 0f);
+        await Assert.That(character.CullStreamedSlavesBeyondAoi()).IsEqualTo(1);
+        await Assert.That(character.StreamedSlaveIds.ContainsKey(hauler.ObjId)).IsFalse();
+
+        world.Dispose();
+    }
+
+    [Test]
+    public async Task TryFlushPendingSlaves_PaintsHullInsideEnter()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var (character, hull, world) = CreateShipAt(200f);
+        hull.IsVisible = true;
+        character.ArmMirrorNpcStream();
+        character.EnqueuePendingSlave(hull);
+
+        await Assert.That(character.TryFlushPendingSlaves()).IsEqualTo(1);
+        await Assert.That(character.StreamedSlaveIds.ContainsKey(hull.ObjId)).IsTrue();
+        await Assert.That(character.HasPendingSlaves).IsFalse();
+
+        world.Dispose();
+    }
+
+    [Test]
+    public async Task TryFlushPendingSlaves_SkipsHullOutsideEnter()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var (character, hull, world) = CreateShipAt(300f);
+        hull.IsVisible = true;
+        character.ArmMirrorNpcStream();
+        character.EnqueuePendingSlave(hull);
+
+        await Assert.That(character.TryFlushPendingSlaves()).IsEqualTo(0);
+        await Assert.That(character.StreamedSlaveIds.ContainsKey(hull.ObjId)).IsFalse();
+        await Assert.That(character.HasPendingSlaves).IsTrue();
+
+        world.Dispose();
+    }
+
+    private static (Character character, Slave slave, WorldInstance world) CreateShipAt(float x) =>
+        CreateSlaveAt(x, SlaveKind.MerchantShip);
+
+    private static (Character character, Slave slave, WorldInstance world) CreateSlaveAt(float x, SlaveKind kind)
+    {
+        var world = new WorldInstance(CreateTemplate(), 0, true, 1);
+        var character = new Character(new UnitCustomModelParams()) { ObjId = 1 };
+        AttachWorld(character, world);
+        character.Transform.Local.SetPosition(0f, 0f, 0f);
+
+        var slave = new Slave
+        {
+            ObjId = 1001,
+            Template = new SlaveTemplate { SlaveKind = kind }
+        };
+        AttachWorld(slave, world);
+        slave.Transform.Local.SetPosition(x, 0f, 0f);
+        world.AddObject(slave);
+        return (character, slave, world);
+    }
+
+    // ParentWorld's setter writes Transform.InstanceId, which asks WorldManager.Instance.
+    private static void AttachWorld(GameObject obj, WorldInstance world)
+    {
+        typeof(GameObject)
+            .GetField("_parentWorld", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(obj, world);
+    }
+
+    private static WorldTemplate CreateTemplate() => new()
+    {
+        CellX = 1,
+        CellY = 1,
+        Cells = new WorldCell[0, 0],
+        HousingZones = [],
+        Id = 0,
+        Name = "test_world",
+        OceanLevel = 100f,
+        SubZones = [],
+        XmlWorld = new XmlWorld { Zones = [] },
+        XmlWorldZones = [],
+        ZoneKeyByRegions = new uint[1, 1],
+        ZoneKeys = [0]
+    };
+}

--- a/AAEmu.UnitTests/Game/Models/Game/StreamAoi/StreamAoiTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/StreamAoi/StreamAoiTests.cs
@@ -1,0 +1,87 @@
+using AAEmu.Game.Models.Game.Slaves;
+using AAEmu.Game.Models.Game.StreamAoi;
+
+namespace AAEmu.UnitTests.Game.Models.Game.StreamAoi;
+
+public class StreamAoiTests
+{
+    [Test]
+    public async Task SeaBand_Appears225_Gone248()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var large = StreamAoiTable.Band(StreamAoiCategory.Large);
+        await Assert.That(large.EnterMetres).IsEqualTo(225f);
+        await Assert.That(large.ExitMetres).IsEqualTo(248f);
+
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Large, 224f * 224f, false)).IsTrue();
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Large, 226f * 226f, false)).IsFalse();
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Large, 247f * 247f, true)).IsTrue();
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Large, 249f * 249f, true)).IsFalse();
+    }
+
+    [Test]
+    public async Task Ambient_MatchesPlayerAndFarmHauler()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var a = StreamAoiTable.Band(StreamAoiCategory.Ambient);
+        await Assert.That(a.EnterMetres).IsEqualTo(105f);
+        await Assert.That(a.ExitMetres).IsEqualTo(110f);
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Ambient, 104f * 104f, false)).IsTrue();
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Ambient, 106f * 106f, false)).IsFalse();
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Ambient, 109f * 109f, true)).IsTrue();
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Ambient, 111f * 111f, true)).IsFalse();
+    }
+
+    [Test]
+    public async Task LargeIds_KrakenAndLeviathanModels()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        await Assert.That(StreamAoiTable.IsLargeNpc(7607, 0)).IsTrue();
+        await Assert.That(StreamAoiTable.IsLargeNpc(14915, 0)).IsTrue();
+        await Assert.That(StreamAoiTable.IsLargeNpc(0, 897)).IsTrue();
+        await Assert.That(StreamAoiTable.IsLargeNpc(0, 530)).IsTrue();
+        await Assert.That(StreamAoiTable.IsLargeNpc(1, 10)).IsFalse();
+    }
+
+    [Test]
+    public async Task ShipAndBosses_ShareSeaBand()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var ship = StreamAoiTable.Band(StreamAoiCategory.Ship);
+        var large = StreamAoiTable.Band(StreamAoiCategory.Large);
+        await Assert.That(ship.EnterMetres).IsEqualTo(large.EnterMetres);
+        await Assert.That(ship.ExitMetres).IsEqualTo(large.ExitMetres);
+        await Assert.That(ship.EnterMetres).IsEqualTo(225f);
+        await Assert.That(ship.ExitMetres).IsEqualTo(248f);
+    }
+
+    [Test]
+    public async Task EventHellgate_700m()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        var e = StreamAoiTable.Band(StreamAoiCategory.Event);
+        await Assert.That(e.EnterMetres).IsEqualTo(700f);
+        await Assert.That(e.ExitMetres).IsEqualTo(700f);
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Event, 699f * 699f, false)).IsTrue();
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Event, 701f * 701f, false)).IsFalse();
+    }
+
+    [Test]
+    public async Task Part_NeverSoftCulls()
+    {
+        StreamAoiTable.ReplaceConfig(new StreamAoiConfig());
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Part, 10_000f * 10_000f, false)).IsTrue();
+        await Assert.That(StreamAoiTable.IsInside(StreamAoiCategory.Part, 10_000f * 10_000f, true)).IsTrue();
+    }
+
+    [Test]
+    public async Task SlaveKinds_HullVsEquipmentVsHauler()
+    {
+        var clipper = new SlaveTemplate { SlaveKind = SlaveKind.MerchantShip };
+        var sail = new SlaveTemplate { SlaveKind = SlaveKind.SlaveEquipment };
+        var hauler = new SlaveTemplate { SlaveKind = SlaveKind.Machine };
+        await Assert.That(clipper.StreamAoiCategory).IsEqualTo(StreamAoiCategory.Ship);
+        await Assert.That(sail.StreamAoiCategory).IsEqualTo(StreamAoiCategory.Part);
+        await Assert.That(hauler.StreamAoiCategory).IsEqualTo(StreamAoiCategory.Ambient);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Units/UnitCustomModelParamsTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Units/UnitCustomModelParamsTests.cs
@@ -1,0 +1,67 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Units;
+
+public class UnitCustomModelParamsTests
+{
+    [Test]
+    public async Task ClearUnusedVisualRaceOverride_ZerosCopyOfOriginRace()
+    {
+        var appearance = new UnitCustomModelParams(UnitCustomModelType.Hair)
+        {
+            Race = 4,
+            Gender = 2,
+            VisualRace = 4,
+            VisualGender = 2,
+            VisualRaceExpiredTime = 1
+        };
+
+        appearance.ClearUnusedVisualRaceOverride(4);
+
+        await Assert.That(appearance.VisualRace).IsEqualTo((byte)0);
+        await Assert.That(appearance.VisualGender).IsEqualTo((byte)0);
+        await Assert.That(appearance.VisualRaceExpiredTime).IsEqualTo(0);
+        await Assert.That(appearance.Race).IsEqualTo((byte)4);
+    }
+
+    [Test]
+    public async Task ClearUnusedVisualRaceOverride_KeepsRealRaceChange()
+    {
+        var appearance = new UnitCustomModelParams(UnitCustomModelType.Hair)
+        {
+            Race = 4,
+            Gender = 2,
+            VisualRace = 1,
+            VisualGender = 1,
+            VisualRaceExpiredTime = 99
+        };
+
+        appearance.ClearUnusedVisualRaceOverride(4);
+
+        await Assert.That(appearance.VisualRace).IsEqualTo((byte)1);
+        await Assert.That(appearance.VisualGender).IsEqualTo((byte)1);
+        await Assert.That(appearance.VisualRaceExpiredTime).IsEqualTo(99);
+    }
+
+    [Test]
+    public async Task Write_AfterClear_EmitsZeroVisualRace()
+    {
+        var appearance = new UnitCustomModelParams(UnitCustomModelType.Hair)
+        {
+            Race = 4,
+            Gender = 2,
+            VisualRace = 4,
+            VisualGender = 2
+        };
+        appearance.ClearUnusedVisualRaceOverride(4);
+
+        var written = appearance.Write(new PacketStream());
+        var roundTrip = new UnitCustomModelParams();
+        roundTrip.Read(new PacketStream(written.GetBytes()));
+
+        await Assert.That(roundTrip.Race).IsEqualTo((byte)4);
+        await Assert.That(roundTrip.VisualRace).IsEqualTo((byte)0);
+        await Assert.That(roundTrip.VisualGender).IsEqualTo((byte)0);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/World/TerrainFloorTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/World/TerrainFloorTests.cs
@@ -1,0 +1,77 @@
+using AAEmu.Game.Models.Game.World;
+
+namespace AAEmu.UnitTests.Game.Models.Game.World;
+
+public class TerrainFloorTests
+{
+    private static float Floor(float ground) => ground + TerrainFloor.ClearanceMetres;
+
+    [Test]
+    public async Task NearBand_SitsOnFloorWithClearance()
+    {
+        await Assert.That(TerrainFloor.ChooseUnitFloorZ(
+            rawZ: 119.2f, ground: 119.2f, overWater: false, waterSurfaceZ: 0f)).IsEqualTo(Floor(119.2f));
+    }
+
+    [Test]
+    public async Task AlreadyNearGround_UsesFloorClearance()
+    {
+        await Assert.That(TerrainFloor.ChooseUnitFloorZ(
+            rawZ: 102f, ground: 100f, overWater: false, waterSurfaceZ: 0f)).IsEqualTo(Floor(100f));
+    }
+
+    [Test]
+    public async Task MildUnderground_LiftsWithinCap()
+    {
+        await Assert.That(TerrainFloor.ChooseUnitFloorZ(
+            rawZ: 114.8f, ground: 120.3f, overWater: false, waterSurfaceZ: 0f)).IsEqualTo(Floor(120.3f));
+    }
+
+    [Test]
+    public async Task CliffSample_DoesNotLiftPastUpwardCap()
+    {
+        await Assert.That(TerrainFloor.ChooseUnitFloorZ(
+            rawZ: 122.9f, ground: 139.0f, overWater: false, waterSurfaceZ: 0f)).IsEqualTo(Floor(122.9f));
+    }
+
+    [Test]
+    public async Task ShortBallDrop_SnapsToTerrain()
+    {
+        await Assert.That(TerrainFloor.ChooseUnitFloorZ(
+            rawZ: 180f, ground: 172f, overWater: false, waterSurfaceZ: 0f)).IsEqualTo(Floor(172f));
+    }
+
+    [Test]
+    public async Task DeepAirPlot_DoesNotSnapIntoHole()
+    {
+        await Assert.That(TerrainFloor.ChooseUnitFloorZ(
+            rawZ: 171.7f, ground: 119.2f, overWater: false, waterSurfaceZ: 0f)).IsEqualTo(171.7f);
+    }
+
+    [Test]
+    public async Task OpenWater_UsesWaterSurfaceNotSeabed()
+    {
+        await Assert.That(TerrainFloor.ChooseUnitFloorZ(
+            rawZ: 64.8f, ground: 37.4f, overWater: true, waterSurfaceZ: 100f))
+            .IsEqualTo(100f + TerrainFloor.ClearanceMetres);
+    }
+
+    /// <summary>
+    /// Lusca Aken: plot marker ~120 above OceanLevel, heightmap is seabed ~22.
+    /// Without water snap, keep-raw fights Zone physics → flash/jump.
+    /// </summary>
+    [Test]
+    public async Task LuscaPlotAboveOcean_SnapsToSurfaceNotSeabedOrRaw()
+    {
+        await Assert.That(TerrainFloor.ChooseUnitFloorZ(
+            rawZ: 120f, ground: 22f, overWater: true, waterSurfaceZ: 100f))
+            .IsEqualTo(100f + TerrainFloor.ClearanceMetres);
+    }
+
+    [Test]
+    public async Task MissingGround_KeepsRaw()
+    {
+        await Assert.That(TerrainFloor.ChooseUnitFloorZ(
+            rawZ: 150f, ground: 0f, overWater: false, waterSurfaceZ: 0f)).IsEqualTo(150f);
+    }
+}

--- a/AAEmu.WorldServer/AAEmu.World/Core/Packets/Wz/WZCreateDoodadPacket.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Packets/Wz/WZCreateDoodadPacket.cs
@@ -1,6 +1,7 @@
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.Items.Templates;
 
@@ -32,7 +33,9 @@ public class WZCreateDoodadPacket(Doodad doodad) : ZonePacket(WzOpcodes.CreateDo
         stream.Write((byte)doodad.AttachPoint);
 
         var useLocal = doodad.AttachPoint > 0 || doodad.ParentObjId > 0;
-        var pos = useLocal ? doodad.Transform.Local.Position : doodad.Transform.World.Position;
+        var pos = useLocal
+            ? doodad.Transform.Local.Position
+            : ZoneCoordBoundary.ToZoneLocal(doodad.Transform.ZoneId, doodad.Transform.World.Position);
         var (roll, pitch, yaw) = useLocal
             ? doodad.Transform.Local.ToRollPitchYawShorts()
             : doodad.Transform.World.ToRollPitchYawShorts();

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/MovementRelay.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/MovementRelay.cs
@@ -364,7 +364,9 @@ public class MovementRelay
                     break;
                 }
 
-                ZoneCoordBoundary.ShiftLocalToWorld(zoneId, mt);
+                var localSim = ZoneCoordBoundary.UseLocalOnZoneWire
+                    || WorldIntegration.FindUnitAcrossWorlds(bcId) is Npc { ZoneSimUsesLocalCoordinates: true };
+                ZoneCoordBoundary.ShiftLocalToWorld(zoneId, mt, localSim);
 
                 if (mt is ShipMoveType hull)
                 {

--- a/AAEmu.WorldServer/AAEmu.World/Program.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Program.cs
@@ -288,46 +288,54 @@ public static class Program
             if (zone == null)
                 return;
 
+            var aggroSourceId = casterId;
+            var casterUnit = WorldIntegration.FindUnitAcrossWorlds(casterId);
+            if (casterUnit != null)
+            {
+                var resolved = ZoneAuthorityCombat.ResolveZoneCombatActorBc(casterUnit);
+                if (resolved != 0)
+                    aggroSourceId = resolved;
+            }
+
+            var zoneCaster = new SkillCasterUnit(aggroSourceId);
             var castAction = new CastSkill(skillId, tl);
             zone.SendPacket(new WZUnitDamagedPacket(
                 castAction,
-                caster,
-                casterId,
+                zoneCaster,
+                aggroSourceId,
                 targetId,
                 damage,
                 absorbed));
             Logger.Info("WZUnitDamaged → zone skill={0} tl={1} caster={2} target={3} dmg={4} abs={5}",
-                skillId, tl, casterId, targetId, damage, absorbed);
+                skillId, tl, aggroSourceId, targetId, damage, absorbed);
 
             // Publishing UpdateAggro alone leaves AggroCount>0 with no target; Zone then
             // ProcessAggroCancel → ZWClearCombat / skill 11503 Return (mid-fight leash).
             // Opt-out: AAEMU_WZ_UPDATE_AGGRO=0 (isolates the whole handoff if a zone drops the link).
             if (Environment.GetEnvironmentVariable("AAEMU_WZ_UPDATE_AGGRO") == "0")
                 return;
-            if (casterId == 0 || targetId == 0 || casterId == targetId)
+            if (aggroSourceId == 0 || targetId == 0 || aggroSourceId == targetId)
                 return;
 
             var aggro = (uint)Math.Max(1, damage + absorbed);
-            var world = WorldManager.Instance.GetWorld(WorldManager.DefaultInstanceId);
-            // Aggro tables and combat engagement belong to NPC targets, not player victims.
-            var damagedNpc = world?.GetNpc(targetId);
+            var damagedNpc = WorldIntegration.FindUnitAcrossWorlds(targetId) as Npc;
             if (damagedNpc == null)
                 return;
 
-            var abuser = world.GetUnit(casterId);
+            var abuser = WorldIntegration.FindUnitAcrossWorlds(aggroSourceId);
             if (abuser != null)
                 damagedNpc.CurrentTarget = abuser;
-            zone.SendPacket(new WZTargetChangedPacket(targetId, casterId, forceByWorld: true));
-            Logger.Info("WZTargetChanged → zone npc={0} target={1} (damage handoff)", targetId, casterId);
+            zone.SendPacket(new WZTargetChangedPacket(targetId, aggroSourceId, forceByWorld: true));
+            Logger.Info("WZTargetChanged → zone npc={0} target={1} (damage handoff)", targetId, aggroSourceId);
 
             zone.SendPacket(new WZUpdateAggroPacket(
                 targetId,
-                casterId,
-                casterId,
+                aggroSourceId,
+                aggroSourceId,
                 aggro,
                 true,
                 castAction));
-            Logger.Info("WZUpdateAggro → zone npc={0} target={1} aggro={2}", targetId, casterId, aggro);
+            Logger.Info("WZUpdateAggro → zone npc={0} target={1} aggro={2}", targetId, aggroSourceId, aggro);
 
             zone.SendPacket(new WZCombatEngagedPacket(targetId));
             Logger.Info("WZCombatEngaged → zone npc={0} (damage handoff)", targetId);
@@ -397,11 +405,20 @@ public static class Program
 
             zone.SendPacket(new WZNpcStatePacket(request.Body));
             zone.Units.RegisterWithId(request.ObjId, request.Body);
+            var authored = WorldIntegration.FindUnitAcrossWorlds(request.ObjId) as Npc;
+            if (authored != null)
+            {
+                if (authored.Faction is { Id: not 0 })
+                    zone.SendPacket(new WZUnitFactionChangedPacket(request.ObjId, 0, (int)authored.Faction.Id, false));
+                if (authored.CanFly)
+                    zone.SendPacket(new WZUnitFlyingStateChangedPacket(request.ObjId, true));
+            }
             Logger.Info(
-                "WZNpcState -> zoneId={0} World-authored npc={1} bodyLen={2}",
+                "WZNpcState -> zoneId={0} World-authored npc={1} bodyLen={2} localSim={3}",
                 zone.ZoneId,
                 request.ObjId,
-                request.Body.Length);
+                request.Body.Length,
+                authored is { ZoneSimUsesLocalCoordinates: true });
             return true;
         };
         WorldIntegration.RelayNpcAggroToZone = request =>
@@ -616,8 +633,9 @@ public static class Program
             if (zone == null)
                 return;
 
-            zone.SendPacket(new WZKnockBackUnitPacket(unitId, x, y, z));
-            Logger.Info("WZKnockBackUnit → zone unit={0} pos=({1:F1},{2:F1},{3:F1})", unitId, x, y, z);
+            var local = ZoneCoordBoundary.ToZoneLocal(zone.ZoneId, new System.Numerics.Vector3(x, y, z));
+            zone.SendPacket(new WZKnockBackUnitPacket(unitId, local.X, local.Y, local.Z));
+            Logger.Info("WZKnockBackUnit → zone unit={0} pos=({1:F1},{2:F1},{3:F1})", unitId, local.X, local.Y, local.Z);
         };
         WorldIntegration.RelayBlinkToZone = (unitId, baseUnitId, move3D, x, y, z) =>
         {
@@ -628,15 +646,16 @@ public static class Program
             if (zone == null)
                 return;
 
+            var local = ZoneCoordBoundary.ToZoneLocal(zone.ZoneId, new System.Numerics.Vector3(x, y, z));
             zone.SendPacket(new WZBlinkUnitPacket(
                 unitId,
                 baseUnitId,
                 move3D,
-                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongX(x),
-                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongY(y),
-                z));
+                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongX(local.X),
+                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongY(local.Y),
+                local.Z));
             Logger.Info("WZBlinkUnit → zone unit={0} pos=({1:F1},{2:F1},{3:F1}) move3D={4}",
-                unitId, x, y, z, move3D);
+                unitId, local.X, local.Y, local.Z, move3D);
         };
         WorldIntegration.RelayCombatEngagedToZone = unitId =>
         {
@@ -720,13 +739,14 @@ public static class Program
             if (zone == null)
                 return;
 
+            var local = ZoneCoordBoundary.ToZoneLocal(zone.ZoneId, new System.Numerics.Vector3(x, y, z));
             zone.SendPacket(new WZUnitResurrectionPacket(
                 unitId,
-                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongX(x),
-                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongY(y),
-                z,
+                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongX(local.X),
+                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongY(local.Y),
+                local.Z,
                 zRot));
-            Logger.Info("WZUnitResurrection → zone unit={0} pos=({1:F1},{2:F1},{3:F1})", unitId, x, y, z);
+            Logger.Info("WZUnitResurrection → zone unit={0} pos=({1:F1},{2:F1},{3:F1})", unitId, local.X, local.Y, local.Z);
         };
         WorldIntegration.RelaySkillStoppedToZone = (unitId, skillId) =>
         {
@@ -775,13 +795,14 @@ public static class Program
             var zone = PlayerEnterService.ForUnit(slaveId);
             if (zone == null)
                 return;
+            var local = ZoneCoordBoundary.ToZoneLocal(zone.ZoneId, new System.Numerics.Vector3(x, y, z));
             zone.SendPacket(new WZEscapeSlavePacket(
                 slaveId,
-                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongX(x),
-                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongY(y),
-                z,
+                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongX(local.X),
+                (ulong)AAEmu.Commons.Utils.Helpers.ConvertLongY(local.Y),
+                local.Z,
                 rot));
-            Logger.Info("WZEscapeSlave → zone slave={0} pos=({1:F1},{2:F1},{3:F1})", slaveId, x, y, z);
+            Logger.Info("WZEscapeSlave → zone slave={0} pos=({1:F1},{2:F1},{3:F1})", slaveId, local.X, local.Y, local.Z);
         };
         WorldIntegration.RelayShipControlChangeToZone = (slaveId, control) =>
         {
@@ -841,8 +862,9 @@ public static class Program
             var zone = PlayerEnterService.ForUnit(unitId) ?? PlayerEnterService.ForZoneId(zoneId);
             if (zone == null)
                 return;
+            var local = ZoneCoordBoundary.ToZoneLocal(zoneId, new System.Numerics.Vector3(x, y, z));
             zone.SendPacket(new WZDropBackpackPacket(
-                item, zoneId, doodadTpl, zone.InstanceId, removeItem, hackAttempt, userDrop, x, y, z));
+                item, zoneId, doodadTpl, zone.InstanceId, removeItem, hackAttempt, userDrop, local.X, local.Y, local.Z));
             Logger.Info("WZDropBackpack → zone unit={0} item={1} doodadTpl={2}", unitId, itemUid, doodadTpl);
         };
         WorldIntegration.OnZoneBackpackDropped = body =>
@@ -1175,7 +1197,7 @@ public static class Program
                 continue;
             }
 
-            zone.SendPacket(new WZGimmickCreatedPacket(gimmick.ToSpawnData(), (int)zoneId));
+            zone.SendPacket(new WZGimmickCreatedPacket(gimmick.ToZoneWireSpawnData(), (int)zoneId));
             sent++;
         }
 


### PR DESCRIPTION
## Summary
- Keep live WZ on continent coordinates, snap World-authored event NPCs to the heightmap floor, and gate plot OnSpawn so army/plot units stay on-mesh under ZoneAuthority.
- Stream AOI bands (ambient / ship / kill-quota boss), boat water-probe scoring, and unused visual-race override so hulls, event bosses, and characters appear without a false transform flag.
- Persist dock/helm/daily-contract state and limit helm occupy buffs to the Driver seat on the hull doodad.

## Test plan
- [ ] Enter world, walk a starter zone: NPCs stay on terrain, no sky fall on plot/event spawn
- [ ] Summon a boat from a shore facing inland: hull places ahead on navigable water, not behind or in a sky lake
- [ ] Sit helm / leave wheel: occupy buffs only on Driver; ship sim stays on until withdraw
- [ ] Relog with a daily contract / docked slave: state restores
- [ ] Walk past a sea hull (~225 m) vs ambient NPC (~105 m): stream bands match StreamAoi.json
- [ ] Costume/appearance on an Elf (no race-change): client does not treat the character as transformed


Made with [Cursor](https://cursor.com)