### PR TITLE
fix(game): preserve character equipment stats in UnitState

### DIFF
--- a/AAEmu.Game/Core/Packets/G2C/UnitState/UnitStatePlacementSerializer.cs
+++ b/AAEmu.Game/Core/Packets/G2C/UnitState/UnitStatePlacementSerializer.cs
@@ -41,8 +41,8 @@ internal static class UnitStatePlacementSerializer
 
     private static void WriteLevelBlock(PacketStream stream, UnitStateWireContext context)
     {
-        // other currently modelled unit types carry their normal level and no second heir value.
-        if (context.BaseUnitType == BaseUnitType.Npc)
+        // The second pair is the balance-level override. A normal character must leave it inactive.
+        if (context.BaseUnitType is BaseUnitType.Character or BaseUnitType.Npc)
         {
             stream.Write((sbyte)0);
             stream.Write((sbyte)0);


### PR DESCRIPTION
## Summary

Restore equipment-derived stats for characters by correcting the level block in `SCUnitState`.

## Root Cause

The UnitState wire format contains two level pairs:

- The character's normal `level` and `heirLevel`
- An optional battlefield/balance-level override

Characters were incorrectly writing their normal level into the balance-level override. A nonzero override causes the client to treat the character as balance-adjusted and bypass normal equipment-stat aggregation.

As a result, equipped items appeared correctly but did not contribute their expected stats.

## Fix

- Preserve the character's normal `level` and `heirLevel` in the primary level fields.
- Write `0, 0` for the inactive balance-level override on normal characters.
- Preserve the existing NPC behavior and leave other unit types unchanged.