### PR TITLE
feat(game): implement skillsaver (ability set) save and activate

### DIFF
--- a/AAEmu.Game/Configurations/Features.json
+++ b/AAEmu.Game/Configurations/Features.json
@@ -4,6 +4,9 @@
         // behind them is still live and never needed the client to know about it.
         "TaxItem": true,
         "BackpackProfitShare": true,
+        // Zero used_free_abil_set_activation at 00:00 UTC (and login catch-up). Only applies when
+        // compact ability_set_free_activation_count is above zero.
+        "AbilitySetFreeActivationDailyReset": true,
 
         // Shared server/client fset bitmap (SCInitialConfig opcode 0x007). Unlisted bits stay off.
         // Scalar bytes 1, 8, 10, 26 are level caps — FeaturesManager fills those at boot, not here.

--- a/AAEmu.Game/Core/Managers/FeaturesManager.cs
+++ b/AAEmu.Game/Core/Managers/FeaturesManager.cs
@@ -35,7 +35,8 @@ public class FeaturesManager(IExperienceManager experienceManager) : Singleton<F
             UnknownTimeLimit = 0,
 
             TaxItem = config.TaxItem,
-            BackpackProfitShare = config.BackpackProfitShare
+            BackpackProfitShare = config.BackpackProfitShare,
+            AbilitySetFreeActivationDailyReset = config.AbilitySetFreeActivationDailyReset
         };
 
         ApplyConfiguredFlags(config);

--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -658,6 +658,7 @@ public class CharacterManager(
 
         character.Abilities = new CharacterAbilities(character);
         character.Abilities.SetAbility(character.Ability1, 0);
+        character.AbilitySets = new CharacterAbilitySets(character);
 
         character.Actability = new CharacterActability(character);
         foreach (var (id, actabilityTemplate) in _actabilities)

--- a/AAEmu.Game/Core/Network/Game/GameNetwork.cs
+++ b/AAEmu.Game/Core/Network/Game/GameNetwork.cs
@@ -159,6 +159,9 @@ public class GameNetwork : Singleton<GameNetwork>
         RegisterPacket(CSOffsets.CSLearnBuffPacket, 1, typeof(CSLearnBuffPacket));
         RegisterPacket(CSOffsets.CSResetSkillsPacket, 1, typeof(CSResetSkillsPacket));
         RegisterPacket(CSOffsets.CSSwapAbilityPacket, 1, typeof(CSSwapAbilityPacket));
+        RegisterPacket(CSOffsets.CSExpandAbilitySetSlotPacket, 1, typeof(CSExpandAbilitySetSlotPacket));
+        RegisterPacket(CSOffsets.CSSaveAbilitySetPacket, 1, typeof(CSSaveAbilitySetPacket));
+        RegisterPacket(CSOffsets.CSDeleteAbilitySetPacket, 1, typeof(CSDeleteAbilitySetPacket));
         RegisterPacket(CSOffsets.CSSendMailPacket, 1, typeof(CSSendMailPacket));
         RegisterPacket(CSOffsets.CSListMailPacket, 1, typeof(CSListMailPacket));
         RegisterPacket(CSOffsets.CSListMailContinuePacket, 1, typeof(CSListMailContinuePacket));
@@ -393,7 +396,7 @@ public class GameNetwork : Singleton<GameNetwork>
         RegisterPacket(CSOffsets.CSTeamSummonGetPacket, 1, typeof(CSTeamSummonGetPacket));
         RegisterPacket(CSOffsets.CSTeamSummonReplyPacket, 1, typeof(CSTeamSummonReplyPacket));
         RegisterPacket(CSOffsets.CSFollowRespPacket, 1, typeof(CSFollowRespPacket));
-        RegisterPacket(CSOffsets.CSExpandAbilitySetSlotPacket, 1, typeof(CSExpandAbilitySetSlotPacket));
+        // CSExpandAbilitySetSlotPacket registered with the other ability-set CS packets above.
         RegisterPacket(CSOffsets.CSHeroDropoutComebackAccept, 1, typeof(CSHeroDropoutComebackAccept));
         RegisterPacket(CSOffsets.CSChangeDiceBidRulePacket, 1, typeof(CSChangeDiceBidRulePacket));
         RegisterPacket(CSOffsets.CSGetDoodadManikinSkin, 1, typeof(CSGetDoodadManikinSkin));

--- a/AAEmu.Game/Core/Packets/C2G/CSDeleteAbilitySetPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSDeleteAbilitySetPacket.cs
@@ -4,12 +4,8 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO: the body is parsed but nothing acts on it yet.
+/// Client skillsaver delete. Success fires <c>SCAbilitySetUpdated</c> (<c>responseType=3</c>).
 /// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
 public class CSDeleteAbilitySetPacket() : GamePacket(CSOffsets.CSDeleteAbilitySetPacket, 1)
 {
     public sbyte SlotIndex { get; private set; }
@@ -17,5 +13,6 @@ public class CSDeleteAbilitySetPacket() : GamePacket(CSOffsets.CSDeleteAbilitySe
     public override void Read(PacketStream stream)
     {
         SlotIndex = stream.ReadSByte();
+        Connection.ActiveChar?.AbilitySets?.TryDelete(SlotIndex);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSExpandAbilitySetSlotPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpandAbilitySetSlotPacket.cs
@@ -4,15 +4,16 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO(v10): the body is parsed but nothing acts on it yet.
+/// Client skillsaver slot expand. Success fires <c>SCAbilitySetSlotCountUpdated</c>
+/// → client <c>ABILITY_SET_USABLE_SLOT_COUNT_CHANGED</c> toast.
 /// </summary>
 /// <remarks>
-/// packet has no body. Every parameterless C2S type folds onto that one function, so the
-/// shared address is identical-COMDAT folding, not a base-class fall-through.
+/// Packet has no body on 10.0.2.13.
 /// </remarks>
 public class CSExpandAbilitySetSlotPacket() : GamePacket(CSOffsets.CSExpandAbilitySetSlotPacket, 1)
 {
     public override void Read(PacketStream stream)
     {
+        Connection.ActiveChar?.AbilitySets?.TryExpand();
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSSaveAbilitySetPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSaveAbilitySetPacket.cs
@@ -4,12 +4,9 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO: the body is parsed but nothing acts on it yet.
+/// Client skillsaver save — snapshots the current triad + learned skills into <paramref name="SlotIndex"/>.
+/// Success fires <c>SCAbilitySetUpdated</c> (<c>responseType=1</c>) → client <c>ABILITY_SET_CHANGED</c> toast.
 /// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
 public class CSSaveAbilitySetPacket() : GamePacket(CSOffsets.CSSaveAbilitySetPacket, 1)
 {
     public sbyte SlotIndex { get; private set; }
@@ -17,5 +14,6 @@ public class CSSaveAbilitySetPacket() : GamePacket(CSOffsets.CSSaveAbilitySetPac
     public override void Read(PacketStream stream)
     {
         SlotIndex = stream.ReadSByte();
+        Connection.ActiveChar?.AbilitySets?.TrySave(SlotIndex);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
@@ -82,6 +82,8 @@ public class CSSelectCharacterPacket() : GamePacket(CSOffsets.CSSelectCharacterP
             Connection.SendPacket(new SCShowCurrentWorldPacket(AppConfiguration.Instance.Id));
 
             Connection.SendPacket(new SCCharacterStatePacket(character));
+            character.AbilitySets?.SendSlotCount();
+            character.AbilitySets?.SendAllInfo();
 
             // SCWorldLevelInfo is NOT sent here. The client's world-level manager binds the packet's data to the
             // local player unit, which does not exist until Spawn() runs on NotifyInGame; sending it in the select

--- a/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
@@ -36,8 +36,10 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
         skillCastTarget.Read(stream);
 
         // Nest interact sent flag=28 → type=12 (invalid). Old path set SkillObject.Flag=12 and
+        // desynced the stream. Type 15 is ActiveAbilitySet (skillsaver slot as i32) on 10.0.2.13.
+        // Type lives in the low 6 bits (same as SC SkillCastExtra); mask 0x0F truncated higher types.
         var flag = stream.ReadByte();
-        var flagType = flag & 15;
+        var flagType = flag & 0x3F;
         SkillObject skillObject;
 
         // In 10.0.2.13 this byte is a bit MASK, not a SkillObjectType. The original server's parser
@@ -53,6 +55,7 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
         // A type this server models is parsed as itself, and that has to be asked first: synthesis
         // sends flag 8, which is both "bit 3 set" and a real type - the material slots - so the
         // generic thirteen-int read would otherwise swallow it and lose which infusions were placed.
+        // AbilitySet (15) is registered in IsKnownType so skillsaver activate keeps its slot payload.
         var hasExtraValues = (flag & 8) != 0;
         if (SkillObject.IsKnownType(flagType))
         {
@@ -104,6 +107,10 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
         var world = Connection.ActiveChar?.ParentWorld ?? WorldManager.Instance.GetWorld(WorldManager.DefaultInstanceId);
 
         Logger.Info($"StartSkill: Id {skillId}, flag {flag}, caster={skillCaster.ObjId}, target={skillCastTarget.ObjId}");
+
+        // Skillsaver apply: stash slot before zone/local split so ActivateSavedAbilitySet can finish it.
+        if (skillId == CharacterAbilitySets.ActivateSkillId)
+            StashAbilitySetActivationSlot(activeCharacter, skillObject);
 
         // ZoneAuthority: Zone owns cast/effects. Forward WZSkillStarted + emit SC cast UX only.
         // Local Skill.Use builds plot CompressedGamePackets (DD04) that desync the client (sc error / zip fail).
@@ -377,5 +384,32 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Skillsaver apply casts skill 32189; the special effect needs the slot index the UI picked.
+    /// Prefer skill-object payloads when present (Unk5.Step / Unk1.Id).
+    /// </summary>
+    private static void StashAbilitySetActivationSlot(Character character, SkillObject skillObject)
+    {
+        // ActiveAbilitySet is i16 on the wire (see SkillObjectAbilitySet). Legacy Unk5/Unk1 kept as fallback.
+        var slot = skillObject switch
+        {
+            SkillObjectAbilitySet abilitySet => abilitySet.SlotIndex,
+            SkillObjectUnk5 unk5 => unk5.Step,
+            SkillObjectUnk1 unk1 => unk1.Id,
+            _ => -1
+        };
+
+        if (slot < 0)
+        {
+            Logger.Warn(
+                "AbilitySet activate stash {0}: no slot in skillObject type={1}",
+                character.Name, skillObject?.Flag);
+            return;
+        }
+
+        Logger.Info("AbilitySet activate stash {0}: slot {1} (skillObject={2})", character.Name, slot, skillObject.Flag);
+        character.AbilitySets?.SetPendingActivationSlot(slot);
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCAbilitySetAllInfoPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCAbilitySetAllInfoPacket.cs
@@ -1,0 +1,76 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Skills;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+/// <summary>
+/// Full skillsaver list for login / resync. Client <c>OnAbilitySetAllInfo</c> /
+/// <c>DWAbilitySetAllInfoPacket::Init</c> feeds <c>GetSavedAbilitySets</c> / preview skill lists.
+/// Opcode 0x149.
+/// </summary>
+/// <remarks>
+/// Wire layout recovered from 10.0.2.13 <c>x2game-dev.dll</c> archive reader (RVA ~0xc881a7):
+/// <list type="bullet">
+/// <item><c>usedFreeActivationCount</c> u8</item>
+/// <item>exactly <see cref="CharacterAbilitySets.MaxSlots"/> (=5) slots, always written</item>
+/// <item>per slot: u32 skillCount → u8×3 abilities → u32[] skills → u32 passiveCount →
+/// u32[] passives → heirSkills (u32 size + elements; size 0 is fine)</item>
+/// </list>
+/// Skill count is clamped to 36 (<c>over max skill count!!</c>). Sending 10 slots / abilities
+/// before count desynced the reader and thrashed the machine on character select.
+/// </remarks>
+public class SCAbilitySetAllInfoPacket(IReadOnlyList<AbilitySetSlot> slotsByIndex, byte usedFreeActivationCount)
+    : GamePacket(SCOffsets.SCAbilitySetAllInfoPacket, 1)
+{
+    public const int MaxSkillsPerSlot = 36;
+    public const int MaxPassivesPerSlot = 33;
+
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(usedFreeActivationCount);
+
+        for (byte i = 0; i < CharacterAbilitySets.MaxSlots; i++)
+        {
+            AbilitySetSlot slot = null;
+            foreach (var candidate in slotsByIndex)
+            {
+                if (candidate.SlotIndex == i)
+                {
+                    slot = candidate;
+                    break;
+                }
+            }
+
+            if (slot == null || !slot.IsOccupied)
+            {
+                stream.Write(0u); // skillCount
+                stream.Write((byte)0);
+                stream.Write((byte)0);
+                stream.Write((byte)0);
+                stream.Write(0u); // passiveCount
+                stream.Write(0u); // heirSkills.Size
+                continue;
+            }
+
+            var skillCount = Math.Min(slot.SkillIds.Count, MaxSkillsPerSlot);
+            stream.Write((uint)skillCount);
+            stream.Write((byte)slot.Ability1);
+            stream.Write((byte)slot.Ability2);
+            stream.Write((byte)slot.Ability3);
+            for (var s = 0; s < skillCount; s++)
+                stream.Write(slot.SkillIds[s]);
+
+            var passiveCount = Math.Min(slot.PassiveBuffIds.Count, MaxPassivesPerSlot);
+            stream.Write((uint)passiveCount);
+            for (var p = 0; p < passiveCount; p++)
+                stream.Write(slot.PassiveBuffIds[p]);
+
+            // heirSkills: Size + elements. Empty list is enough until heir skillsavers are wired.
+            stream.Write(0u);
+        }
+
+        return stream;
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCAbilitySetUpdatedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCAbilitySetUpdatedPacket.cs
@@ -4,17 +4,18 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// TODO: nothing constructs this packet yet.
+/// Skillsaver save/activate/delete result. Client maps <c>responseType</c> to
+/// <c>ABILITY_SET_CHANGED</c> (1=saved_job, 2=changed_job, 3=deleted_job; ≤0 = lack_of_saved_job_slot).
 /// </summary>
 /// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
+/// Wire layout (no leading pad): sbyte responseType, u32 slotIndex, sbyte usedFreeActivationCount.
+/// An earlier recovered "unnamed1" pad made the client treat 0 as responseType and always toast failure.
 /// </remarks>
-public class SCAbilitySetUpdatedPacket(sbyte unnamed1, sbyte responseType, uint slotIndex, sbyte usedFreeActivationCount) : GamePacket(SCOffsets.SCAbilitySetUpdatedPacket, 1)
+public class SCAbilitySetUpdatedPacket(sbyte responseType, uint slotIndex, sbyte usedFreeActivationCount)
+    : GamePacket(SCOffsets.SCAbilitySetUpdatedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(unnamed1);
         stream.Write(responseType);
         stream.Write(slotIndex);
         stream.Write(usedFreeActivationCount);

--- a/AAEmu.Game/Core/Packets/G2C/SCAbilitySwappedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCAbilitySwappedPacket.cs
@@ -5,10 +5,18 @@ using AAEmu.Game.Models.Game.Skills;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// times over { u8 "old", u8 "new" } — one pair per ability slot, not just the slot that changed.
-/// Sending a single pair left the client short by four bytes ("not enough buffer for old"), which
-/// desynced the SC stream and silently dropped the swap, so unlocking a second skillset did nothing.
+/// times over { u8 "old", u8 "new" } ×3. Reader always consumes three pairs.
 /// </summary>
+/// <remarks>
+/// Two useful shapes:
+/// <list type="bullet">
+/// <item>Full triad (skillsaver): all three news valid → client updates sheet but skips
+/// <c>ABILITY_CHANGED</c> (no msg_swap_ability / learn-ability banner).</item>
+/// <item>Single change (NPC): <c>olds/news = [changed, General, General]</c> → one leading
+/// valid news → fires <c>ABILITY_CHANGED</c>. Learn unlock uses <c>olds[0]=General</c>.</item>
+/// </list>
+/// Sending fewer than three pairs desyncs the SC stream ("not enough buffer for old").
+/// </remarks>
 public class SCAbilitySwappedPacket(
     uint objId, AbilityType[] oldAbilities, AbilityType[] newAbilities)
     : GamePacket(SCOffsets.SCAbilitySwappedPacket, 1)

--- a/AAEmu.Game/Core/Packets/G2C/SCCharacterStatePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCCharacterStatePacket.cs
@@ -78,7 +78,7 @@ public class SCCharacterStatePacket(Character character) : GamePacket(SCOffsets.
         stream.Write(0u);                                   // dailyHonorWarPoint
         stream.Write(0L);                                   // dailyHonorWarPointDate
         stream.Write(0u);                                   // totalReportBadUser
-        stream.Write((byte)0);                              // usableAbilSetSlotCount (u8)
+        stream.Write(character.AbilitySets?.UsableSlotCount ?? CharacterAbilitySets.DefaultUsableSlots); // usableAbilSetSlotCount (u8)
 
         stream.Write(0u);                                   // _pageInfos size=0 (UnitState_SerializePageInfoList)
         stream.Write(0u);                                   // _selectPageIndex

--- a/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
@@ -262,6 +262,8 @@ public static class SCOffsets
     public const ushort SCBuffLearnedPacket = 0x144; // 10.0.2.13
     public const ushort SCSkillsResetPacket = 0x145; // 10.0.2.13
     public const ushort SCAbilitySwappedPacket = 0x147; // 10.0.2.13
+    public const ushort SCSpecialAbilityLearnedPacket = 0x148; // 10.0.2.13 (madness / special ability path)
+    public const ushort SCAbilitySetAllInfoPacket = 0x149; // 10.0.2.13 skillsaver full list
     public const ushort SCErrorMsgPacket = 0x14D; // 10.0.2.13 (10.0.2.13 name: ErrorMsgPacket)
     public const ushort SCDoodadCreatedPacket = 0x14E; // 10.0.2.13 (10.0.2.13 name: DoodadCreatedPacket)
     public const ushort SCDoodadRemovedPacket = 0x14F; // 10.0.2.13 (10.0.2.13 name: DoodadRemovedPacket)

--- a/AAEmu.Game/Models/Game/Char/AbilityChangeCosts.cs
+++ b/AAEmu.Game/Models/Game/Char/AbilityChangeCosts.cs
@@ -1,0 +1,104 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.Formulas;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Utils.DB;
+
+using NLog;
+
+namespace AAEmu.Game.Models.Game.Char;
+
+/// <summary>
+/// Gold costs for NPC skillset swap (formula 41) and skillsaver activate (formula 42).
+/// Config bases come from compact <c>content_configs</c>: <c>change_ability</c> /
+/// <c>swap_ability_set</c> (client maps these to <c>config_swap_ability_*</c>).
+/// </summary>
+internal static class AbilityChangeCosts
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    private const int DefaultChangeAbility = 600;
+    private const int DefaultSwapAbilitySet = 600;
+    private const int DefaultFreeActivations = 0;
+
+    private static int? _changeAbility;
+    private static int? _swapAbilitySet;
+    private static int? _freeActivations;
+
+    public static int FreeActivationLimit =>
+        _freeActivations ??= LoadInt("ability_set_free_activation_count", DefaultFreeActivations);
+
+    /// <summary>
+    /// Charge inventory gold for an NPC skillset change. Returns false if the player cannot pay
+    /// (<see cref="Character.ChangeMoney"/> already sends NotEnoughMoney).
+    /// </summary>
+    public static bool TryChargeSwapAbility(Character owner)
+    {
+        var cost = Evaluate(
+            FormulaKind.SwapAbilityCost,
+            owner,
+            "config_swap_ability_cost",
+            _changeAbility ??= LoadInt("change_ability", DefaultChangeAbility));
+        if (cost <= 0)
+            return true;
+
+        return owner.ChangeMoney(SlotType.Inventory, -cost, ItemTaskType.AbilityChange);
+    }
+
+    /// <summary>
+    /// Charge inventory gold for a skillsaver activation after free uses are exhausted.
+    /// </summary>
+    public static bool TryChargeSwapAbilitySet(Character owner)
+    {
+        var cost = Evaluate(
+            FormulaKind.SwapAbilitySetCost,
+            owner,
+            "config_swap_ability_set_cost",
+            _swapAbilitySet ??= LoadInt("swap_ability_set", DefaultSwapAbilitySet));
+        if (cost <= 0)
+            return true;
+
+        return owner.ChangeMoney(SlotType.Inventory, -cost, ItemTaskType.AbilityChange);
+    }
+
+    private static long Evaluate(FormulaKind kind, Character owner, string configKey, int configValue)
+    {
+        var formula = FormulaManager.Instance.GetFormula((uint)kind);
+        if (formula == null)
+        {
+            Logger.Warn("Ability change cost: missing formula {0}", kind);
+            return 0;
+        }
+
+        var value = formula.Evaluate(new Dictionary<string, double>
+        {
+            ["pc_level"] = owner.Level,
+            ["heir_level"] = owner.HeirLevel,
+            [configKey] = configValue
+        });
+        return (long)Math.Max(0, Math.Round(value));
+    }
+
+    private static int LoadInt(string name, int fallback)
+    {
+        try
+        {
+            using var connection = SQLite.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                "SELECT c.value FROM content_configs c " +
+                "JOIN enum_content_configs e ON e.id = c.id " +
+                "WHERE e.name = @name LIMIT 1";
+            command.Parameters.AddWithValue("@name", name);
+            var result = command.ExecuteScalar();
+            if (result != null && result != DBNull.Value)
+                return Convert.ToInt32(result);
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "Ability change cost: content_config '{0}' missing, using {1}", name, fallback);
+        }
+
+        return fallback;
+    }
+}

--- a/AAEmu.Game/Models/Game/Char/AbilitySetResponseType.cs
+++ b/AAEmu.Game/Models/Game/Char/AbilitySetResponseType.cs
@@ -1,0 +1,13 @@
+namespace AAEmu.Game.Models.Game.Char;
+
+/// <summary>
+/// <c>SCAbilitySetUpdated.responseType</c> values the 10.0.2.13 client maps to notify toasts
+/// (<c>saved_job</c> / <c>changed_job</c> / <c>deleted_job</c>). Values ≤ 0 show lack-of-slot.
+/// </summary>
+public enum AbilitySetResponseType : sbyte
+{
+    Failed = 0,
+    Saved = 1,
+    Changed = 2,
+    Deleted = 3
+}

--- a/AAEmu.Game/Models/Game/Char/AbilitySetSlot.cs
+++ b/AAEmu.Game/Models/Game/Char/AbilitySetSlot.cs
@@ -16,4 +16,25 @@ public sealed class AbilitySetSlot
         Ability1 is not AbilityType.None and not AbilityType.General ||
         Ability2 is not AbilityType.None and not AbilityType.General ||
         Ability3 is not AbilityType.None and not AbilityType.General;
+
+    /// <summary>True when the equipped three trees match this snapshot's triad order.</summary>
+    public bool MatchesTriad(AbilityType ability1, AbilityType ability2, AbilityType ability3) =>
+        Ability1 == ability1 && Ability2 == ability2 && Ability3 == ability3;
+
+    /// <summary>
+    /// True when the equipped combat skills/passives for this triad match the snapshot lists
+    /// (order-independent). Used so same-triad activates are not treated as no-ops when the
+    /// player reallocated points or is switching between two saved builds of the same trees.
+    /// </summary>
+    public bool MatchesSkillLoadout(
+        IReadOnlyCollection<uint> equippedSkillIds,
+        IReadOnlyCollection<uint> equippedPassiveBuffIds)
+    {
+        if (SkillIds.Count != equippedSkillIds.Count ||
+            PassiveBuffIds.Count != equippedPassiveBuffIds.Count)
+            return false;
+
+        return SkillIds.ToHashSet().SetEquals(equippedSkillIds) &&
+               PassiveBuffIds.ToHashSet().SetEquals(equippedPassiveBuffIds);
+    }
 }

--- a/AAEmu.Game/Models/Game/Char/AbilitySetSlot.cs
+++ b/AAEmu.Game/Models/Game/Char/AbilitySetSlot.cs
@@ -1,0 +1,19 @@
+using AAEmu.Game.Models.Game.Skills;
+
+namespace AAEmu.Game.Models.Game.Char;
+
+/// <summary>One skillsaver slot: active triad + learned combat skills/passives at save time.</summary>
+public sealed class AbilitySetSlot
+{
+    public byte SlotIndex { get; init; }
+    public AbilityType Ability1 { get; set; } = AbilityType.None;
+    public AbilityType Ability2 { get; set; } = AbilityType.None;
+    public AbilityType Ability3 { get; set; } = AbilityType.None;
+    public List<uint> SkillIds { get; } = [];
+    public List<uint> PassiveBuffIds { get; } = [];
+
+    public bool IsOccupied =>
+        Ability1 is not AbilityType.None and not AbilityType.General ||
+        Ability2 is not AbilityType.None and not AbilityType.General ||
+        Ability3 is not AbilityType.None and not AbilityType.General;
+}

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -3548,6 +3548,7 @@ public partial class Character : Unit, ICharacter
             Abilities.Load(connection);
             AbilitySets = new CharacterAbilitySets(this);
             AbilitySets.Load(connection);
+            AbilitySets.CheckDailyResetAtLogin();
             Actability = new CharacterActability(this);
             Actability.Load(connection);
             Skills = new CharacterSkills(this);

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -848,6 +848,7 @@ public partial class Character : Unit, ICharacter
     public CharacterMails Mails { get; set; }
     public CharacterAppellations Appellations { get; set; }
     public CharacterAbilities Abilities { get; set; }
+    public CharacterAbilitySets AbilitySets { get; set; }
     public CharacterPortals Portals { get; set; }
     public CharacterFriends Friends { get; set; }
     public CharacterBlocked Blocked { get; set; }
@@ -3545,6 +3546,8 @@ public partial class Character : Unit, ICharacter
             // Inventory.Load(connection);
             Abilities = new CharacterAbilities(this);
             Abilities.Load(connection);
+            AbilitySets = new CharacterAbilitySets(this);
+            AbilitySets.Load(connection);
             Actability = new CharacterActability(this);
             Actability.Load(connection);
             Skills = new CharacterSkills(this);
@@ -3768,6 +3771,7 @@ public partial class Character : Unit, ICharacter
 
             // Inventory?.Save(connection, transaction);
             Abilities?.Save(connection, transaction);
+            AbilitySets?.Save(connection, transaction);
             Actability?.Save(connection, transaction);
             Appellations?.Save(connection, transaction);
             // Save active buffs that should persist across logout (SaveRuleId > 0)

--- a/AAEmu.Game/Models/Game/Char/CharacterAbilities.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterAbilities.cs
@@ -93,8 +93,20 @@ public class CharacterAbilities
         // Adding into an empty slot sends oldAbilityId = None (30). There is nothing to wipe, and
         // SCSkillsReset(None) makes the client look up ability name 30 → "invalid ability".
         var isAdding = oldAbilityId is AbilityType.None or AbilityType.General;
-        if (!isAdding)
-            Owner.Skills.Reset(oldAbilityId);
+
+        // Client CanBuyAbilityChange() always shows formula 41 gold — charge before mutating.
+        if (Owner.Ability1 != oldAbilityId &&
+            Owner.Ability2 != oldAbilityId &&
+            Owner.Ability3 != oldAbilityId)
+        {
+            Logger.Warn(
+                "SwapAbility: no slot matched old={0} new={1} (slots {2}/{3}/{4})",
+                oldAbilityId, abilityId, Owner.Ability1, Owner.Ability2, Owner.Ability3);
+            return;
+        }
+
+        if (!AbilityChangeCosts.TryChargeSwapAbility(Owner))
+            return;
 
         // 0x147 reports every slot's before/after pair, so snapshot all three before mutating.
         AbilityType[] before = [Owner.Ability1, Owner.Ability2, Owner.Ability3];
@@ -131,13 +143,6 @@ public class CharacterAbilities
                 }
             }
         }
-        else
-        {
-            Logger.Warn(
-                "SwapAbility: no slot matched old={0} new={1} (slots {2}/{3}/{4})",
-                oldAbilityId, abilityId, Owner.Ability1, Owner.Ability2, Owner.Ability3);
-            return;
-        }
 
         if (!isAdding)
             Abilities[oldAbilityId].Order = 255;
@@ -149,16 +154,27 @@ public class CharacterAbilities
             Owner.Ability1, Owner.Ability2, Owner.Ability3,
             oldAbilityId, abilityId, isAdding);
 
-        Owner.BroadcastPacket(
-            new SCAbilitySwappedPacket(
-                Owner.ObjId, before, [Owner.Ability1, Owner.Ability2, Owner.Ability3]),
-            true);
+        // Wipe server book for the old tree (no SCSkillsReset — that cancels the banner queue).
+        if (!isAdding)
+            Owner.Skills.Reset(oldAbilityId, notifyClient: false);
 
-        // Client 0x147 handler clears skills for every pair's "old" id — including unchanged
-        // Ability1 — so re-push what the server still has or the tree looks empty in the UI.
-        Owner.Skills.ResendLearnedToOwner();
+        // Client 0x147 swap path only fires ABILITY_CHANGED (msg_swap_ability + learn-ability
+        // banner) when a single leading news[] ability is valid. A full triad (all three
+        // equipped) always skips that event — which is why NPC swaps looked broken.
+        // Pad with General(0): still three wire pairs (reader requires them), r13==1.
+        // Single-slot apply replaces old→new by ability id; only that tree is wiped client-side.
+        AbilityType[] wireOld =
+        [
+            isAdding ? AbilityType.General : oldAbilityId,
+            AbilityType.General,
+            AbilityType.General
+        ];
+        AbilityType[] wireNew = [abilityId, AbilityType.General, AbilityType.General];
 
-        // Free starters, same as character-create for Ability1.
+        Owner.BroadcastPacket(new SCAbilitySwappedPacket(Owner.ObjId, wireOld, wireNew), true);
+
+        // Only the swapped tree was cleared on the client — do not ResendLearned (chat spam).
+        // When unlocking a slot, push starters with notify so the client learns just those.
         if (isAdding && abilityId is not AbilityType.None and not AbilityType.General)
         {
             foreach (var template in SkillManager.Instance.GetStartAbilitySkills(abilityId))

--- a/AAEmu.Game/Models/Game/Char/CharacterAbilitySets.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterAbilitySets.cs
@@ -1,6 +1,7 @@
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.Formulas;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Skills;
@@ -403,6 +404,40 @@ public sealed class CharacterAbilitySets(Character owner)
             usedFree = UsedFreeActivationCount;
         }
         Owner.SendPacket(new SCAbilitySetAllInfoPacket(snapshot, usedFree));
+    }
+
+    /// <summary>
+    /// Offline catch-up when <see cref="FeaturesManager.Fsets.AbilitySetFreeActivationDailyReset"/> is on.
+    /// Uses <c>leave_time</c> like <see cref="CharacterQuests.CheckDailyResetAtLogin"/>.
+    /// </summary>
+    public void CheckDailyResetAtLogin()
+    {
+        if (!FeaturesManager.Fsets.AbilitySetFreeActivationDailyReset)
+            return;
+
+        var leaveUtc = ServerCalendar.AsUtc(Owner.LeaveTime);
+        if (leaveUtc.Date >= ServerCalendar.TodayUtc)
+            return;
+
+        ResetFreeActivationCount(syncClient: false);
+    }
+
+    /// <summary>
+    /// Clears the persisted free-activation counter for a new UTC day.
+    /// </summary>
+    public void ResetFreeActivationCount(bool syncClient)
+    {
+        lock (_sync)
+        {
+            if (UsedFreeActivationCount == 0)
+                return;
+
+            UsedFreeActivationCount = 0;
+        }
+
+        PersistCharacterColumns();
+        if (syncClient)
+            SendAllInfo();
     }
 
     private bool TryChargeActivation(byte slot)

--- a/AAEmu.Game/Models/Game/Char/CharacterAbilitySets.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterAbilitySets.cs
@@ -1,0 +1,639 @@
+using AAEmu.Commons.Utils.DB;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Formulas;
+using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Utils.DB;
+
+using MySql.Data.MySqlClient;
+
+using NLog;
+
+namespace AAEmu.Game.Models.Game.Char;
+
+/// <summary>
+/// Skillsaver (ability set) state for one character. Client toast popups are driven by
+/// <see cref="SCAbilitySetUpdatedPacket"/> / <see cref="SCAbilitySetSlotCountUpdatedPacket"/>.
+/// Activation is finished by special effect <c>ActivateSavedAbilitySet</c> after skill 32189.
+/// </summary>
+public sealed class CharacterAbilitySets(Character owner)
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    /// <summary>Retail client <c>MAX_ABILITY_SET_SLOTS</c> — hard cap after all expands (API dump = 5).</summary>
+    public const byte MaxSlots = 5;
+
+    /// <summary>Default unlocked slots for a new character.</summary>
+    public const byte DefaultUsableSlots = 1;
+
+    /// <summary>Skill cast when the client confirms a skillsaver apply (<c>갈무리 능력 활성</c>).</summary>
+    public const uint ActivateSkillId = 32189;
+
+    /// <summary>
+    /// Retail expand seal (<c>갈무리 확장의 인장</c>). Same item as
+    /// <c>bless_uthstin_expand_page_item_type</c>; client <c>GetExpandAbilitySetSlotInfo</c> uses it.
+    /// </summary>
+    public const uint ExpandItemId = 39559;
+
+    /// <summary>
+    /// Free activations before formula 42 gold applies. Compact
+    /// <c>ability_set_free_activation_count</c> is currently 0 (client always shows gold).
+    /// </summary>
+    public static byte MaxFreeActivations =>
+        (byte)Math.Clamp(AbilityChangeCosts.FreeActivationLimit, 0, byte.MaxValue);
+
+    /// <summary>
+    /// Pendant counts from compact <c>ability_set_slot_expand_item_need_cnt1..5</c> (shipped 1/2/4/4/4).
+    /// Expanding from usable slot count N consumes entry <c>min(N, 5)</c> — matches client needCount.
+    /// </summary>
+    private static readonly int[] DefaultExpandNeedCounts = [1, 2, 4, 4, 4];
+
+    private static int[] _expandNeedCounts;
+
+    private readonly object _sync = new();
+    private readonly Dictionary<byte, AbilitySetSlot> _slots = [];
+
+    private Character Owner { get; } = owner;
+
+    public byte UsableSlotCount { get; private set; } = DefaultUsableSlots;
+    public byte UsedFreeActivationCount { get; private set; }
+
+    /// <summary>Slot index waiting for skill 32189 / <c>ActivateSavedAbilitySet</c> to finish.</summary>
+    public int PendingActivationSlot { get; private set; } = -1;
+
+    public void SetPendingActivationSlot(int slotIndex)
+    {
+        lock (_sync)
+            PendingActivationSlot = slotIndex;
+    }
+
+    public void ClearPendingActivationSlot()
+    {
+        lock (_sync)
+            PendingActivationSlot = -1;
+    }
+
+    public bool TrySave(sbyte slotIndex)
+    {
+        // Skills UI defaults to the "current_use" combo row (index MAX+1) and sends
+        // SaveAbilitySet(MAX_ABILITY_SET_SLOTS). Treat that as "next free usable slot".
+        if (!TryResolveSaveSlot(slotIndex, out var slot))
+        {
+            Logger.Warn(
+                "AbilitySet save {0}: no writable slot (requested={1}, usable={2}, occupied={3})",
+                Owner.Name, slotIndex, UsableSlotCount, _slots.Count);
+            return Fail(slot);
+        }
+
+        if (Owner.Ability1 is AbilityType.None or AbilityType.General ||
+            Owner.Ability2 is AbilityType.None or AbilityType.General ||
+            Owner.Ability3 is AbilityType.None or AbilityType.General)
+        {
+            Logger.Warn("AbilitySet save {0}: need three active abilities (slot {1})", Owner.Name, slot);
+            return Fail(slot);
+        }
+
+        var snapshot = CaptureCurrent(slot);
+        lock (_sync)
+        {
+            if (!TryPersistSlot(snapshot))
+                return Fail(slot);
+
+            _slots[slot] = snapshot;
+        }
+
+        SendUpdated(AbilitySetResponseType.Saved, slot);
+        SendAllInfo();
+        Logger.Info("AbilitySet save {0}: slot {1} ok (requested={2})", Owner.Name, slot, slotIndex);
+        return true;
+    }
+
+    public bool TryDelete(sbyte slotIndex)
+    {
+        if (!TryValidateWritableSlot(slotIndex, out var slot))
+            return Fail(slot);
+
+        lock (_sync)
+        {
+            if (!_slots.ContainsKey(slot))
+                return Fail(slot);
+
+            if (!TryDeletePersistedSlot(slot))
+                return Fail(slot);
+
+            _slots.Remove(slot);
+        }
+
+        SendUpdated(AbilitySetResponseType.Deleted, slot);
+        SendAllInfo();
+        return true;
+    }
+
+    public bool TryExpand()
+    {
+        byte next;
+        int needCount;
+        lock (_sync)
+        {
+            if (UsableSlotCount >= MaxSlots)
+                return false;
+
+            needCount = GetExpandNeedCount(UsableSlotCount);
+            if (needCount <= 0)
+                return false;
+
+            if (!Owner.Inventory.CheckItems(Items.SlotType.Inventory, ExpandItemId, needCount))
+            {
+                Owner.SendErrorMessage(ErrorMessageType.NotEnoughExpandItem);
+                return false;
+            }
+
+            var consumed = Owner.Inventory.Bag.ConsumeItem(
+                ItemTaskType.AbilityChange,
+                ExpandItemId,
+                needCount,
+                null);
+            if (consumed != needCount)
+                return false;
+
+            next = (byte)(UsableSlotCount + 1);
+            UsableSlotCount = next;
+        }
+
+        // Persist immediately so a crash/relog does not roll back a consumed pendant.
+        PersistCharacterColumns();
+        Owner.SendPacket(new SCAbilitySetSlotCountUpdatedPacket((sbyte)next));
+        return true;
+    }
+
+    /// <summary>
+    /// Pendant cost to expand from <paramref name="currentUsableSlots"/> → +1.
+    /// Reads <c>ability_set_slot_expand_item_need_cnt1..5</c>; steps beyond 5 reuse cnt5.
+    /// </summary>
+    public static int GetExpandNeedCount(byte currentUsableSlots)
+    {
+        var counts = _expandNeedCounts ??= LoadExpandNeedCounts();
+        var step = Math.Clamp((int)currentUsableSlots, 1, counts.Length);
+        return counts[step - 1];
+    }
+
+    private static int[] LoadExpandNeedCounts()
+    {
+        var counts = (int[])DefaultExpandNeedCounts.Clone();
+        try
+        {
+            using var connection = SQLite.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                "SELECT e.name, c.value FROM content_configs c " +
+                "JOIN enum_content_configs e ON e.id = c.id " +
+                "WHERE e.name LIKE 'ability_set_slot_expand_item_need_cnt%'";
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                var name = reader.GetString(0);
+                var suffix = name[^1];
+                if (suffix is < '1' or > '5')
+                    continue;
+                var idx = suffix - '1';
+                counts[idx] = Convert.ToInt32(reader.GetValue(1));
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "AbilitySet expand need counts: using compact defaults 1/2/4/4/4");
+        }
+
+        return counts;
+    }
+
+    /// <summary>
+    /// Applies the pending skillsaver after skill 32189 fires <c>ActivateSavedAbilitySet</c>.
+    /// </summary>
+    public bool TryActivatePending()
+    {
+        int pending;
+        lock (_sync)
+        {
+            pending = PendingActivationSlot;
+            PendingActivationSlot = -1;
+        }
+
+        if (pending < 0)
+        {
+            Logger.Warn("AbilitySet activate {0}: no pending slot", Owner.Name);
+            return false;
+        }
+
+        return TryActivate((byte)pending);
+    }
+
+    public bool TryActivate(byte slot)
+    {
+        AbilitySetSlot saved;
+        lock (_sync)
+        {
+            if (slot >= UsableSlotCount || !_slots.TryGetValue(slot, out saved) || !saved.IsOccupied)
+                return Fail(slot);
+        }
+
+        AbilityType[] before = [Owner.Ability1, Owner.Ability2, Owner.Ability3];
+        AbilityType[] after = [saved.Ability1, saved.Ability2, saved.Ability3];
+
+        // Same triad already equipped — do not wipe/relearn (looks like a refresh) or toast "changed".
+        if (before[0] == after[0] && before[1] == after[1] && before[2] == after[2])
+        {
+            Logger.Info(
+                "AbilitySet activate {0}: slot {1} already {2}/{3}/{4} — skip swap",
+                Owner.Name, slot, before[0], before[1], before[2]);
+            return true;
+        }
+
+        if (!TryChargeActivation(slot))
+            return false;
+
+        // Server-side wipe first (no SCSkillsReset). SCAbilitySwapped must not be followed by
+        // reset spam or the learn-ability banner queue is cancelled.
+        foreach (var oldAbility in before.Distinct())
+        {
+            if (oldAbility is AbilityType.None or AbilityType.General)
+                continue;
+            Owner.Skills.Reset(oldAbility, notifyClient: false);
+            if (Owner.Abilities.Abilities.TryGetValue(oldAbility, out var ability))
+                ability.Order = 255;
+        }
+
+        Owner.Ability1 = saved.Ability1;
+        Owner.Ability2 = saved.Ability2;
+        Owner.Ability3 = saved.Ability3;
+        Owner.Abilities.SetAbility(saved.Ability1, 0);
+        Owner.Abilities.SetAbility(saved.Ability2, 1);
+        Owner.Abilities.SetAbility(saved.Ability3, 2);
+
+        ApplySnapshotSkills(saved);
+
+        // Retail skillsaver activate: 0x147 (sheet + client wipe of old trees), then
+        // SCAbilitySetUpdated(Changed). The client silently re-learns skills from its
+        // savedAbilitySets snapshot (filled by AllInfo / save) — do NOT ResendLearned
+        // (each SCSkillLearned posts "Learned …" chat). Full triad 0x147 also skips
+        // ABILITY_CHANGED (msg_swap_ability / learn-ability banner); that event only
+        // fires when a single leading news[] ability is valid.
+        Owner.BroadcastPacket(new SCAbilitySwappedPacket(Owner.ObjId, before, after), true);
+        SendUpdated(AbilitySetResponseType.Changed, slot);
+        Logger.Info(
+            "AbilitySet activate {0}: slot {1} {2}/{3}/{4} → {5}/{6}/{7} (skills={8})",
+            Owner.Name, slot,
+            before[0], before[1], before[2],
+            after[0], after[1], after[2],
+            saved.SkillIds.Count);
+        return true;
+    }
+
+    public void Load(MySqlConnection connection)
+    {
+        try
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText =
+                    "SELECT `usable_abil_set_slot_count`, `used_free_abil_set_activation` FROM characters WHERE `id` = @owner";
+                command.Parameters.AddWithValue("@owner", Owner.Id);
+                using var reader = command.ExecuteReader();
+                if (reader.Read())
+                {
+                    UsableSlotCount = reader.IsDBNull(0)
+                        ? DefaultUsableSlots
+                        : Math.Clamp(reader.GetByte(0), (byte)1, MaxSlots);
+                    UsedFreeActivationCount = reader.IsDBNull(1) ? (byte)0 : reader.GetByte(1);
+                }
+            }
+
+            _slots.Clear();
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText =
+                    "SELECT `slot`, `ability1`, `ability2`, `ability3` FROM ability_sets WHERE `owner` = @owner";
+                command.Parameters.AddWithValue("@owner", Owner.Id);
+                using var reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    var slot = new AbilitySetSlot
+                    {
+                        SlotIndex = reader.GetByte("slot"),
+                        Ability1 = (AbilityType)reader.GetByte("ability1"),
+                        Ability2 = (AbilityType)reader.GetByte("ability2"),
+                        Ability3 = (AbilityType)reader.GetByte("ability3")
+                    };
+                    _slots[slot.SlotIndex] = slot;
+                }
+            }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText =
+                    "SELECT `slot`, `skill_id`, `is_passive` FROM ability_set_skills WHERE `owner` = @owner";
+                command.Parameters.AddWithValue("@owner", Owner.Id);
+                using var reader = command.ExecuteReader();
+                while (reader.Read())
+                {
+                    var slotIndex = reader.GetByte("slot");
+                    if (!_slots.TryGetValue(slotIndex, out var slot))
+                        continue;
+
+                    var skillId = reader.GetUInt32("skill_id");
+                    if (reader.GetBoolean("is_passive"))
+                        slot.PassiveBuffIds.Add(skillId);
+                    else
+                        slot.SkillIds.Add(skillId);
+                }
+            }
+        }
+        catch (MySqlException ex)
+        {
+            // Schema update not applied yet — keep defaults so login still works.
+            Logger.Warn(ex, "AbilitySet load skipped for {0}", Owner.Name);
+            UsableSlotCount = DefaultUsableSlots;
+            UsedFreeActivationCount = 0;
+            _slots.Clear();
+        }
+    }
+
+    public void Save(MySqlConnection connection, MySqlTransaction transaction)
+    {
+        using (var command = connection.CreateCommand())
+        {
+            command.Connection = connection;
+            command.Transaction = transaction;
+            command.CommandText =
+                "UPDATE characters SET `usable_abil_set_slot_count` = @usable, `used_free_abil_set_activation` = @usedFree WHERE `id` = @owner";
+            command.Parameters.AddWithValue("@usable", UsableSlotCount);
+            command.Parameters.AddWithValue("@usedFree", UsedFreeActivationCount);
+            command.Parameters.AddWithValue("@owner", Owner.Id);
+            try
+            {
+                command.ExecuteNonQuery();
+            }
+            catch (MySqlException ex)
+            {
+                // Column may be missing until the SQL update is applied — keep gameplay working.
+                Logger.Warn(ex, "AbilitySet character column save skipped for {0}", Owner.Name);
+            }
+        }
+
+        // Slots are written immediately on save/delete; nothing else to flush here.
+    }
+
+    public void SendSlotCount()
+    {
+        Owner.SendPacket(new SCAbilitySetSlotCountUpdatedPacket((sbyte)UsableSlotCount));
+    }
+
+    /// <summary>
+    /// Push the full skillsaver list so <c>GetSavedAbilitySets</c> works after login/relog.
+    /// Without this the UI looks empty after a World restart even when MySQL still has rows.
+    /// </summary>
+    public void SendAllInfo()
+    {
+        AbilitySetSlot[] snapshot;
+        byte usedFree;
+        lock (_sync)
+        {
+            snapshot = _slots.Values.OrderBy(s => s.SlotIndex).ToArray();
+            usedFree = UsedFreeActivationCount;
+        }
+        Owner.SendPacket(new SCAbilitySetAllInfoPacket(snapshot, usedFree));
+    }
+
+    private bool TryChargeActivation(byte slot)
+    {
+        lock (_sync)
+        {
+            if (UsedFreeActivationCount < MaxFreeActivations)
+            {
+                UsedFreeActivationCount++;
+                PersistCharacterColumns();
+                return true;
+            }
+        }
+
+        // ChangeMoney already sends NotEnoughMoney on failure.
+        if (!AbilityChangeCosts.TryChargeSwapAbilitySet(Owner))
+            return Fail(slot);
+
+        return true;
+    }
+
+    private AbilitySetSlot CaptureCurrent(byte slot)
+    {
+        var snapshot = new AbilitySetSlot
+        {
+            SlotIndex = slot,
+            Ability1 = Owner.Ability1,
+            Ability2 = Owner.Ability2,
+            Ability3 = Owner.Ability3
+        };
+
+        foreach (var skill in Owner.Skills.Skills.Values)
+        {
+            var abilityId = skill.Template?.AbilityId ?? AbilityType.General;
+            if (abilityId == snapshot.Ability1 || abilityId == snapshot.Ability2 || abilityId == snapshot.Ability3)
+                snapshot.SkillIds.Add(skill.Id);
+        }
+
+        foreach (var buff in Owner.Skills.PassiveBuffs.Values)
+        {
+            var abilityId = buff.Template?.AbilityId ?? AbilityType.General;
+            if (abilityId == snapshot.Ability1 || abilityId == snapshot.Ability2 || abilityId == snapshot.Ability3)
+                snapshot.PassiveBuffIds.Add(buff.Id);
+        }
+
+        return snapshot;
+    }
+
+    private void ApplySnapshotSkills(AbilitySetSlot saved)
+    {
+        foreach (var skillId in saved.SkillIds)
+        {
+            if (Owner.Skills.Skills.ContainsKey(skillId))
+                continue;
+            var template = SkillManager.Instance.GetSkillTemplate(skillId);
+            if (template != null)
+                Owner.Skills.AddSkill(template, 1, false);
+        }
+
+        foreach (var buffId in saved.PassiveBuffIds)
+        {
+            if (Owner.Skills.PassiveBuffs.ContainsKey(buffId))
+                continue;
+            // Silent: SCBuffLearned → client "Learned …" chat; skillsaver restore uses AbilitySetUpdated.
+            Owner.Skills.AddBuff(buffId, notify: false);
+        }
+    }
+
+    private bool TryValidateWritableSlot(sbyte slotIndex, out byte slot)
+    {
+        slot = 0;
+        if (slotIndex < 0 || slotIndex >= MaxSlots)
+            return false;
+        slot = (byte)slotIndex;
+        return slot < UsableSlotCount;
+    }
+
+    /// <summary>
+    /// Resolves the slot to write. Explicit indices 0..usable-1 are used as-is (overwrite allowed).
+    /// Indices outside that range (notably <see cref="MaxSlots"/> from the "current_use" row) pick
+    /// the first empty usable slot.
+    /// </summary>
+    private bool TryResolveSaveSlot(sbyte slotIndex, out byte slot)
+    {
+        slot = 0;
+        lock (_sync)
+        {
+            if (slotIndex >= 0 && slotIndex < UsableSlotCount)
+            {
+                slot = (byte)slotIndex;
+                return true;
+            }
+
+            // Auto-pick: current_use sentinel, or any out-of-range request when a free slot exists.
+            for (byte i = 0; i < UsableSlotCount; i++)
+            {
+                if (_slots.TryGetValue(i, out var existing) && existing.IsOccupied)
+                    continue;
+                slot = i;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void PersistCharacterColumns()
+    {
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                "UPDATE characters SET `usable_abil_set_slot_count` = @usable, `used_free_abil_set_activation` = @usedFree WHERE `id` = @owner";
+            command.Parameters.AddWithValue("@usable", UsableSlotCount);
+            command.Parameters.AddWithValue("@usedFree", UsedFreeActivationCount);
+            command.Parameters.AddWithValue("@owner", Owner.Id);
+            command.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "AbilitySet column persist failed for {0}", Owner.Name);
+        }
+    }
+
+    private bool Fail(byte slot)
+    {
+        SendUpdated(AbilitySetResponseType.Failed, slot);
+        return false;
+    }
+
+    private void SendUpdated(AbilitySetResponseType responseType, byte slot)
+    {
+        Owner.SendPacket(new SCAbilitySetUpdatedPacket(
+            responseType: (sbyte)responseType,
+            slotIndex: slot,
+            usedFreeActivationCount: (sbyte)UsedFreeActivationCount));
+    }
+
+    private bool TryPersistSlot(AbilitySetSlot snapshot)
+    {
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var transaction = connection.BeginTransaction();
+            using (var command = connection.CreateCommand())
+            {
+                command.Connection = connection;
+                command.Transaction = transaction;
+                command.CommandText =
+                    "REPLACE INTO ability_sets(`owner`,`slot`,`ability1`,`ability2`,`ability3`) VALUES (@owner,@slot,@a1,@a2,@a3)";
+                command.Parameters.AddWithValue("@owner", Owner.Id);
+                command.Parameters.AddWithValue("@slot", snapshot.SlotIndex);
+                command.Parameters.AddWithValue("@a1", (byte)snapshot.Ability1);
+                command.Parameters.AddWithValue("@a2", (byte)snapshot.Ability2);
+                command.Parameters.AddWithValue("@a3", (byte)snapshot.Ability3);
+                command.ExecuteNonQuery();
+            }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.Connection = connection;
+                command.Transaction = transaction;
+                command.CommandText = "DELETE FROM ability_set_skills WHERE `owner` = @owner AND `slot` = @slot";
+                command.Parameters.AddWithValue("@owner", Owner.Id);
+                command.Parameters.AddWithValue("@slot", snapshot.SlotIndex);
+                command.ExecuteNonQuery();
+            }
+
+            foreach (var skillId in snapshot.SkillIds)
+                InsertSkillRow(connection, transaction, snapshot.SlotIndex, skillId, isPassive: false);
+            foreach (var buffId in snapshot.PassiveBuffIds)
+                InsertSkillRow(connection, transaction, snapshot.SlotIndex, buffId, isPassive: true);
+
+            transaction.Commit();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "AbilitySet persist failed for {0} slot {1}", Owner.Name, snapshot.SlotIndex);
+            return false;
+        }
+    }
+
+    private void InsertSkillRow(MySqlConnection connection, MySqlTransaction transaction, byte slot, uint skillId, bool isPassive)
+    {
+        using var command = connection.CreateCommand();
+        command.Connection = connection;
+        command.Transaction = transaction;
+        command.CommandText =
+            "INSERT INTO ability_set_skills(`owner`,`slot`,`skill_id`,`is_passive`) VALUES (@owner,@slot,@skill,@passive)";
+        command.Parameters.AddWithValue("@owner", Owner.Id);
+        command.Parameters.AddWithValue("@slot", slot);
+        command.Parameters.AddWithValue("@skill", skillId);
+        command.Parameters.AddWithValue("@passive", isPassive);
+        command.ExecuteNonQuery();
+    }
+
+    private bool TryDeletePersistedSlot(byte slot)
+    {
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var transaction = connection.BeginTransaction();
+            using (var command = connection.CreateCommand())
+            {
+                command.Connection = connection;
+                command.Transaction = transaction;
+                command.CommandText = "DELETE FROM ability_set_skills WHERE `owner` = @owner AND `slot` = @slot";
+                command.Parameters.AddWithValue("@owner", Owner.Id);
+                command.Parameters.AddWithValue("@slot", slot);
+                command.ExecuteNonQuery();
+            }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.Connection = connection;
+                command.Transaction = transaction;
+                command.CommandText = "DELETE FROM ability_sets WHERE `owner` = @owner AND `slot` = @slot";
+                command.Parameters.AddWithValue("@owner", Owner.Id);
+                command.Parameters.AddWithValue("@slot", slot);
+                command.ExecuteNonQuery();
+            }
+
+            transaction.Commit();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "AbilitySet delete failed for {0} slot {1}", Owner.Name, slot);
+            return false;
+        }
+    }
+}

--- a/AAEmu.Game/Models/Game/Char/CharacterAbilitySets.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterAbilitySets.cs
@@ -5,6 +5,7 @@ using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.Formulas;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Utils.DB;
 
 using MySql.Data.MySqlClient;
@@ -241,12 +242,15 @@ public sealed class CharacterAbilitySets(Character owner)
 
         AbilityType[] before = [Owner.Ability1, Owner.Ability2, Owner.Ability3];
         AbilityType[] after = [saved.Ability1, saved.Ability2, saved.Ability3];
+        var triadUnchanged = saved.MatchesTriad(before[0], before[1], before[2]);
 
-        // Same triad already equipped — do not wipe/relearn (looks like a refresh) or toast "changed".
-        if (before[0] == after[0] && before[1] == after[1] && before[2] == after[2])
+        // No-op only when the complete loadout matches — triad alone is not enough.
+        // Same trees with a different skill/passive allocation (reallocate, or another
+        // saved build of the same triad) must still wipe, restore, and toast Changed.
+        if (triadUnchanged && MatchesCurrentSkillLoadout(saved))
         {
             Logger.Info(
-                "AbilitySet activate {0}: slot {1} already {2}/{3}/{4} — skip swap",
+                "AbilitySet activate {0}: slot {1} already {2}/{3}/{4} with matching skills — skip",
                 Owner.Name, slot, before[0], before[1], before[2]);
             return true;
         }
@@ -254,8 +258,10 @@ public sealed class CharacterAbilitySets(Character owner)
         if (!TryChargeActivation(slot))
             return false;
 
-        // Server-side wipe first (no SCSkillsReset). SCAbilitySwapped must not be followed by
-        // reset spam or the learn-ability banner queue is cancelled.
+        // Server-side wipe first (no SCSkillsReset). Needed even when the triad is unchanged
+        // so reallocations / other same-tree builds drop skills not in the snapshot.
+        // SCAbilitySwapped must not be followed by reset spam or the learn-ability banner
+        // queue is cancelled.
         foreach (var oldAbility in before.Distinct())
         {
             if (oldAbility is AbilityType.None or AbilityType.General)
@@ -265,9 +271,14 @@ public sealed class CharacterAbilitySets(Character owner)
                 ability.Order = 255;
         }
 
-        Owner.Ability1 = saved.Ability1;
-        Owner.Ability2 = saved.Ability2;
-        Owner.Ability3 = saved.Ability3;
+        if (!triadUnchanged)
+        {
+            Owner.Ability1 = saved.Ability1;
+            Owner.Ability2 = saved.Ability2;
+            Owner.Ability3 = saved.Ability3;
+        }
+
+        // Always re-stamp sheet order — the wipe above sets Order=255 on every old tree.
         Owner.Abilities.SetAbility(saved.Ability1, 0);
         Owner.Abilities.SetAbility(saved.Ability2, 1);
         Owner.Abilities.SetAbility(saved.Ability3, 2);
@@ -280,15 +291,75 @@ public sealed class CharacterAbilitySets(Character owner)
         // (each SCSkillLearned posts "Learned …" chat). Full triad 0x147 also skips
         // ABILITY_CHANGED (msg_swap_ability / learn-ability banner); that event only
         // fires when a single leading news[] ability is valid.
-        Owner.BroadcastPacket(new SCAbilitySwappedPacket(Owner.ObjId, before, after), true);
+        // Same-triad restores skip 0x147 — trees did not change; Changed alone drives the
+        // client rebuild from the saved slot snapshot.
+        if (!triadUnchanged)
+            Owner.BroadcastPacket(new SCAbilitySwappedPacket(Owner.ObjId, before, after), true);
         SendUpdated(AbilitySetResponseType.Changed, slot);
         Logger.Info(
-            "AbilitySet activate {0}: slot {1} {2}/{3}/{4} → {5}/{6}/{7} (skills={8})",
+            "AbilitySet activate {0}: slot {1} {2}/{3}/{4} → {5}/{6}/{7} (skills={8}, triadUnchanged={9})",
             Owner.Name, slot,
             before[0], before[1], before[2],
             after[0], after[1], after[2],
-            saved.SkillIds.Count);
+            saved.SkillIds.Count,
+            triadUnchanged);
         return true;
+    }
+
+    /// <summary>
+    /// Seeds an occupied slot in memory for unit tests (skips MySQL persist).
+    /// </summary>
+    internal void SeedSlotForTests(AbilitySetSlot snapshot, byte usableSlotCount = MaxSlots)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        lock (_sync)
+        {
+            UsableSlotCount = Math.Clamp(usableSlotCount, (byte)1, MaxSlots);
+            _slots[snapshot.SlotIndex] = snapshot;
+        }
+    }
+
+    /// <summary>
+    /// When true, <see cref="TryChargeActivation"/> succeeds without gold or free-counter mutation.
+    /// </summary>
+    internal bool BypassActivationChargeForTests { get; set; }
+
+    private Dictionary<uint, SkillTemplate> _testSkillTemplates;
+
+    /// <summary>Unit-test seam: skill templates for <see cref="ApplySnapshotSkills"/> without SkillManager DI.</summary>
+    internal void SeedSkillTemplateForTests(SkillTemplate template)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+        _testSkillTemplates ??= [];
+        _testSkillTemplates[template.Id] = template;
+    }
+
+    private SkillTemplate ResolveSkillTemplate(uint skillId)
+    {
+        if (_testSkillTemplates != null && _testSkillTemplates.TryGetValue(skillId, out var seeded))
+            return seeded;
+        return SkillManager.Instance.GetSkillTemplate(skillId);
+    }
+
+    private bool MatchesCurrentSkillLoadout(AbilitySetSlot saved)
+    {
+        var equippedSkills = new List<uint>();
+        foreach (var skill in Owner.Skills.Skills.Values)
+        {
+            var abilityId = skill.Template?.AbilityId ?? AbilityType.General;
+            if (abilityId == saved.Ability1 || abilityId == saved.Ability2 || abilityId == saved.Ability3)
+                equippedSkills.Add(skill.Id);
+        }
+
+        var equippedPassives = new List<uint>();
+        foreach (var buff in Owner.Skills.PassiveBuffs.Values)
+        {
+            var abilityId = buff.Template?.AbilityId ?? AbilityType.General;
+            if (abilityId == saved.Ability1 || abilityId == saved.Ability2 || abilityId == saved.Ability3)
+                equippedPassives.Add(buff.Id);
+        }
+
+        return saved.MatchesSkillLoadout(equippedSkills, equippedPassives);
     }
 
     public void Load(MySqlConnection connection)
@@ -442,6 +513,9 @@ public sealed class CharacterAbilitySets(Character owner)
 
     private bool TryChargeActivation(byte slot)
     {
+        if (BypassActivationChargeForTests)
+            return true;
+
         lock (_sync)
         {
             if (UsedFreeActivationCount < MaxFreeActivations)
@@ -492,7 +566,7 @@ public sealed class CharacterAbilitySets(Character owner)
         {
             if (Owner.Skills.Skills.ContainsKey(skillId))
                 continue;
-            var template = SkillManager.Instance.GetSkillTemplate(skillId);
+            var template = ResolveSkillTemplate(skillId);
             if (template != null)
                 Owner.Skills.AddSkill(template, 1, false);
         }

--- a/AAEmu.Game/Models/Game/Char/CharacterSkills.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterSkills.cs
@@ -90,10 +90,14 @@ public class CharacterSkills(Character owner)
     }
 
     /// <summary>
-    /// Try to learn a Passive Skill
+    /// Try to learn a Passive Skill.
     /// </summary>
     /// <param name="buffId"></param>
-    public void AddBuff(uint buffId)
+    /// <param name="notify">
+    /// When true, broadcasts <c>SCBuffLearned</c> (client chat "Learned …"). Use false for
+    /// skillsaver snapshot restore — the client rebuilds passives from AllInfo / AbilitySetUpdated.
+    /// </param>
+    public void AddBuff(uint buffId, bool notify = true)
     {
         // Check if what we want to learn is part of an active skill tree (or not part of one)
         var template = SkillManager.Instance.GetPassiveBuffTemplate(buffId);
@@ -124,14 +128,16 @@ public class CharacterSkills(Character owner)
         // Add Passive Buff
         var buff = new PassiveBuff { Id = buffId, Template = template };
         PassiveBuffs.Add(buff.Id, buff);
-        Owner.BroadcastPacket(new SCBuffLearnedPacket(Owner.ObjId, buff.Id), true);
+        if (notify)
+            Owner.BroadcastPacket(new SCBuffLearnedPacket(Owner.ObjId, buff.Id), true);
         buff.Apply(Owner);
     }
 
     /// <summary>
-    /// Re-send every learned skill/passive to this character. Needed after SCAbilitySwapped:
-    /// the client clears skills for each pair's <c>old</c> ability id — including unchanged
-    /// slots — so without a resync Ability1 looks wiped even though the server still has them.
+    /// Re-send every learned skill/passive to this character. Needed after <c>SCAbilitySwapped</c>
+    /// when the client wiped trees and there is no <c>SCAbilitySetUpdated(Changed)</c> path to
+    /// restore them from a saved set (e.g. NPC <see cref="CharacterAbilities.Swap"/>).
+    /// Each <c>SCSkillLearned</c> raises chat <c>SKILL_LEARNED</c> — do not use on skillsaver activate.
     /// </summary>
     public void ResendLearnedToOwner()
     {
@@ -145,7 +151,11 @@ public class CharacterSkills(Character owner)
     /// Resets all skills from a specific ability Skill Tree
     /// </summary>
     /// <param name="abilityId"></param>
-    public void Reset(AbilityType abilityId)
+    /// <param name="notifyClient">
+    /// When false, only mutates server state. Used before <c>SCAbilitySwapped</c> so a following
+    /// <c>SCSkillsReset</c> does not cancel the client's learn-ability banner queue.
+    /// </param>
+    public void Reset(AbilityType abilityId, bool notifyClient = true)
     {
         // TODO: with price...
         foreach (var skill in new List<Skill>(Skills.Values))
@@ -165,8 +175,9 @@ public class CharacterSkills(Character owner)
             _removed.Add(buff.Id);
         }
 
-        Owner.HeirSkills?.RemoveByAbility(abilityId, notifyClient: true);
-        Owner.BroadcastPacket(new SCSkillsResetPacket(Owner.ObjId, abilityId), true);
+        Owner.HeirSkills?.RemoveByAbility(abilityId, notifyClient: notifyClient);
+        if (notifyClient)
+            Owner.BroadcastPacket(new SCSkillsResetPacket(Owner.ObjId, abilityId), true);
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Configurations.cs
+++ b/AAEmu.Game/Models/Game/Configurations.cs
@@ -370,6 +370,14 @@ public class FeaturesConfig
     /// Configure in <c>AAEmu.Game/Configurations/Features.json</c> under <c>Features.BackpackProfitShare</c>.
     /// </summary>
     public bool BackpackProfitShare { get; set; } = true;
+
+    /// <summary>
+    /// Zero <c>used_free_abil_set_activation</c> at the UTC day boundary and on login catch-up after
+    /// <c>leave_time</c>. Only matters when compact <c>ability_set_free_activation_count</c> is above zero.
+    /// Configure in <c>AAEmu.Game/Configurations/Features.json</c> under
+    /// <c>Features.AbilitySetFreeActivationDailyReset</c>.
+    /// </summary>
+    public bool AbilitySetFreeActivationDailyReset { get; set; } = true;
 }
 
 /// <summary>

--- a/AAEmu.Game/Models/Game/Features/FeatureSet.cs
+++ b/AAEmu.Game/Models/Game/Features/FeatureSet.cs
@@ -146,6 +146,12 @@ public class FeatureSet
     /// </summary>
     public bool BackpackProfitShare { get; set; } = true;
 
+    /// <summary>
+    /// Reset skillsaver free-activation usage at the UTC day boundary.
+    /// Set from <c>Features.AbilitySetFreeActivationDailyReset</c>; read by CharacterAbilitySets.
+    /// </summary>
+    public bool AbilitySetFreeActivationDailyReset { get; set; } = true;
+
     #endregion
 
     public override string ToString()

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ActivateSavedAbilitySet.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ActivateSavedAbilitySet.cs
@@ -3,10 +3,12 @@ using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
 
+/// <summary>
+/// Completes a skillsaver apply after the client casts skill 32189.
+/// Pending slot is stashed when <c>CSStartSkill</c> sees that skill id (from skill-object payload when present).
+/// </summary>
 public class ActivateSavedAbilitySet : SpecialEffectAction
 {
-    //protected override SpecialType SpecialEffectActionType => SpecialType.ActivateSavedAbilitySet;
-
     public override void Execute(BaseUnit caster,
         SkillCaster casterObj,
         BaseUnit target,
@@ -20,7 +22,23 @@ public class ActivateSavedAbilitySet : SpecialEffectAction
         int value3,
         int value4)
     {
-        // TODO ...
-        if (caster is Character) { Logger.Debug("Special effects: ActivateSavedAbilitySet value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4); }
+        if (caster is not Character character)
+            return;
+
+        // Prefer skill-object slot. DB special-effect values are all 0 and must not mean "slot 0".
+        if (character.AbilitySets.PendingActivationSlot < 0)
+        {
+            var fromObject = skillObject switch
+            {
+                SkillObjectAbilitySet abilitySet => abilitySet.SlotIndex,
+                SkillObjectUnk5 unk5 => unk5.Step,
+                SkillObjectUnk1 unk1 => unk1.Id,
+                _ => -1
+            };
+            if (fromObject >= 0)
+                character.AbilitySets.SetPendingActivationSlot(fromObject);
+        }
+
+        character.AbilitySets.TryActivatePending();
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/SkillCastWire.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillCastWire.cs
@@ -17,9 +17,16 @@ public static class SkillCastWire
     public static PacketStream WriteSkillCastExtra(this PacketStream stream, SkillObject skillObject)
     {
         skillObject ??= new SkillObject();
-        var type = (byte)skillObject.Flag;
-        stream.Write(type); // flag: type in low 6 bits; 0x40/0x80 unused for normal casts
-        switch (skillObject.Flag)
+
+        // ActiveAbilitySet (15) is CS-only: skillsaver slot index. Echoing it on SCSkillStarted /
+        // SCSkillFired makes the client drop cast UX (no cast bar / cast anim) and can scramble
+        // parsing of later SC packets in the same session. Slot is already stashed from CSStartSkill.
+        var flag = skillObject.Flag == SkillObjectType.AbilitySet
+            ? SkillObjectType.None
+            : skillObject.Flag;
+
+        stream.Write((byte)flag); // flag: type in low 6 bits; 0x40/0x80 unused for normal casts
+        switch (flag)
         {
             case SkillObjectType.Unk1 when skillObject is SkillObjectUnk1 u1:
                 stream.Write(u1.Type);

--- a/AAEmu.Game/Models/Game/Skills/SkillObject.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillObject.cs
@@ -13,9 +13,11 @@ public enum SkillObjectType
     Unk5 = 5,
     Unk6 = 6,
     ItemGradeEnchantingSupport = 7,
-
     /// <summary>Synthesis material slots. See <see cref="SkillObjectItemEvolvingMaterials"/>.</summary>
     ItemEvolvingMaterials = 8,
+
+    /// <summary>10.0.2.13 <c>ActiveAbilitySet</c> — payload is skillsaver slot index (i32).</summary>
+    AbilitySet = 15,
 
     /// <summary>The awakening result the player picked. See <see cref="SkillObjectItemChangeMapping"/>.</summary>
     ItemChangeMapping = 26
@@ -32,12 +34,9 @@ public class SkillObject : PacketMarshaler
     }
 
     /// <summary>
-    /// Whether this server can parse a skill-object type. Reading an unknown one would take the
-    /// wrong number of bytes off the stream and desync everything after it, so callers drop those
-    /// rather than guess.
-    /// </summary>
-    /// <summary>
-    /// Whether the low bits of a cast's flag byte name a shape this server can read back.
+    /// Whether the low bits of a cast's flag byte name a shape this server can read back. Reading an
+    /// unknown one would take the wrong number of bytes off the stream and desync everything after
+    /// it, so callers drop those rather than guess.
     /// </summary>
     /// <remarks>
     /// Six is excluded. The flag is a bit mask, and only bit 3 carries a payload, so a cast setting
@@ -49,6 +48,7 @@ public class SkillObject : PacketMarshaler
     public static bool IsKnownType(int flagType) =>
         flagType is >= (int)SkillObjectType.Unk1 and <= (int)SkillObjectType.ItemEvolvingMaterials
             and not (int)SkillObjectType.Unk6
+            or (int)SkillObjectType.AbilitySet
             or (int)SkillObjectType.ItemChangeMapping;
 
     public static SkillObject GetByType(SkillObjectType flag)
@@ -79,6 +79,9 @@ public class SkillObject : PacketMarshaler
                 break;
             case SkillObjectType.ItemEvolvingMaterials:
                 obj = new SkillObjectItemEvolvingMaterials();
+                break;
+            case SkillObjectType.AbilitySet:
+                obj = new SkillObjectAbilitySet();
                 break;
             case SkillObjectType.ItemChangeMapping:
                 obj = new SkillObjectItemChangeMapping();
@@ -258,18 +261,10 @@ public class SkillObjectExtraValues : SkillObject
 
     public int[] Values { get; set; } = new int[ValueCount];
 
-    /// <summary>How many of <see cref="Values"/> the sender actually supplied.</summary>
-    public int ReadCount { get; private set; }
-
     public override void Read(PacketStream stream)
     {
         Values = new int[ValueCount];
-
-        // Only as many as the sender supplied: this block is not always the full thirteen. A nest
-        // interaction carries two, and reading the difference off the end of the body logged eleven
-        // stream errors per cast while contributing nothing but zeroes.
-        ReadCount = System.Math.Min(ValueCount, stream.LeftBytes / sizeof(int));
-        for (var i = 0; i < ReadCount; i++)
+        for (var i = 0; i < ValueCount; i++)
             Values[i] = stream.ReadInt32();
     }
 

--- a/AAEmu.Game/Models/Game/Skills/SkillObject.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillObject.cs
@@ -13,6 +13,7 @@ public enum SkillObjectType
     Unk5 = 5,
     Unk6 = 6,
     ItemGradeEnchantingSupport = 7,
+
     /// <summary>Synthesis material slots. See <see cref="SkillObjectItemEvolvingMaterials"/>.</summary>
     ItemEvolvingMaterials = 8,
 
@@ -34,9 +35,12 @@ public class SkillObject : PacketMarshaler
     }
 
     /// <summary>
-    /// Whether the low bits of a cast's flag byte name a shape this server can read back. Reading an
-    /// unknown one would take the wrong number of bytes off the stream and desync everything after
-    /// it, so callers drop those rather than guess.
+    /// Whether this server can parse a skill-object type. Reading an unknown one would take the
+    /// wrong number of bytes off the stream and desync everything after it, so callers drop those
+    /// rather than guess.
+    /// </summary>
+    /// <summary>
+    /// Whether the low bits of a cast's flag byte name a shape this server can read back.
     /// </summary>
     /// <remarks>
     /// Six is excluded. The flag is a bit mask, and only bit 3 carries a payload, so a cast setting
@@ -261,10 +265,18 @@ public class SkillObjectExtraValues : SkillObject
 
     public int[] Values { get; set; } = new int[ValueCount];
 
+    /// <summary>How many of <see cref="Values"/> the sender actually supplied.</summary>
+    public int ReadCount { get; private set; }
+
     public override void Read(PacketStream stream)
     {
         Values = new int[ValueCount];
-        for (var i = 0; i < ValueCount; i++)
+
+        // Only as many as the sender supplied: this block is not always the full thirteen. A nest
+        // interaction carries two, and reading the difference off the end of the body logged eleven
+        // stream errors per cast while contributing nothing but zeroes.
+        ReadCount = System.Math.Min(ValueCount, stream.LeftBytes / sizeof(int));
+        for (var i = 0; i < ReadCount; i++)
             Values[i] = stream.ReadInt32();
     }
 

--- a/AAEmu.Game/Models/Game/Skills/SkillObjectAbilitySet.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillObjectAbilitySet.cs
@@ -1,0 +1,25 @@
+using AAEmu.Commons.Network;
+
+namespace AAEmu.Game.Models.Game.Skills;
+
+/// <summary>
+/// CS SkillCastExtra type 15 (<c>ActiveAbilitySet</c>). Payload is the skillsaver slot index as
+/// <b>i16</b> (2 bytes). Reading it as i32 underruns when only those 2 bytes remain and
+/// <see cref="PacketStream.ReadInt32"/> returns 0 — every activate looked like slot 0.
+/// </summary>
+public class SkillObjectAbilitySet : SkillObject
+{
+    public short SlotIndex { get; set; }
+
+    public override void Read(PacketStream stream)
+    {
+        SlotIndex = stream.ReadInt16();
+    }
+
+    public override PacketStream Write(PacketStream stream)
+    {
+        base.Write(stream);
+        stream.Write(SlotIndex);
+        return stream;
+    }
+}

--- a/AAEmu.Game/Models/Tasks/Quests/QuestDailyResetTask.cs
+++ b/AAEmu.Game/Models/Tasks/Quests/QuestDailyResetTask.cs
@@ -26,7 +26,21 @@ public class QuestDailyResetTask : Task
             character.Quests.ResetDailyQuests(true);
             TimedRewardsManager.Instance.DoDailyAccountLogin(character.AccountId);
             if (FeaturesManager.Fsets.AbilitySetFreeActivationDailyReset)
-                character.AbilitySets.ResetFreeActivationCount(syncClient: true);
+            {
+                // Isolate client sync failures so one character cannot abort the rest of the
+                // online free-activation reset (Greptile on AAEmu#1546).
+                try
+                {
+                    character.AbilitySets.ResetFreeActivationCount(syncClient: true);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(
+                        ex,
+                        "Failed to reset ability-set free activations for character {0}",
+                        character.Id);
+                }
+            }
         }
 
         // Today (detail 13) completion bits above; also reseed Path of Destiny UI/DB day_key state.

--- a/AAEmu.Game/Models/Tasks/Quests/QuestDailyResetTask.cs
+++ b/AAEmu.Game/Models/Tasks/Quests/QuestDailyResetTask.cs
@@ -8,7 +8,8 @@ namespace AAEmu.Game.Models.Tasks.Quests;
 /// <summary>
 /// Fires at 00:00:00 UTC every day (cron <c>0 0 0 */1 * *</c> on TaskManager's UTC clock).
 /// Resets all daily-detail completed quests (not just Path of Destiny), today-assignment state,
-/// and daily-login account rewards for online characters. Offline catch-up is leave_time based.
+/// daily-login account rewards, and skillsaver free-activation usage for online characters.
+/// Offline catch-up is leave_time based.
 /// </summary>
 public class QuestDailyResetTask : Task
 {
@@ -24,6 +25,8 @@ public class QuestDailyResetTask : Task
         {
             character.Quests.ResetDailyQuests(true);
             TimedRewardsManager.Instance.DoDailyAccountLogin(character.AccountId);
+            if (FeaturesManager.Fsets.AbilitySetFreeActivationDailyReset)
+                character.AbilitySets.ResetFreeActivationCount(syncClient: true);
         }
 
         // Today (detail 13) completion bits above; also reseed Path of Destiny UI/DB day_key state.

--- a/AAEmu.UnitTests/Game/Models/Game/Char/AbilitySetSlotTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Char/AbilitySetSlotTests.cs
@@ -1,0 +1,38 @@
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Skills;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Char;
+
+/// <summary>
+/// Pure loadout-match rules used by skillsaver activate no-op detection.
+/// </summary>
+public class AbilitySetSlotTests
+{
+    [Test]
+    public async Task MatchesTriad_RequiresOrderedEquality()
+    {
+        var slot = new AbilitySetSlot
+        {
+            SlotIndex = 0,
+            Ability1 = AbilityType.Fight,
+            Ability2 = AbilityType.Illusion,
+            Ability3 = AbilityType.Wild
+        };
+
+        await Assert.That(slot.MatchesTriad(AbilityType.Fight, AbilityType.Illusion, AbilityType.Wild)).IsTrue();
+        await Assert.That(slot.MatchesTriad(AbilityType.Illusion, AbilityType.Fight, AbilityType.Wild)).IsFalse();
+    }
+
+    [Test]
+    public async Task MatchesSkillLoadout_IsOrderIndependent()
+    {
+        var slot = new AbilitySetSlot { SlotIndex = 0 };
+        slot.SkillIds.AddRange([10u, 20u, 30u]);
+        slot.PassiveBuffIds.AddRange([100u, 200u]);
+
+        await Assert.That(slot.MatchesSkillLoadout([30u, 10u, 20u], [200u, 100u])).IsTrue();
+        await Assert.That(slot.MatchesSkillLoadout([10u, 20u], [100u, 200u])).IsFalse();
+        await Assert.That(slot.MatchesSkillLoadout([10u, 20u, 30u], [100u])).IsFalse();
+        await Assert.That(slot.MatchesSkillLoadout([10u, 20u, 99u], [100u, 200u])).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Char/CharacterAbilitySetsActivationTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Char/CharacterAbilitySetsActivationTests.cs
@@ -1,0 +1,139 @@
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Char;
+
+/// <summary>
+/// Regression for same-triad skillsaver activate: two saved allocations of the same trees
+/// must restore skills, not early-return on triad equality alone (AAEmu#1546 review).
+/// </summary>
+public class CharacterAbilitySetsActivationTests
+{
+    private const AbilityType Tree1 = AbilityType.Fight;
+    private const AbilityType Tree2 = AbilityType.Illusion;
+    private const AbilityType Tree3 = AbilityType.Wild;
+
+    [Test]
+    public async Task TryActivate_SameTriadDifferentSkills_RestoresSavedAllocation()
+    {
+        var character = CreateCharacter();
+        SeedSkill(character, 101, Tree1);
+        SeedSkill(character, 102, Tree1);
+        SeedSkill(character, 201, Tree1);
+        SeedSkill(character, 202, Tree1);
+
+        var slotA = SameTriadSlot(0, [101u, 102u]);
+        var slotB = SameTriadSlot(1, [201u, 202u]);
+        character.AbilitySets.SeedSlotForTests(slotA, usableSlotCount: 2);
+        character.AbilitySets.SeedSlotForTests(slotB, usableSlotCount: 2);
+        character.AbilitySets.BypassActivationChargeForTests = true;
+
+        Learn(character, 101, Tree1);
+        Learn(character, 102, Tree1);
+
+        await Assert.That(character.AbilitySets.TryActivate(1)).IsTrue();
+        await Assert.That(character.Skills.Skills.ContainsKey(201)).IsTrue();
+        await Assert.That(character.Skills.Skills.ContainsKey(202)).IsTrue();
+        await Assert.That(character.Skills.Skills.ContainsKey(101)).IsFalse();
+        await Assert.That(character.Skills.Skills.ContainsKey(102)).IsFalse();
+        await Assert.That(character.Ability1).IsEqualTo(Tree1);
+        await Assert.That(character.Ability2).IsEqualTo(Tree2);
+        await Assert.That(character.Ability3).IsEqualTo(Tree3);
+    }
+
+    [Test]
+    public async Task TryActivate_SameTriadMatchingSkills_IsNoOp()
+    {
+        var character = CreateCharacter();
+        SeedSkill(character, 101, Tree1);
+        SeedSkill(character, 102, Tree1);
+
+        var slot = SameTriadSlot(0, [101u, 102u]);
+        character.AbilitySets.SeedSlotForTests(slot, usableSlotCount: 1);
+        character.AbilitySets.BypassActivationChargeForTests = true;
+
+        Learn(character, 101, Tree1);
+        Learn(character, 102, Tree1);
+
+        await Assert.That(character.AbilitySets.TryActivate(0)).IsTrue();
+        await Assert.That(character.Skills.Skills.ContainsKey(101)).IsTrue();
+        await Assert.That(character.Skills.Skills.ContainsKey(102)).IsTrue();
+        await Assert.That(character.Skills.Skills.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task TryActivate_SameTriadAfterReallocate_RestoresSnapshot()
+    {
+        var character = CreateCharacter();
+        SeedSkill(character, 101, Tree1);
+        SeedSkill(character, 102, Tree1);
+        SeedSkill(character, 103, Tree1);
+
+        var saved = SameTriadSlot(0, [101u, 102u]);
+        character.AbilitySets.SeedSlotForTests(saved, usableSlotCount: 1);
+        character.AbilitySets.BypassActivationChargeForTests = true;
+
+        // Player reallocated while keeping the same three trees.
+        Learn(character, 103, Tree1);
+
+        await Assert.That(character.AbilitySets.TryActivate(0)).IsTrue();
+        await Assert.That(character.Skills.Skills.ContainsKey(101)).IsTrue();
+        await Assert.That(character.Skills.Skills.ContainsKey(102)).IsTrue();
+        await Assert.That(character.Skills.Skills.ContainsKey(103)).IsFalse();
+    }
+
+    private static Character CreateCharacter()
+    {
+        var character = new Character(new UnitCustomModelParams())
+        {
+            Id = 42,
+            Name = "SkillsaverTester",
+            Level = 50,
+            Ability1 = Tree1,
+            Ability2 = Tree2,
+            Ability3 = Tree3
+        };
+        character.Abilities = new CharacterAbilities(character);
+        character.Abilities.SetAbility(Tree1, 0);
+        character.Abilities.SetAbility(Tree2, 1);
+        character.Abilities.SetAbility(Tree3, 2);
+        character.Skills = new CharacterSkills(character);
+        character.AbilitySets = new CharacterAbilitySets(character);
+        return character;
+    }
+
+    private static AbilitySetSlot SameTriadSlot(byte index, uint[] skillIds)
+    {
+        var slot = new AbilitySetSlot
+        {
+            SlotIndex = index,
+            Ability1 = Tree1,
+            Ability2 = Tree2,
+            Ability3 = Tree3
+        };
+        slot.SkillIds.AddRange(skillIds);
+        return slot;
+    }
+
+    private static void SeedSkill(Character character, uint id, AbilityType tree)
+    {
+        character.AbilitySets.SeedSkillTemplateForTests(new SkillTemplate
+        {
+            Id = id,
+            AbilityId = tree,
+            SkillPoints = 0
+        });
+    }
+
+    private static void Learn(Character character, uint skillId, AbilityType tree)
+    {
+        character.Skills.Skills[skillId] = new Skill
+        {
+            Id = skillId,
+            Template = new SkillTemplate { Id = skillId, AbilityId = tree, SkillPoints = 0 },
+            Level = 1
+        };
+    }
+}

--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -17,6 +17,23 @@ CREATE TABLE IF NOT EXISTS `abilities` (
   PRIMARY KEY (`id`,`owner`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Skillsets Exp';
 
+CREATE TABLE IF NOT EXISTS `ability_sets` (
+  `owner` int unsigned NOT NULL,
+  `slot` tinyint unsigned NOT NULL,
+  `ability1` tinyint unsigned NOT NULL DEFAULT 30,
+  `ability2` tinyint unsigned NOT NULL DEFAULT 30,
+  `ability3` tinyint unsigned NOT NULL DEFAULT 30,
+  PRIMARY KEY (`owner`, `slot`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Saved skillsaver ability triads';
+
+CREATE TABLE IF NOT EXISTS `ability_set_skills` (
+  `owner` int unsigned NOT NULL,
+  `slot` tinyint unsigned NOT NULL,
+  `skill_id` int unsigned NOT NULL,
+  `is_passive` tinyint(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`owner`, `slot`, `skill_id`, `is_passive`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Skills/passives snapshotted into a skillsaver slot';
+
 
 CREATE TABLE IF NOT EXISTS `accounts` (
   `account_id` INT(11) NOT NULL,
@@ -208,6 +225,8 @@ CREATE TABLE IF NOT EXISTS `characters` (
   `num_inv_slot` tinyint unsigned NOT NULL DEFAULT '50',
   `num_bank_slot` smallint unsigned NOT NULL DEFAULT '50',
   `expanded_expert` tinyint NOT NULL,
+  `usable_abil_set_slot_count` tinyint unsigned NOT NULL DEFAULT '1',
+  `used_free_abil_set_activation` tinyint unsigned NOT NULL DEFAULT '0',
   `slots` blob NOT NULL,
   `created_at` datetime(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
   `updated_at` datetime(0) NOT NULL DEFAULT '0001-01-01 00:00:00',

--- a/SQL/updates/2026-08-26_aaemu_game_character_ability_sets.sql
+++ b/SQL/updates/2026-08-26_aaemu_game_character_ability_sets.sql
@@ -1,0 +1,27 @@
+USE aaemu_game;
+
+-- Skillsaver (ability set) slots. usable count + daily free activations live on characters;
+-- each saved triad and its learned skills/passives live in the child tables.
+
+ALTER TABLE `characters`
+  ADD COLUMN `usable_abil_set_slot_count` tinyint unsigned NOT NULL DEFAULT 1
+    COMMENT 'How many skillsaver slots the character may use (expanded over time)' AFTER `expanded_expert`,
+  ADD COLUMN `used_free_abil_set_activation` tinyint unsigned NOT NULL DEFAULT 0
+    COMMENT 'Free skillsaver activations consumed this reset window' AFTER `usable_abil_set_slot_count`;
+
+CREATE TABLE IF NOT EXISTS `ability_sets` (
+  `owner` int unsigned NOT NULL,
+  `slot` tinyint unsigned NOT NULL,
+  `ability1` tinyint unsigned NOT NULL DEFAULT 30,
+  `ability2` tinyint unsigned NOT NULL DEFAULT 30,
+  `ability3` tinyint unsigned NOT NULL DEFAULT 30,
+  PRIMARY KEY (`owner`, `slot`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Saved skillsaver ability triads';
+
+CREATE TABLE IF NOT EXISTS `ability_set_skills` (
+  `owner` int unsigned NOT NULL,
+  `slot` tinyint unsigned NOT NULL,
+  `skill_id` int unsigned NOT NULL,
+  `is_passive` tinyint(1) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`owner`, `slot`, `skill_id`, `is_passive`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Skills/passives snapshotted into a skillsaver slot';


### PR DESCRIPTION
## Summary
- Implement skillsaver (ability set) save, delete, expand, and activate via skill 32189
- Add MySQL persistence (`ability_sets`, `ability_set_skills`, character columns)
- Wire CS/SC packets (AllInfo 0x149, Updated, SlotCount) and fix SCAbilitySetUpdated wire layout
- Fix NPC skillchanger gold charging and SCAbilitySwapped single-slot wire shape

## Test plan
- [ ] Run `SQL/updates/2026-08-26_aaemu_game_character_ability_sets.sql` on `aaemu_game`
- [ ] `dotnet build AAEmu.Game/AAEmu.Game.csproj`
- [ ] Login — skillsaver shows 1 usable slot
- [ ] Save current triad — toast on save, persists after relog
- [ ] Activate saved set — triad swaps without learn-spam
- [ ] Delete slot — toast + DB row removed
- [ ] Expand slot (item 39559) — slot count updates
- [ ] NPC skillchanger — gold deducted, swap banner shows