### PR TITLE
feat(guild): guild war, prestige-shop buffs, residence, and leveling

### DIFF
--- a/AAEmu.Game/Core/Managers/ExpeditionManager.cs
+++ b/AAEmu.Game/Core/Managers/ExpeditionManager.cs
@@ -38,14 +38,9 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
 
     /// <summary>
     /// Guild War economy, read from compact.sqlite3's content_configs (kind_id = 25), named through
-    /// enum_content_configs - same pattern as AuctionFeeSchedule. Values found live on this build:
-    /// expedition_war_initial_money_for_declaration=1000000, expedition_war_money_multiplier=5,
-    /// expedition_war_duration=3600000, expedition_war_duration_for_protection=172800,
-    /// expedition_war_reward_for_win=500, expedition_war_reward_for_lose=50, expedition_war_reward_for_draw=50.
-    /// The two duration configs have DIFFERENT units (confirmed 2026-09-02 by a live declaration logging
-    /// "ends 2026-10-14" - 41 days - from expedition_war_duration read as seconds):
-    ///   - expedition_war_duration = 3600000 is MILLISECONDS -> a 1-hour war (sane; 41 days is not).
-    ///   - expedition_war_duration_for_protection = 172800 is SECONDS -> a 48-hour re-declaration cooldown.
+    /// enum_content_configs - same pattern as AuctionFeeSchedule.
+    /// TODO: expedition_war_duration and expedition_war_duration_for_protection use different units
+    /// (milliseconds vs seconds) - do not assume they match if adding more duration configs here.
     /// </summary>
     private readonly Dictionary<string, long> _warConfig = [];
 
@@ -308,10 +303,7 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
     }
 
     /// <summary>
-    /// Sets the recruitment-board interest bitmask shown as icons in the info panel - backs
-    /// CSExpeditionInterestUpatePacket (X2Faction:SetMyExpeditionInterest). TypeValue's meaning is
-    /// unconfirmed and not required here (matches this codebase's convention elsewhere of leaving genuinely
-    /// unconfirmed fields parsed but unused).
+    /// Sets the recruitment-board interest bitmask shown as icons in the info panel.
     /// </summary>
     public void SetInterest(Character character, short interest)
     {
@@ -325,10 +317,9 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
     }
 
     /// <summary>
-    /// Backs X2Faction:SetExpeditionNotice (the info panel's guild-notice text) - mirrors SetInterest's
-    /// persist-then-resend-desc flow. No role-policy flag exists for notices specifically (the client
-    /// gates the edit control itself), so any guild member may set it, matching the member-gate used
-    /// for Guild Residence placement.
+    /// Sets the guild-notice text shown in the info panel. Any guild member may set it - no
+    /// role-policy flag exists for this specifically, matching the member-gate used for Guild
+    /// Residence placement.
     /// </summary>
     public void SetNotice(Character character, string notice)
     {
@@ -367,10 +358,8 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
         expedition.Level = gameData.GetAutoLevelForExp(expedition.Level, expedition.Exp);
 
         expedition.SendPacket(new SCExpeditionExpAddPacket(amount));
-        // Always resend the full descriptor, not just on a level change - SCExpeditionExpAddPacket's own
-        // wire format was never confirmed against the real client (still flagged "nothing constructs this
-        // yet" before this session), so the guild window's displayed exp/level can only be trusted to
-        // refresh via the already Ghidra-confirmed SCExpeditionDescPacket.
+        // Always resend the full descriptor, not just on a level change - the client's displayed
+        // exp/level can only be trusted to refresh via SCExpeditionDescPacket.
         expedition.SendPacket(new SCExpeditionDescPacket(expedition));
 
         Save(expedition);
@@ -420,14 +409,11 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
     }
 
     /// <summary>
-    /// Purchases/upgrades one guild prestige-shop buff to <paramref name="targetGrade"/> - handles
-    /// CSExpeditionBuffGradePacket (2026-08-27: that packet, and its sibling CSExpeditionBuffPacket, existed
-    /// fully parsed but "nothing acts on it yet" and were never even registered in GameNetwork's dispatch
-    /// table - same class of bug as CSExpeditionLevelUpPacket). Grades must be purchased in order (can't
-    /// skip from grade 2 to grade 4); paid for via the exact same Contribution Point spend the existing
-    /// Guild Contribution Shop already uses (see CSBuyItemsPacket.Pay/ExpeditionManager.TryChangeContributionPoints)
-    /// - straight from the purchasing character's own contribution_point balance, not a separate guild-pooled
-    /// currency - but the unlocked grade applies guild-wide once purchased.
+    /// Purchases/upgrades one guild prestige-shop buff to <paramref name="targetGrade"/>. Grades must
+    /// be purchased in order (can't skip from grade 2 to grade 4); paid for the same way the existing
+    /// Guild Contribution Shop spends Contribution Points - straight from the purchasing character's
+    /// own contribution_point balance, not a separate guild-pooled currency - but the unlocked grade
+    /// applies guild-wide once purchased.
     /// </summary>
     public bool TryPurchaseBuffGrade(Character character, uint buffId, byte targetGrade)
     {
@@ -463,10 +449,7 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
             return false;
         }
 
-        // 2026-09-02: expedition_buff_grades.housing (28 of 93 rows) requires the guild to already have its
-        // Guild Residence placed before this grade can be bought - a real shipped-data gate the client's own
-        // tooltip already advertises (expedition_buff_get_condition_tooltip_housing) but nothing server-side
-        // ever enforced. See ExpeditionBuffGrade.Housing's doc comment.
+        // expedition_buff_grades.housing requires the guild to already have its Guild Residence placed.
         if (grade.Housing && expedition.ResidenceHouseId == 0)
         {
             Logger.Warn("ExpeditionBuffGrade purchase rejected: buffId={0} grade={1} requires the guild to have a placed Guild Residence, expedition {2} has none",
@@ -508,15 +491,8 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
             command.ExecuteNonQuery();
         }
 
-        // 2026-09-02: send order matters here, and it was backwards. The client's "EXPEDITION_BUFF_CHANGE"
-        // Lua event handler (fired by SCExpeditionBuffChangedPacket) reacts by calling RefreshLeftList(),
-        // which re-queries X2Faction:GetExpeditionBuffs() - a client-side CACHE that is only ever populated
-        // by SCExpeditionBuffsPacket's own handler (FUN_394eef30, confirmed 2026-08-28 via Frida). Sending
-        // Changed (which triggers the read) before Buffs (which writes the cache the read depends on) meant
-        // every refresh queried the cache one purchase too early - explaining why grade always showed as
-        // its OLD value (e.g. the "0/x" display) even though the change notification demonstrably fired and
-        // the server-side purchase was already correct. Buffs now goes first so the cache is current by the
-        // time Changed's event handler re-reads it.
+        // Order matters: Buffs must go out before Changed, or the client's change-notification handler
+        // re-reads its buff cache before this purchase has updated it, showing the old grade.
         expedition.SendPacket(new SCExpeditionBuffsPacket((uint)expedition.Id, expedition.PurchasedBuffGrades));
         expedition.SendPacket(new SCExpeditionBuffChangedPacket((int)expedition.Id, (int)buffId, currentGrade, targetGrade));
         expedition.ApplyBuffBonusesToAllOnline();
@@ -645,12 +621,7 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
             new SCUnitExpeditionChangedPacket(owner.ObjId, owner.Id, "", owner.Name, 0, (uint)expedition.Id, false),
             true
         );
-        // unitId=0 sentinel = "this is about you" (see CSNotifyInGamePacket.cs's doc comment for the full
-        // Ghidra-confirmed trail) - primes the owner's own MyExpeditionId cache right on founding. Its native
-        // handler also resets cache+0x0 to 0 as a side effect (FUN_396b5f40) without re-populating it, but
-        // SendExpeditionInfo (below) resends SCExpeditionDescPacket right after, which repopulates cache+0x0 -
-        // no extra resend needed here (unlike CSNotifyInGamePacket.cs's login-refresh site, which had nothing
-        // else resending desc afterward).
+        // unitId=0 sentinel = "this is about you" - primes the owner's own MyExpeditionId cache right on founding.
         owner.SendPacket(
             new SCUnitExpeditionChangedPacket(0, owner.Id, "", owner.Name, 0, (uint)expedition.Id, false));
 
@@ -741,9 +712,6 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
         Logger.Info("Invite: {0} sending SCExpeditionInvitationPacket to {1} (inviter.Id={2}, expedition={3}/{4})",
             inviter.Name, invited.Name, inviter.Id, (uint)inviter.Expedition.Id, inviter.Expedition.Name);
         invited.SendPacket(
-            // 2026-08-27, third pass - see SCExpeditionInvitationPacket's own doc comment for the full
-            // corrected reasoning: this field is a plain 8-byte value carrying the persistent character id
-            // (matches the "playerId" field confirmed at the same interface slot elsewhere), not an ObjId.
             new SCExpeditionInvitationPacket(inviter.Id, inviter.Name, (uint)inviter.Expedition.Id,
                 inviter.Expedition.Name)
         );
@@ -767,8 +735,6 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
             new SCUnitExpeditionChangedPacket(invited.ObjId, invited.Id, "", invited.Name, 0, (uint)expedition.Id, false),
             true);
         // unitId=0 sentinel = "this is about you" - primes the accepting member's own MyExpeditionId cache.
-        // This is the fix for the member-list/invite/level-up-button-permanently-broken regression: this
-        // character never got told its own guild id, so IsExpedInfoLoaded() never passed.
         invited.SendPacket(
             new SCUnitExpeditionChangedPacket(0, invited.Id, "", invited.Name, 0, (uint)expedition.Id, false));
         SendExpeditionInfo(invited);
@@ -876,9 +842,7 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
             return;
 
         changedMember.Role = newRole;
-        // 2026-09-02: corrected wire format (see SCExpeditionRoleChangedPacket's own doc comment) - this
-        // announces WHICH MEMBER'S role changed (id + name + new role id), not a role-policy definition.
-        // Still sent alongside the member-status broadcast, which the member LIST row's live refresh uses.
+        // Member LIST row refresh uses the status broadcast; RoleChanged announces the identity separately.
         expedition.SendPacket(new SCExpeditionMemberStatusChangedPacket(changedMember, 0));
         expedition.SendPacket(new SCExpeditionRoleChangedPacket(changedMember.CharacterId, changedMember.Name, newRole));
         Save(expedition);
@@ -908,8 +872,6 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
                 newOwnerMember.Name
             )
         );
-        // 2026-08-28: same correction as ChangeMemberRole - member rows refresh via the status
-        // broadcast; SCExpeditionRoleChangedPacket carries role policies, not member identity.
         expedition.SendPacket(new SCExpeditionMemberStatusChangedPacket(ownerMember, 0));
         expedition.SendPacket(new SCExpeditionMemberStatusChangedPacket(newOwnerMember, 0));
         Save(expedition);
@@ -1033,13 +995,8 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
         Save(expedition);
         Save(targetExpedition);
 
-        // Broadcast server-wide, not just to the two guilds - the client's own handler for this packet
-        // (FUN_395ba9f0) has a dedicated bystander branch: when the RECIPIENT's own guild matches neither
-        // side AND started=true, it shows a plain "War declared!" banner (both guild names, no per-unit
-        // tagging) instead of the full enemy-tagging pass the two participants get. Sending only to the
-        // two guilds (as before) meant nobody else ever received the packet at all, so third parties saw
-        // neither a banner nor any indication a war had started - same idiom as EndWar's global result
-        // broadcast below.
+        // Broadcast server-wide, not just to the two guilds - bystanders get their own "War declared!"
+        // banner, same idiom as EndWar's global result broadcast below.
         var endsAtUnix = Helpers.UnixTime(endsAt);
         var declarePacket = new SCExpeditionWarStatePacket((int)expedition.Id, (int)targetExpedition.Id, true, endsAtUnix, false);
         foreach (var onlineCharacter in WorldManager.Instance.GetAllCharacters())
@@ -1135,15 +1092,8 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
         var enemyId = (int)expedition.WarEnemyExpeditionId;
         var defenderUnix = defender != null ? Helpers.UnixTime(protectedUntil) : 0;
 
-        // Order matters, and it's the OPPOSITE of what a previous session tried: the client's win/lost/tied
-        // banner is computed inside the KILL-SCORE packet handler (FUN_395b6c10), not the war-state one.
-        // That handler writes the fresh totals to the client's cache and then checks a "war just ended"
-        // flag - a flag that only the terminated SCExpeditionWarStatePacket sets. If the flag isn't set
-        // yet when the kill-score packet lands, the check is skipped and the ONLY banner the player ever
-        // sees is the war-state packet's own popup, which is unconditionally hardcoded to "tied" (traced
-        // in FUN_395ba9f0 - it always resolves to the fixed DAT_39ea8258 string, no result data involved).
-        // So the terminated war-state packet must go out FIRST (arms the flag), and the final kill-score
-        // packet LAST (fires the real win/lost/tied comparison against the just-armed flag and clears it).
+        // TODO: order matters here - the terminated war-state packet must go out BEFORE the final
+        // kill-score packet, or the client only shows a generic "tied" banner instead of the real result.
         expedition.SendPacket(new SCExpeditionWarStatePacket((int)expedition.Id, enemyId, false,
             expedition.WarIsDeclarer ? 0 : defenderUnix, true));
         enemyExpedition?.SendPacket(new SCExpeditionWarStatePacket((int)expedition.Id, enemyId, false,
@@ -1152,12 +1102,9 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
         if (declarer != null && defender != null)
         {
             // result: 1 = the 'id' guild (declarer) won, 2 = the 'id2' guild (defender) won, 0 = draw.
-            // SCNotifyExpeditionWarResultPacket's own handler (FUN_395b72d0) is gated to skip both actual
-            // participants - it only ever displays for bystanders not currently at war with either side -
-            // but nothing in the client decompile scopes it by faction/alliance beyond that. Broadcast it
-            // server-wide, same idiom as HeroManager.BroadcastPhaseChange (another major, realm-crossing
-            // announcement that also just does GetAllCharacters() with no faction filter). The two guilds'
-            // own members get their personal win/lost banner instead, from the kill-score packet below.
+            // This packet only ever displays for bystanders, not the two war participants themselves -
+            // broadcast server-wide, same idiom as HeroManager.BroadcastPhaseChange. The two guilds' own
+            // members get their personal win/lost banner instead, from the kill-score packet below.
             var declarerScore = declarer.WarKillScore;
             var defenderScore = defender.WarKillScore;
             byte result = declarerScore == defenderScore ? (byte)0 : declarerScore > defenderScore ? (byte)1 : (byte)2;
@@ -1346,14 +1293,8 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
             character.Expedition.TotalContributionPoint,
             string.Join(",", members.Select(m => $"{m.Name}={m.ContributionPoint}")));
 
-        // 2026-08-27: REVERTED the "send last" experiment from moments earlier tonight - user confirmed it
-        // made things WORSE (the level-up button, at least visible before, disappeared entirely; role
-        // permissions broke too), not better. Most likely explanation: the client latches UI state (level-up
-        // button visibility, role-policy-driven permission enabling) eagerly as each packet in this sequence
-        // arrives, expecting Level/Exp/the 0xff sentinel to already be cached by the time RolePolicyList/
-        // MemberList are processed - delaying this packet to last meant those one-shot UI updates ran against
-        // stale/default (zero) cached values instead of the real ones, which arrived too late to matter. Back
-        // to the original order: desc first, then policies/members.
+        // TODO: send order matters - desc must go out before RolePolicyList/MemberList, or the client's
+        // level-up button and role permissions latch against stale cached values.
         character.SendPacket(new SCExpeditionDescPacket(character.Expedition));
         character.SendPacket(new SCExpeditionRolePolicyListPacket(character.Expedition.Policies));
 

--- a/AAEmu.Game/Core/Managers/ExpeditionManager.cs
+++ b/AAEmu.Game/Core/Managers/ExpeditionManager.cs
@@ -13,9 +13,15 @@ using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Expeditions;
 using AAEmu.Game.Models.Game.Faction;
+using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Team;
 using AAEmu.Game.Models.StaticValues;
+using AAEmu.Game.Models.Tasks;
+using AAEmu.Game.Models.Tasks.Expeditions;
+using AAEmu.Game.Utils.DB;
+
+using NLog;
 
 using WorldIntegration = AAEmu.Game.WorldIntegration;
 
@@ -23,12 +29,53 @@ namespace AAEmu.Game.Core.Managers;
 
 public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamManager teamManager, IWorldManager worldManager, IChatManager chatManager) : Singleton<ExpeditionManager>, IExpeditionManager
 {
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
     //private ExpeditionConfig _config;
     private Regex _nameRegex;
 
     private Dictionary<FactionsEnum, Expedition> _expeditions;
 
+    /// <summary>
+    /// Guild War economy, read from compact.sqlite3's content_configs (kind_id = 25), named through
+    /// enum_content_configs - same pattern as AuctionFeeSchedule. Values found live on this build:
+    /// expedition_war_initial_money_for_declaration=1000000, expedition_war_money_multiplier=5,
+    /// expedition_war_duration=3600000, expedition_war_duration_for_protection=172800,
+    /// expedition_war_reward_for_win=500, expedition_war_reward_for_lose=50, expedition_war_reward_for_draw=50.
+    /// The two duration configs have DIFFERENT units (confirmed 2026-09-02 by a live declaration logging
+    /// "ends 2026-10-14" - 41 days - from expedition_war_duration read as seconds):
+    ///   - expedition_war_duration = 3600000 is MILLISECONDS -> a 1-hour war (sane; 41 days is not).
+    ///   - expedition_war_duration_for_protection = 172800 is SECONDS -> a 48-hour re-declaration cooldown.
+    /// </summary>
+    private readonly Dictionary<string, long> _warConfig = [];
+
     public IEnumerable<Expedition> Expeditions { get => _expeditions.Values; }
+
+    private long WarConfig(string name, long fallback) => _warConfig.GetValueOrDefault(name, fallback);
+
+    /// <summary>Testing override for the war duration in minutes (set via the /gwtime GM command).
+    /// 0 = use expedition_war_duration from config (1h on retail).</summary>
+    public static int WarDurationTestMinutes { get; set; }
+
+    private void LoadWarEconomyConfig()
+    {
+        _warConfig.Clear();
+
+        using var connection = SQLite.CreateConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT e.name, c.value FROM content_configs c " +
+            "JOIN enum_content_configs e ON e.id = c.id " +
+            "WHERE c.kind_id = 25";
+        command.Prepare();
+
+        using var sqliteReader = command.ExecuteReader();
+        using var reader = new SQLiteWrapperReader(sqliteReader);
+        while (reader.Read())
+            _warConfig[reader.GetString("name")] = reader.GetInt32("value");
+
+        Logger.Info($"Loaded {_warConfig.Count} guild war economy values");
+    }
 
     private Expedition Create(string name, Character owner)
     {
@@ -59,6 +106,7 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
     {
         _expeditions = [];
         _nameRegex = new Regex(AppConfiguration.Instance.Expedition.NameRegex, RegexOptions.Compiled);
+        LoadWarEconomyConfig();
 
         using (var connection = MySQL.CreateConnection())
         {
@@ -79,6 +127,17 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
                             OwnerName = reader.GetString("owner_name"),
                             UnitOwnerType = 0,
                             PoliticalSystem = 1,
+                            Level = reader.GetUInt32("level"),
+                            Exp = reader.GetUInt32("exp"),
+                            Notice = reader.GetString("notice"),
+                            ResidenceHouseId = reader.GetUInt32("residence_house_id"),
+                            Interest = reader.GetInt16("interest"),
+                            WarEnemyExpeditionId = reader.GetUInt32("war_enemy_expedition_id"),
+                            WarDeclaredAt = reader.IsDBNull(reader.GetOrdinal("war_declared_at")) ? null : reader.GetDateTime("war_declared_at"),
+                            WarProtectedUntil = reader.IsDBNull(reader.GetOrdinal("war_protected_until")) ? null : reader.GetDateTime("war_protected_until"),
+                            WarEndsAt = reader.IsDBNull(reader.GetOrdinal("war_ends_at")) ? null : reader.GetDateTime("war_ends_at"),
+                            WarKillScore = reader.GetUInt32("war_kill_score"),
+                            WarIsDeclarer = reader.GetBoolean("war_is_declarer"),
                             Created = reader.GetDateTime("created_at"),
                             AggroLink = false,
                             DiplomacyTarget = false
@@ -151,13 +210,45 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
                                 Chat = reader.GetBoolean("chat"),
                                 ManagerChat = reader.GetBoolean("manager_chat"),
                                 SiegeMaster = reader.GetBoolean("siege_master"),
-                                JoinSiege = reader.GetBoolean("join_siege")
+                                JoinSiege = reader.GetBoolean("join_siege"),
+                                UseInstance = reader.GetBoolean("use_instance")
                             };
                             expedition.Policies.Add(policy);
                         }
                     }
                 }
+
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        "SELECT expedition_buff_id, grade FROM expedition_buff_purchases WHERE expedition_id = @expedition_id";
+                    command.Parameters.AddWithValue("@expedition_id", expedition.Id);
+                    command.Prepare();
+                    using (var reader = command.ExecuteReader())
+                    {
+                        while (reader.Read())
+                            expedition.PurchasedBuffGrades[reader.GetUInt32("expedition_buff_id")] = reader.GetByte("grade");
+                    }
+                }
+
+                Logger.Info("Expedition loaded: {0} ({1}) - {2} members, {3} policies, level={4}, exp={5}, residenceHouseId={6}",
+                    expedition.Name, expedition.Id, expedition.Members.Count, expedition.Policies.Count, expedition.Level, expedition.Exp, expedition.ResidenceHouseId);
             }
+        }
+
+        // A war's end is normally driven by a one-shot ExpeditionWarEndTask, which does not survive a
+        // World restart. Re-arm it for anything still active, and catch up immediately on anything whose
+        // deadline already passed while the server was down.
+        foreach (var expedition in _expeditions.Values)
+        {
+            if (!expedition.WarEndsAt.HasValue)
+                continue;
+
+            var remaining = expedition.WarEndsAt.Value - DateTime.UtcNow;
+            if (remaining <= TimeSpan.Zero)
+                EndWar(expedition.Id);
+            else
+                TaskManager.Instance.Schedule(new ExpeditionWarEndTask(expedition.Id), remaining);
         }
     }
 
@@ -209,7 +300,238 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
 
         character.SendPacket(new SCAddContributionPointPacket(unchecked((uint)amount), member.ContributionPoint));
         expedition.SendPacket(new SCExpeditionMemberStatusChangedPacket(member, 0));
+        // The guild overview panel and the prestige-shop affordability check both read the pooled
+        // TotalContributionPoint carried on SCExpeditionDescPacket, not the per-member delta above -
+        // without this resend they keep showing/checking against a stale (often zero) total.
+        expedition.SendPacket(new SCExpeditionDescPacket(expedition));
         return true;
+    }
+
+    /// <summary>
+    /// Sets the recruitment-board interest bitmask shown as icons in the info panel - backs
+    /// CSExpeditionInterestUpatePacket (X2Faction:SetMyExpeditionInterest). TypeValue's meaning is
+    /// unconfirmed and not required here (matches this codebase's convention elsewhere of leaving genuinely
+    /// unconfirmed fields parsed but unused).
+    /// </summary>
+    public void SetInterest(Character character, short interest)
+    {
+        var expedition = character.Expedition;
+        if (expedition == null)
+            return;
+
+        expedition.Interest = interest;
+        Save(expedition);
+        expedition.SendPacket(new SCExpeditionDescPacket(expedition));
+    }
+
+    /// <summary>
+    /// Backs X2Faction:SetExpeditionNotice (the info panel's guild-notice text) - mirrors SetInterest's
+    /// persist-then-resend-desc flow. No role-policy flag exists for notices specifically (the client
+    /// gates the edit control itself), so any guild member may set it, matching the member-gate used
+    /// for Guild Residence placement.
+    /// </summary>
+    public void SetNotice(Character character, string notice)
+    {
+        var expedition = character.Expedition;
+        if (expedition == null)
+            return;
+
+        expedition.Notice = notice ?? string.Empty;
+        Save(expedition);
+        expedition.SendPacket(new SCExpeditionDescPacket(expedition));
+    }
+
+    /// <summary>
+    /// Adds guild exp and auto-advances the guild's level as far as expedition_levels allows without
+    /// requiring an item (see ExpeditionLevelGameData). A level gated behind an item stops the auto
+    /// climb and waits for TryLevelUp.
+    /// </summary>
+    public bool AddExp(Expedition expedition, uint amount)
+    {
+        if (expedition == null || amount == 0)
+            return false;
+
+        var gameData = ExpeditionLevelGameData.Instance;
+        var newExpLong = (long)expedition.Exp + amount;
+        var maxLevelData = gameData.GetLevel(gameData.MaxLevel);
+        if (maxLevelData != null && newExpLong > maxLevelData.TotalExp)
+            newExpLong = maxLevelData.TotalExp;
+        if (newExpLong > uint.MaxValue)
+            newExpLong = uint.MaxValue;
+
+        var newExp = (uint)newExpLong;
+        if (newExp == expedition.Exp)
+            return false;
+
+        expedition.Exp = newExp;
+        expedition.Level = gameData.GetAutoLevelForExp(expedition.Level, expedition.Exp);
+
+        expedition.SendPacket(new SCExpeditionExpAddPacket(amount));
+        // Always resend the full descriptor, not just on a level change - SCExpeditionExpAddPacket's own
+        // wire format was never confirmed against the real client (still flagged "nothing constructs this
+        // yet" before this session), so the guild window's displayed exp/level can only be trusted to
+        // refresh via the already Ghidra-confirmed SCExpeditionDescPacket.
+        expedition.SendPacket(new SCExpeditionDescPacket(expedition));
+
+        Save(expedition);
+        return true;
+    }
+
+    /// <summary>
+    /// Handles an explicit CSExpeditionLevelUpPacket - confirms a level gated behind
+    /// expedition_levels.require_item_id, consuming the item from the requesting member's own
+    /// inventory. Gated on the Expel permission, same "guild management" precedent already used for
+    /// Kick/ChangeExpeditionRolePolicy - there's no dedicated policy flag for this yet.
+    /// </summary>
+    public bool TryLevelUp(Character character)
+    {
+        var expedition = character.Expedition;
+        var member = expedition?.GetMember(character);
+        if (member == null)
+            return false;
+
+        if (!expedition.GetPolicyByRole(member.Role).Expel)
+        {
+            character.SendErrorMessage(ErrorMessageType.Invalid);
+            return false;
+        }
+
+        if (!ExpeditionLevelGameData.Instance.TryGetLevelUpRequirement(expedition.Level, expedition.Exp, out var requirement))
+            return false;
+
+        if (requirement.RequireItemId != 0)
+        {
+            if (!character.Inventory.CheckItems(SlotType.Inventory, requirement.RequireItemId, requirement.RequireItemAmount))
+            {
+                character.SendErrorMessage(ErrorMessageType.NotEnoughItem);
+                return false;
+            }
+
+            var consumed = character.Inventory.Bag.ConsumeItem(
+                ItemTaskType.ExpeditionCreation, requirement.RequireItemId, requirement.RequireItemAmount, null);
+            if (consumed != requirement.RequireItemAmount)
+                return false;
+        }
+
+        expedition.Level = requirement.Id;
+        expedition.SendPacket(new SCExpeditionDescPacket(expedition));
+        Save(expedition);
+        return true;
+    }
+
+    /// <summary>
+    /// Purchases/upgrades one guild prestige-shop buff to <paramref name="targetGrade"/> - handles
+    /// CSExpeditionBuffGradePacket (2026-08-27: that packet, and its sibling CSExpeditionBuffPacket, existed
+    /// fully parsed but "nothing acts on it yet" and were never even registered in GameNetwork's dispatch
+    /// table - same class of bug as CSExpeditionLevelUpPacket). Grades must be purchased in order (can't
+    /// skip from grade 2 to grade 4); paid for via the exact same Contribution Point spend the existing
+    /// Guild Contribution Shop already uses (see CSBuyItemsPacket.Pay/ExpeditionManager.TryChangeContributionPoints)
+    /// - straight from the purchasing character's own contribution_point balance, not a separate guild-pooled
+    /// currency - but the unlocked grade applies guild-wide once purchased.
+    /// </summary>
+    public bool TryPurchaseBuffGrade(Character character, uint buffId, byte targetGrade)
+    {
+        var expedition = character.Expedition;
+        if (expedition == null)
+        {
+            Logger.Warn("ExpeditionBuffGrade purchase rejected: {0} has no expedition (buffId={1}, targetGrade={2})", character.Name, buffId, targetGrade);
+            return false;
+        }
+
+        var grade = ExpeditionBuffGameData.Instance.GetGrade(buffId, targetGrade);
+        if (grade == null)
+        {
+            Logger.Warn("ExpeditionBuffGrade purchase rejected: no game data for buffId={0} grade={1} (character {2}, expedition {3})", buffId, targetGrade, character.Name, expedition.Name);
+            character.SendErrorMessage(ErrorMessageType.Invalid);
+            return false;
+        }
+
+        var currentGrade = expedition.PurchasedBuffGrades.GetValueOrDefault(buffId, (byte)0);
+        if (targetGrade != currentGrade + 1)
+        {
+            Logger.Warn("ExpeditionBuffGrade purchase rejected: buffId={0} requested grade={1} but current grade is {2} (must buy {3} next) (character {4}, expedition {5})",
+                buffId, targetGrade, currentGrade, currentGrade + 1, character.Name, expedition.Name);
+            character.SendErrorMessage(ErrorMessageType.Invalid);
+            return false;
+        }
+
+        if (expedition.Level < grade.ExpeditionLevelId)
+        {
+            Logger.Warn("ExpeditionBuffGrade purchase rejected: buffId={0} grade={1} requires expedition level {2}, expedition {3} is level {4}",
+                buffId, targetGrade, grade.ExpeditionLevelId, expedition.Name, expedition.Level);
+            character.SendErrorMessage(ErrorMessageType.Invalid);
+            return false;
+        }
+
+        // 2026-09-02: expedition_buff_grades.housing (28 of 93 rows) requires the guild to already have its
+        // Guild Residence placed before this grade can be bought - a real shipped-data gate the client's own
+        // tooltip already advertises (expedition_buff_get_condition_tooltip_housing) but nothing server-side
+        // ever enforced. See ExpeditionBuffGrade.Housing's doc comment.
+        if (grade.Housing && expedition.ResidenceHouseId == 0)
+        {
+            Logger.Warn("ExpeditionBuffGrade purchase rejected: buffId={0} grade={1} requires the guild to have a placed Guild Residence, expedition {2} has none",
+                buffId, targetGrade, expedition.Name);
+            character.SendErrorMessage(ErrorMessageType.Invalid);
+            return false;
+        }
+
+        if (grade.Contribution > 0 && !TryChangeContributionPoints(character, -grade.Contribution, false))
+        {
+            Logger.Warn("ExpeditionBuffGrade purchase rejected: buffId={0} grade={1} costs {2} contribution, character {3} could not pay",
+                buffId, targetGrade, grade.Contribution, character.Name);
+            character.SendErrorMessage(ErrorMessageType.NotEnoughRequiredItem);
+            return false;
+        }
+
+        if (grade.ItemId != 0)
+        {
+            if (!character.Inventory.CheckItems(SlotType.Inventory, grade.ItemId, grade.Count))
+            {
+                if (grade.Contribution > 0)
+                    TryChangeContributionPoints(character, grade.Contribution, false); // refund the point spend above
+                character.SendErrorMessage(ErrorMessageType.NotEnoughItem);
+                return false;
+            }
+            character.Inventory.Bag.ConsumeItem(ItemTaskType.StoreBuy, grade.ItemId, grade.Count, null);
+        }
+
+        expedition.PurchasedBuffGrades[buffId] = targetGrade;
+        using (var connection = MySQL.CreateConnection())
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText =
+                "REPLACE INTO expedition_buff_purchases (expedition_id, expedition_buff_id, grade) VALUES (@expedition_id, @buff_id, @grade)";
+            command.Parameters.AddWithValue("@expedition_id", expedition.Id);
+            command.Parameters.AddWithValue("@buff_id", buffId);
+            command.Parameters.AddWithValue("@grade", targetGrade);
+            command.Prepare();
+            command.ExecuteNonQuery();
+        }
+
+        // 2026-09-02: send order matters here, and it was backwards. The client's "EXPEDITION_BUFF_CHANGE"
+        // Lua event handler (fired by SCExpeditionBuffChangedPacket) reacts by calling RefreshLeftList(),
+        // which re-queries X2Faction:GetExpeditionBuffs() - a client-side CACHE that is only ever populated
+        // by SCExpeditionBuffsPacket's own handler (FUN_394eef30, confirmed 2026-08-28 via Frida). Sending
+        // Changed (which triggers the read) before Buffs (which writes the cache the read depends on) meant
+        // every refresh queried the cache one purchase too early - explaining why grade always showed as
+        // its OLD value (e.g. the "0/x" display) even though the change notification demonstrably fired and
+        // the server-side purchase was already correct. Buffs now goes first so the cache is current by the
+        // time Changed's event handler re-reads it.
+        expedition.SendPacket(new SCExpeditionBuffsPacket((uint)expedition.Id, expedition.PurchasedBuffGrades));
+        expedition.SendPacket(new SCExpeditionBuffChangedPacket((int)expedition.Id, (int)buffId, currentGrade, targetGrade));
+        expedition.ApplyBuffBonusesToAllOnline();
+        Logger.Info("Expedition buff purchase: {0}'s guild ({1}) bought buff {2} grade {3}", character.Name, expedition.Name, buffId, targetGrade);
+        return true;
+    }
+
+    /// <summary>Sends the guild's current full prestige-shop buff state to one client - handles CSExpeditionBuffPacket's "view" request and should also fire on Expedition join/login, mirroring SendExpeditionInfo.</summary>
+    public void SendExpeditionBuffs(Character character)
+    {
+        var expedition = character.Expedition;
+        if (expedition == null)
+            return;
+
+        character.SendPacket(new SCExpeditionBuffsPacket((uint)expedition.Id, expedition.PurchasedBuffGrades));
     }
 
     public Expedition GetExpedition(FactionsEnum id)
@@ -310,17 +632,37 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
         _expeditions.Add(expedition.Id, expedition);
 
         owner.Expedition = expedition;
+        SaveCharacterExpeditionNow(owner);
         WorldIntegration.RelayUnitExpeditionChangedToZone?.Invoke(owner.ObjId, 0, (int)expedition.Id);
 
         owner.SendPacket(
             new SCFactionCreatedPacket(expedition, owner.ObjId, [(owner.ObjId, owner.Id, owner.Name)])
         );
 
-        owner.SendPacket(new SCExpeditionListPacket(_expeditions.Values.ToArray()));
+        var expeditionsSnapshot = _expeditions.Values.ToArray();
+        owner.SendPacket(new SCExpeditionListPacket(expeditionsSnapshot));
         owner.BroadcastPacket(
             new SCUnitExpeditionChangedPacket(owner.ObjId, owner.Id, "", owner.Name, 0, (uint)expedition.Id, false),
             true
         );
+        // unitId=0 sentinel = "this is about you" (see CSNotifyInGamePacket.cs's doc comment for the full
+        // Ghidra-confirmed trail) - primes the owner's own MyExpeditionId cache right on founding. Its native
+        // handler also resets cache+0x0 to 0 as a side effect (FUN_396b5f40) without re-populating it, but
+        // SendExpeditionInfo (below) resends SCExpeditionDescPacket right after, which repopulates cache+0x0 -
+        // no extra resend needed here (unlike CSNotifyInGamePacket.cs's login-refresh site, which had nothing
+        // else resending desc afterward).
+        owner.SendPacket(
+            new SCUnitExpeditionChangedPacket(0, owner.Id, "", owner.Name, 0, (uint)expedition.Id, false));
+
+        // Every other already-connected character only got the id->name table for guilds that existed at
+        // their own login (SendExpeditions, called from CSSelectCharacterPacket). Without this, a guild
+        // created mid-session has no name any currently-online client can look up, so its members' nameplate
+        // tags render blank until everyone who was already online relogs.
+        foreach (var online in worldManager.GetAllCharacters())
+        {
+            if (online.Id != owner.Id)
+                online.SendPacket(new SCExpeditionListPacket(expeditionsSnapshot));
+        }
 
         chatManager.GetGuildChat(expedition).JoinChannel(owner);
         SendExpeditionInfo(owner);
@@ -335,15 +677,18 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
             var newMember = GetMemberFromCharacter(expedition, invited, false);
 
             invited.Expedition = expedition;
+            SaveCharacterExpeditionNow(invited);
             WorldIntegration.RelayUnitExpeditionChangedToZone?.Invoke(invited.ObjId, 0, (int)expedition.Id);
             expedition.Members.Add(newMember);
 
             invited.BroadcastPacket(
                 new SCUnitExpeditionChangedPacket(invited.ObjId, invited.Id, "", invited.Name, 0, (uint)expedition.Id, false),
                 true);
+            // unitId=0 sentinel = "this is about you" - primes this founding member's own MyExpeditionId cache.
+            invited.SendPacket(
+                new SCUnitExpeditionChangedPacket(0, invited.Id, "", invited.Name, 0, (uint)expedition.Id, false));
             SendExpeditionInfo(invited);
             expedition.OnCharacterLogin(invited);
-            // invited.Save(); // Moved to SaveMananger
         }
         Save(expedition);
     }
@@ -353,14 +698,52 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
         var inviter = connection.ActiveChar;
 
         var inviterMember = inviter.Expedition?.GetMember(inviter);
-        if (inviterMember == null || !inviter.Expedition.GetPolicyByRole(inviterMember.Role).Invite)
+        if (inviterMember == null)
+        {
+            Logger.Info("Invite: {0} rejected - not a member of any Expedition", inviter.Name);
             return;
+        }
+
+        var policy = inviter.Expedition.GetPolicyByRole(inviterMember.Role);
+        if (policy == null)
+        {
+            Logger.Info("Invite: {0} rejected - no ExpeditionRolePolicy found for role {1}", inviter.Name, inviterMember.Role);
+            return;
+        }
+        if (!policy.Invite)
+        {
+            Logger.Info("Invite: {0} rejected - role {1}'s policy has Invite=false", inviter.Name, inviterMember.Role);
+            return;
+        }
 
         var invited = worldManager.GetCharacter(invitedName);
-        if (invited == null) return;
-        if (invited.Expedition != null) return;
+        if (invited == null)
+        {
+            Logger.Info("Invite: {0} rejected - target '{1}' not found online", inviter.Name, invitedName);
+            return;
+        }
+        if (invited.Expedition != null)
+        {
+            Logger.Info("Invite: {0} rejected - target '{1}' already has an Expedition ({2})", inviter.Name, invitedName, invited.Expedition.Id);
+            return;
+        }
+        // Same top-level alliance check Create() already enforces on founding members (Nuia/Haranya/Pirate -
+        // MotherId, not the exact race) - Invite had no equivalent, so a guild could pick up members from
+        // another faction entirely, which retail doesn't allow.
+        if (invited.Faction.MotherId != inviter.Faction.MotherId)
+        {
+            Logger.Info("Invite: {0} rejected - target '{1}' is a different faction (invited MotherId={2}, inviter MotherId={3})",
+                inviter.Name, invitedName, invited.Faction.MotherId, inviter.Faction.MotherId);
+            inviter.SendErrorMessage(ErrorMessageType.ExpeditionBadFaction);
+            return;
+        }
 
+        Logger.Info("Invite: {0} sending SCExpeditionInvitationPacket to {1} (inviter.Id={2}, expedition={3}/{4})",
+            inviter.Name, invited.Name, inviter.Id, (uint)inviter.Expedition.Id, inviter.Expedition.Name);
         invited.SendPacket(
+            // 2026-08-27, third pass - see SCExpeditionInvitationPacket's own doc comment for the full
+            // corrected reasoning: this field is a plain 8-byte value carrying the persistent character id
+            // (matches the "playerId" field confirmed at the same interface slot elsewhere), not an ObjId.
             new SCExpeditionInvitationPacket(inviter.Id, inviter.Name, (uint)inviter.Expedition.Id,
                 inviter.Expedition.Name)
         );
@@ -376,16 +759,21 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
         var newMember = GetMemberFromCharacter(expedition, invited, false);
 
         invited.Expedition = expedition;
+        SaveCharacterExpeditionNow(invited);
         WorldIntegration.RelayUnitExpeditionChangedToZone?.Invoke(invited.ObjId, 0, (int)expedition.Id);
         expedition.Members.Add(newMember);
 
         invited.BroadcastPacket(
             new SCUnitExpeditionChangedPacket(invited.ObjId, invited.Id, "", invited.Name, 0, (uint)expedition.Id, false),
             true);
+        // unitId=0 sentinel = "this is about you" - primes the accepting member's own MyExpeditionId cache.
+        // This is the fix for the member-list/invite/level-up-button-permanently-broken regression: this
+        // character never got told its own guild id, so IsExpedInfoLoaded() never passed.
+        invited.SendPacket(
+            new SCUnitExpeditionChangedPacket(0, invited.Id, "", invited.Name, 0, (uint)expedition.Id, false));
         SendExpeditionInfo(invited);
         expedition.OnCharacterLogin(invited);
         Save(expedition);
-        // invited.Save(); // Moved to SaveMananger
     }
 
     public void ChangeExpeditionRolePolicy(GameConnection connection, ExpeditionRolePolicy policy)
@@ -428,9 +816,13 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
             false
         );
         character.Expedition = null;
+        SaveCharacterExpeditionNow(character);
         WorldIntegration.RelayUnitExpeditionChangedToZone?.Invoke(character.ObjId, (int)expedition.Id, 0);
         character.BroadcastPacket(changedPacket, true);
         expedition.SendPacket(changedPacket);
+        // unitId=0 sentinel = "this is about you" - clears the leaving character's own MyExpeditionId cache
+        // (without this, their client keeps IsExpedInfoLoaded() pinned to the old, now-stale guild id).
+        character.SendPacket(new SCUnitExpeditionChangedPacket(0, character.Id, "", character.Name, (uint)expedition.Id, 0, false));
         Save(expedition);
     }
 
@@ -457,8 +849,11 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
         if (kickedChar is not null)
         {
             kickedChar.Expedition = null;
+            SaveCharacterExpeditionNow(kickedChar);
             WorldIntegration.RelayUnitExpeditionChangedToZone?.Invoke(kickedChar.ObjId, (int)expedition.Id, 0);
             kickedChar.BroadcastPacket(changedPacket, true);
+            // unitId=0 sentinel = "this is about you" - clears the kicked character's own MyExpeditionId cache.
+            kickedChar.SendPacket(new SCUnitExpeditionChangedPacket(0, kicked.CharacterId, character.Name, kicked.Name, (uint)expedition.Id, 0, true));
         }
         expedition.SendPacket(changedPacket);
 
@@ -481,9 +876,11 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
             return;
 
         changedMember.Role = newRole;
-        expedition.SendPacket(
-            new SCExpeditionRoleChangedPacket(changedMember.CharacterId, changedMember.Role, changedMember.Name)
-        );
+        // 2026-09-02: corrected wire format (see SCExpeditionRoleChangedPacket's own doc comment) - this
+        // announces WHICH MEMBER'S role changed (id + name + new role id), not a role-policy definition.
+        // Still sent alongside the member-status broadcast, which the member LIST row's live refresh uses.
+        expedition.SendPacket(new SCExpeditionMemberStatusChangedPacket(changedMember, 0));
+        expedition.SendPacket(new SCExpeditionRoleChangedPacket(changedMember.CharacterId, changedMember.Name, newRole));
         Save(expedition);
     }
 
@@ -511,13 +908,397 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
                 newOwnerMember.Name
             )
         );
-        expedition.SendPacket(
-            new SCExpeditionRoleChangedPacket(ownerMember.CharacterId, ownerMember.Role, ownerMember.Name)
-        );
-        expedition.SendPacket(
-            new SCExpeditionRoleChangedPacket(newOwnerMember.CharacterId, newOwnerMember.Role, newOwnerMember.Name)
-        );
+        // 2026-08-28: same correction as ChangeMemberRole - member rows refresh via the status
+        // broadcast; SCExpeditionRoleChangedPacket carries role policies, not member identity.
+        expedition.SendPacket(new SCExpeditionMemberStatusChangedPacket(ownerMember, 0));
+        expedition.SendPacket(new SCExpeditionMemberStatusChangedPacket(newOwnerMember, 0));
         Save(expedition);
+    }
+
+    /// <summary>
+    /// Guild War step 1: the enemy-member right-click menu calls X2Faction:RequestDeclarationMoney(),
+    /// which sends CSRequestDeclarationMoneyPacket. We validate the same preconditions DeclareWar checks,
+    /// compute the declaration cost, and reply with SCExpeditionWarDeclarationMoney - that response is
+    /// what opens the client's confirm dialog. Only clicking OK there sends CSDeclareExpeditionWarPacket
+    /// (which re-validates and actually spends the money). A failed precondition here just surfaces an
+    /// error message and sends no response, so no dialog opens - matching "can't declare right now".
+    /// </summary>
+    public void RequestDeclarationMoney(GameConnection connection, uint targetObjId)
+    {
+        var character = connection.ActiveChar;
+        var expedition = character?.Expedition;
+        var ownerMember = expedition?.GetMember(character);
+        if (ownerMember == null || ownerMember.Role != 255)
+        {
+            Logger.Debug($"RequestDeclarationMoney: rejected, {character?.Name} is not their expedition's owner");
+            return;
+        }
+
+        if (expedition.IsAtWar || expedition.IsProtected)
+        {
+            character.SendErrorMessage(ErrorMessageType.Invalid);
+            return;
+        }
+
+        var targetCharacter = WorldManager.Instance.GetCharacterByObjId(targetObjId);
+        var targetExpedition = targetCharacter?.Expedition;
+        if (targetExpedition == null || targetExpedition.Id == expedition.Id)
+        {
+            Logger.Debug($"RequestDeclarationMoney: rejected, target objId {targetObjId} did not resolve to another guild's member (targetCharacter={targetCharacter?.Name})");
+            character.SendErrorMessage(ErrorMessageType.ExpeditionNoTarget);
+            return;
+        }
+
+        if (targetExpedition.IsAtWar || targetExpedition.IsProtected)
+        {
+            character.SendErrorMessage(ErrorMessageType.Invalid);
+            return;
+        }
+
+        var requiredMoney = WarConfig("expedition_war_initial_money_for_declaration", 1000000);
+        character.SendPacket(new SCExpeditionWarDeclarationMoney(targetObjId, (uint)requiredMoney));
+        Logger.Info($"RequestDeclarationMoney: {expedition.Name} -> {targetExpedition.Name}, cost {requiredMoney} (confirm dialog opened)");
+    }
+
+    /// <summary>
+    /// Guild War: CSDeclareExpeditionWarPacket was a fully-parsed no-op stub - X2Faction:DeclareExpeditionWar
+    /// (declaring war on another guild from the member-search / guild-info window) never had any
+    /// server-side reaction, so nothing happened. Only the guild owner can declare, matching the
+    /// owner-only gate ChangeOwner already uses (Role 255).
+    /// </summary>
+    public void DeclareWar(GameConnection connection, uint targetObjId, uint money)
+    {
+        var character = connection.ActiveChar;
+        var expedition = character.Expedition;
+        var ownerMember = expedition?.GetMember(character);
+        if (ownerMember == null || ownerMember.Role != 255)
+        {
+            Logger.Debug($"DeclareWar: rejected, {character.Name} is not their expedition's owner");
+            return;
+        }
+
+        if (expedition.IsAtWar || expedition.IsProtected)
+        {
+            Logger.Debug($"DeclareWar: rejected, {expedition.Name} is already at war or currently protected (WarEndsAt={expedition.WarEndsAt}, WarProtectedUntil={expedition.WarProtectedUntil})");
+            character.SendErrorMessage(ErrorMessageType.Invalid);
+            return;
+        }
+
+        var targetCharacter = WorldManager.Instance.GetCharacterByObjId(targetObjId);
+        var targetExpedition = targetCharacter?.Expedition;
+        if (targetExpedition == null || targetExpedition.Id == expedition.Id)
+        {
+            Logger.Debug($"DeclareWar: rejected, target objId {targetObjId} did not resolve to another guild's member (targetCharacter={targetCharacter?.Name})");
+            character.SendErrorMessage(ErrorMessageType.ExpeditionNoTarget);
+            return;
+        }
+
+        if (targetExpedition.IsAtWar || targetExpedition.IsProtected)
+        {
+            Logger.Debug($"DeclareWar: rejected, target guild {targetExpedition.Name} is already at war or currently protected (WarEndsAt={targetExpedition.WarEndsAt}, WarProtectedUntil={targetExpedition.WarProtectedUntil})");
+            character.SendErrorMessage(ErrorMessageType.Invalid);
+            return;
+        }
+
+        var requiredMoney = WarConfig("expedition_war_initial_money_for_declaration", 1000000);
+        if (money < requiredMoney || !character.SubtractMoney(SlotType.Inventory, requiredMoney))
+        {
+            character.SendErrorMessage(ErrorMessageType.ExpeditionCreateMoney);
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        // expedition_war_duration is in milliseconds (3600000 = 1h) - see _warConfig doc comment.
+        // WarDurationTestMinutes (set via /gwtime) overrides it for testing; 0 = use the config value.
+        var endsAt = WarDurationTestMinutes > 0
+            ? now.AddMinutes(WarDurationTestMinutes)
+            : now.AddMilliseconds(WarConfig("expedition_war_duration", 3600000));
+
+        expedition.WarEnemyExpeditionId = (uint)targetExpedition.Id;
+        expedition.WarDeclaredAt = now;
+        expedition.WarEndsAt = endsAt;
+        expedition.WarProtectedUntil = null;
+        expedition.WarKillScore = 0;
+        expedition.WarKillsByMember.Clear();
+        expedition.WarIsDeclarer = true;
+
+        targetExpedition.WarEnemyExpeditionId = (uint)expedition.Id;
+        targetExpedition.WarDeclaredAt = now;
+        targetExpedition.WarEndsAt = endsAt;
+        targetExpedition.WarProtectedUntil = null;
+        targetExpedition.WarKillScore = 0;
+        targetExpedition.WarKillsByMember.Clear();
+        targetExpedition.WarIsDeclarer = false;
+
+        Save(expedition);
+        Save(targetExpedition);
+
+        // Broadcast server-wide, not just to the two guilds - the client's own handler for this packet
+        // (FUN_395ba9f0) has a dedicated bystander branch: when the RECIPIENT's own guild matches neither
+        // side AND started=true, it shows a plain "War declared!" banner (both guild names, no per-unit
+        // tagging) instead of the full enemy-tagging pass the two participants get. Sending only to the
+        // two guilds (as before) meant nobody else ever received the packet at all, so third parties saw
+        // neither a banner nor any indication a war had started - same idiom as EndWar's global result
+        // broadcast below.
+        var endsAtUnix = Helpers.UnixTime(endsAt);
+        var declarePacket = new SCExpeditionWarStatePacket((int)expedition.Id, (int)targetExpedition.Id, true, endsAtUnix, false);
+        foreach (var onlineCharacter in WorldManager.Instance.GetAllCharacters())
+            onlineCharacter.SendPacket(declarePacket);
+
+        // The guild info panel's own "protectDate" field (SCExpeditionDescPacket) reads WarProtectedUntil/
+        // WarEndsAt live off the Expedition now, so both guilds' open info windows pick this up on their
+        // next refresh without a dedicated push.
+        TaskManager.Instance.Schedule(new ExpeditionWarEndTask(expedition.Id), endsAt - now);
+
+        Logger.Info($"Guild War declared: {expedition.Name} ({expedition.Id}) vs {targetExpedition.Name} ({targetExpedition.Id}), ends {endsAt:u}");
+    }
+
+    /// <summary>Testing helper (GM /gwend wipe): clears the war/protection state on both guilds outright -
+    /// no rewards, no post-war protection - so a fresh war can be declared immediately. Any pending
+    /// ExpeditionWarEndTask harmlessly no-ops (EndWar returns early once WarEndsAt is null).</summary>
+    public void WipeWar(FactionsEnum expeditionId)
+    {
+        if (!_expeditions.TryGetValue(expeditionId, out var expedition))
+            return;
+        _expeditions.TryGetValue((FactionsEnum)expedition.WarEnemyExpeditionId, out var enemyExpedition);
+
+        var enemyId = (int)expedition.WarEnemyExpeditionId;
+        foreach (var e in new[] { expedition, enemyExpedition })
+        {
+            if (e == null)
+                continue;
+            e.WarEndsAt = null;
+            e.WarProtectedUntil = null;
+            e.WarDeclaredAt = null;
+            e.WarEnemyExpeditionId = 0;
+            e.WarKillScore = 0;
+            e.WarKillsByMember.Clear();
+            Save(e);
+        }
+
+        expedition.SendPacket(new SCExpeditionWarStatePacket((int)expedition.Id, enemyId, false, 0, true));
+        enemyExpedition?.SendPacket(new SCExpeditionWarStatePacket((int)expedition.Id, enemyId, false, 0, true));
+        Logger.Info($"Guild War WIPED (GM): {expedition.Name} vs {enemyExpedition?.Name ?? enemyId.ToString()}");
+    }
+
+    /// <summary>GM /endgp: clear a guild's post-war / Ceasefire protection immediately (by name).
+    /// Returns the resolved expedition name, or null if no guild by that name.</summary>
+    public string EndGuildProtection(string guildName)
+    {
+        var expedition = _expeditions.Values.FirstOrDefault(e =>
+            string.Equals(e.Name, guildName, System.StringComparison.OrdinalIgnoreCase));
+        if (expedition == null)
+            return null;
+
+        expedition.WarProtectedUntil = null;
+        Save(expedition);
+        expedition.SendPacket(new SCExpeditionWarStatePacket((int)expedition.Id, 0, false, 0, true));
+        Logger.Info($"Guild protection cleared (GM /endgp): {expedition.Name}");
+        return expedition.Name;
+    }
+
+    /// <summary>Fires when a war's scheduled duration runs out (see ExpeditionWarEndTask, re-armed on Load()).</summary>
+    public void EndWar(FactionsEnum expeditionId)
+    {
+        if (!_expeditions.TryGetValue(expeditionId, out var expedition) || expedition.WarEndsAt == null)
+            return;
+
+        _expeditions.TryGetValue((FactionsEnum)expedition.WarEnemyExpeditionId, out var enemyExpedition);
+
+        var now = DateTime.UtcNow;
+        // Post-war cooldown: only the guild that was DECLARED UPON gets it, and it's ~1h on retail
+        // (not the 48h that expedition_war_duration_for_protection would give - that value is the
+        // Ceasefire item's duration, a different thing). Overridable via /gwtime for testing.
+        var protectMinutes = WarDurationTestMinutes > 0 ? WarDurationTestMinutes : 60;
+        var protectedUntil = now.AddMinutes(protectMinutes);
+        var ourScore = expedition.WarKillScore;
+        var theirScore = enemyExpedition?.WarKillScore ?? 0;
+
+        var declarer = expedition.WarIsDeclarer ? expedition : enemyExpedition;
+        var defender = expedition.WarIsDeclarer ? enemyExpedition : expedition;
+
+        expedition.WarEndsAt = null;
+        expedition.WarProtectedUntil = expedition.WarIsDeclarer ? null : protectedUntil;
+        Save(expedition);
+
+        if (enemyExpedition != null)
+        {
+            enemyExpedition.WarEndsAt = null;
+            enemyExpedition.WarProtectedUntil = enemyExpedition.WarIsDeclarer ? null : protectedUntil;
+            Save(enemyExpedition);
+        }
+
+        AwardWarResult(expedition, ourScore == theirScore ? 0 : ourScore > theirScore ? 1 : -1);
+        if (enemyExpedition != null)
+            AwardWarResult(enemyExpedition, ourScore == theirScore ? 0 : theirScore > ourScore ? 1 : -1);
+
+        var enemyId = (int)expedition.WarEnemyExpeditionId;
+        var defenderUnix = defender != null ? Helpers.UnixTime(protectedUntil) : 0;
+
+        // Order matters, and it's the OPPOSITE of what a previous session tried: the client's win/lost/tied
+        // banner is computed inside the KILL-SCORE packet handler (FUN_395b6c10), not the war-state one.
+        // That handler writes the fresh totals to the client's cache and then checks a "war just ended"
+        // flag - a flag that only the terminated SCExpeditionWarStatePacket sets. If the flag isn't set
+        // yet when the kill-score packet lands, the check is skipped and the ONLY banner the player ever
+        // sees is the war-state packet's own popup, which is unconditionally hardcoded to "tied" (traced
+        // in FUN_395ba9f0 - it always resolves to the fixed DAT_39ea8258 string, no result data involved).
+        // So the terminated war-state packet must go out FIRST (arms the flag), and the final kill-score
+        // packet LAST (fires the real win/lost/tied comparison against the just-armed flag and clears it).
+        expedition.SendPacket(new SCExpeditionWarStatePacket((int)expedition.Id, enemyId, false,
+            expedition.WarIsDeclarer ? 0 : defenderUnix, true));
+        enemyExpedition?.SendPacket(new SCExpeditionWarStatePacket((int)expedition.Id, enemyId, false,
+            enemyExpedition.WarIsDeclarer ? 0 : defenderUnix, true));
+
+        if (declarer != null && defender != null)
+        {
+            // result: 1 = the 'id' guild (declarer) won, 2 = the 'id2' guild (defender) won, 0 = draw.
+            // SCNotifyExpeditionWarResultPacket's own handler (FUN_395b72d0) is gated to skip both actual
+            // participants - it only ever displays for bystanders not currently at war with either side -
+            // but nothing in the client decompile scopes it by faction/alliance beyond that. Broadcast it
+            // server-wide, same idiom as HeroManager.BroadcastPhaseChange (another major, realm-crossing
+            // announcement that also just does GetAllCharacters() with no faction filter). The two guilds'
+            // own members get their personal win/lost banner instead, from the kill-score packet below.
+            var declarerScore = declarer.WarKillScore;
+            var defenderScore = defender.WarKillScore;
+            byte result = declarerScore == defenderScore ? (byte)0 : declarerScore > defenderScore ? (byte)1 : (byte)2;
+            var resultPacket = new SCNotifyExpeditionWarResultPacket((uint)declarer.Id, (uint)defender.Id, result);
+
+            foreach (var character in WorldManager.Instance.GetAllCharacters())
+                character.SendPacket(resultPacket);
+
+            declarer.SendPacket(new SCExpeditionWarKillScorePacket(declarer, defender));
+            defender.SendPacket(new SCExpeditionWarKillScorePacket(defender, declarer));
+        }
+
+        Logger.Info($"Guild War ended: {declarer?.Name ?? expedition.Name} (declarer, {declarer?.WarKillScore ?? ourScore} kills) vs {defender?.Name ?? enemyExpedition?.Name ?? "?"} (defender, {defender?.WarKillScore ?? theirScore} kills); {defender?.Name ?? "?"} protected {protectMinutes}min");
+    }
+
+    /// <summary>outcome: 1 = win, -1 = loss, 0 = draw. Pays every member (online or not) directly against
+    /// expedition_members, mirroring TryChangeContributionPoints' SQL - most members will be offline by
+    /// the time a weeks-long war concludes.</summary>
+    private void AwardWarResult(Expedition expedition, int outcome)
+    {
+        var reward = (int)WarConfig(outcome switch
+        {
+            1 => "expedition_war_reward_for_win",
+            -1 => "expedition_war_reward_for_lose",
+            _ => "expedition_war_reward_for_draw"
+        }, 0);
+        if (reward <= 0)
+            return;
+
+        foreach (var member in expedition.Members.ToArray())
+        {
+            lock (member)
+            {
+                var newTotal = (uint)Math.Clamp((long)member.ContributionPoint + reward, 0, uint.MaxValue);
+
+                using (var connection = MySQL.CreateConnection())
+                using (var command = connection.CreateCommand())
+                {
+                    command.CommandText =
+                        "UPDATE expedition_members SET contribution_point = @contribution_point WHERE character_id = @character_id AND expedition_id = @expedition_id";
+                    command.Parameters.AddWithValue("@contribution_point", newTotal);
+                    command.Parameters.AddWithValue("@character_id", member.CharacterId);
+                    command.Parameters.AddWithValue("@expedition_id", member.ExpeditionId);
+                    command.ExecuteNonQuery();
+                }
+
+                member.ContributionPoint = newTotal;
+            }
+
+            var character = WorldManager.Instance.GetCharacterById(member.CharacterId);
+            if (character == null)
+                continue;
+
+            character.SendPacket(new SCAddContributionPointPacket(unchecked((uint)reward), member.ContributionPoint));
+            expedition.SendPacket(new SCExpeditionMemberStatusChangedPacket(member, 0));
+        }
+
+        expedition.SendPacket(new SCExpeditionDescPacket(expedition));
+    }
+
+    /// <summary>
+    /// Called from CharacterCombat.DoDie on every PvP kill - credits the killer's expedition's war score if
+    /// killer and victim's guilds are the current active war enemies of each other.
+    /// </summary>
+    public void RegisterWarKill(Character killer, Character victim)
+    {
+        var killerExpedition = killer.Expedition;
+        var victimExpedition = victim.Expedition;
+        if (killerExpedition == null || victimExpedition == null)
+            return;
+
+        if (!killerExpedition.IsAtWar || killerExpedition.WarEnemyExpeditionId != (uint)victimExpedition.Id)
+        {
+            Logger.Debug($"RegisterWarKill: {killer.Name} killed {victim.Name} but no active war between {killerExpedition.Name} and {victimExpedition.Name} (IsAtWar={killerExpedition.IsAtWar}, enemyId={killerExpedition.WarEnemyExpeditionId})");
+            return;
+        }
+
+        killerExpedition.WarKillScore++;
+        killerExpedition.WarKillsByMember.TryGetValue(killer.Id, out var memberKills);
+        killerExpedition.WarKillsByMember[killer.Id] = memberKills + 1;
+        Save(killerExpedition);
+        Logger.Info($"Guild War kill: {killer.Name} ({killerExpedition.Name}) killed {victim.Name} ({victimExpedition.Name}) - score now {killerExpedition.WarKillScore} (this member: {memberKills + 1})");
+
+        // Push the updated scoreboard to both guilds so open scoreboards update without waiting for
+        // the client's next poll.
+        killerExpedition.SendPacket(new SCExpeditionWarKillScorePacket(killerExpedition, victimExpedition));
+        victimExpedition.SendPacket(new SCExpeditionWarKillScorePacket(victimExpedition, killerExpedition));
+    }
+
+    /// <summary>Answers CSExpeditionWarKillScorePacket - the client's periodic guild-war-scoreboard poll.</summary>
+    public void SendWarKillScore(GameConnection connection)
+    {
+        var character = connection?.ActiveChar;
+        var expedition = character?.Expedition;
+        if (expedition == null || (!expedition.IsAtWar && !expedition.IsProtected))
+            return;
+
+        _expeditions.TryGetValue((FactionsEnum)expedition.WarEnemyExpeditionId, out var enemyExpedition);
+        character.SendPacket(new SCExpeditionWarKillScorePacket(expedition, enemyExpedition));
+    }
+
+    /// <summary>
+    /// Backs the "정전 협정서"/Ceasefire Agreement item (id 52121, use_skill_id 31460) via
+    /// ProtectionForExpedition's special effect (protection_for_expedition, value1 = duration in seconds,
+    /// 172800 on this build) - was a declared-but-empty TODO stub, found while chasing why a declared war
+    /// "had no effect" (the target guild had used the item, and nothing server-side ever recorded it).
+    /// Cannot be used while already at war - a live war still has to run its course or be waited out.
+    /// </summary>
+    public void SetProtection(Character character, int durationSeconds)
+    {
+        var expedition = character.Expedition;
+        if (expedition == null || durationSeconds <= 0)
+            return;
+
+        if (expedition.IsAtWar)
+        {
+            character.SendErrorMessage(ErrorMessageType.Invalid);
+            return;
+        }
+
+        expedition.WarProtectedUntil = DateTime.UtcNow.AddSeconds(durationSeconds);
+        Save(expedition);
+        expedition.SendPacket(new SCExpeditionDescPacket(expedition));
+
+        Logger.Info($"Guild War protection: {expedition.Name} protected until {expedition.WarProtectedUntil:u} (via Ceasefire Agreement, used by {character.Name})");
+    }
+
+    /// <summary>Backs the guild info panel's "cancel protection" button - CSCancelExpeditionProtectionPacket
+    /// was a fully-parsed (empty-body) no-op stub. Owner-only, matching that button's own visibility gate.</summary>
+    public void CancelProtection(Character character)
+    {
+        var expedition = character.Expedition;
+        var ownerMember = expedition?.GetMember(character);
+        if (ownerMember == null || ownerMember.Role != 255 || !expedition.IsProtected)
+            return;
+
+        expedition.WarProtectedUntil = null;
+        Save(expedition);
+        expedition.SendPacket(new SCExpeditionDescPacket(expedition));
+
+        Logger.Info($"Guild War protection cancelled early for {expedition.Name} by {character.Name}");
     }
 
     public bool Disband(Character owner)
@@ -543,6 +1324,7 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
                 if (c.IsOnline)
                     c.SendPacket(new SCExpeditionDismissedPacket((uint)guild.Id, true));
                 c.Expedition = null;
+                SaveCharacterExpeditionNow(c);
             }
             guild.RemoveMember(guild.Members[i]);
         }
@@ -559,6 +1341,20 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
         var total = (uint)members.Count;
         var id = character.Expedition.Id;
 
+        Logger.Info("SendExpeditionInfo: {0} -> guild {1} ({2}), {3} members, {4} policies, totalContribution={5} (per-member: {6})",
+            character.Name, character.Expedition.Name, id, total, character.Expedition.Policies.Count,
+            character.Expedition.TotalContributionPoint,
+            string.Join(",", members.Select(m => $"{m.Name}={m.ContributionPoint}")));
+
+        // 2026-08-27: REVERTED the "send last" experiment from moments earlier tonight - user confirmed it
+        // made things WORSE (the level-up button, at least visible before, disappeared entirely; role
+        // permissions broke too), not better. Most likely explanation: the client latches UI state (level-up
+        // button visibility, role-policy-driven permission enabling) eagerly as each packet in this sequence
+        // arrives, expecting Level/Exp/the 0xff sentinel to already be cached by the time RolePolicyList/
+        // MemberList are processed - delaying this packet to last meant those one-shot UI updates ran against
+        // stale/default (zero) cached values instead of the real ones, which arrived too late to matter. Back
+        // to the original order: desc first, then policies/members.
+        character.SendPacket(new SCExpeditionDescPacket(character.Expedition));
         character.SendPacket(new SCExpeditionRolePolicyListPacket(character.Expedition.Policies));
 
         for (var i = 0; i < members.Count; i += 20)
@@ -568,6 +1364,16 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
         }
 
         character.SendPacket(new SCExpeditionMemberListEndPacket((int)total, (int)id));
+
+        // Guild War: a client loses X2Faction's war/protection state on disconnect, so a (re)connecting
+        // member would see the enemy guild as friendly (green) and be unable to target them. Re-push it
+        // here, the same shape DeclareWar/EndWar broadcast - see also ExpeditionWarEndTask re-arm on Load().
+        var exp = character.Expedition;
+        if (exp.IsAtWar || exp.IsProtected)
+        {
+            var until = Helpers.UnixTime(exp.WarEndsAt ?? exp.WarProtectedUntil ?? DateTime.UtcNow);
+            character.SendPacket(new SCExpeditionWarStatePacket((int)id, (int)exp.WarEnemyExpeditionId, exp.IsAtWar, until, false));
+        }
     }
 
     public static void Save(Expedition expedition)
@@ -578,6 +1384,22 @@ public class ExpeditionManager(IExpeditionIdManager expeditionIdManager, ITeamMa
             expedition.Save(connection, transaction);
             transaction.Commit();
         }
+    }
+
+    /// <summary>
+    /// Persists a character's `expedition_id` right away instead of waiting for the periodic
+    /// SaveManager tick (default 5 minutes) or a graceful shutdown. Guild join/leave/kick/create/disband
+    /// must call this - a non-graceful World stop (crash, Stop-Process, etc.) inside that window would
+    /// otherwise leave `expeditions`/`expedition_members` correctly saved (those already save
+    /// synchronously) while the character's own `expedition_id` column reverts to whatever it was at
+    /// last autosave, desyncing `Character.Expedition` from the real membership on next boot.
+    /// </summary>
+    private static void SaveCharacterExpeditionNow(Character character)
+    {
+        using var connection = MySQL.CreateConnection();
+        using var transaction = connection.BeginTransaction();
+        character.Save(connection, transaction);
+        transaction.Commit();
     }
 
     public static ExpeditionMember GetMemberFromCharacter(Expedition expedition, Character character, bool owner)

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -761,14 +761,15 @@ public class HousingManager(
             connection?.ActiveChar?.SendErrorMessage(ErrorMessageType.InvalidHouseInfo);
             return;
         }
-        // A Guild Residence is demolishable by any member of the owning guild, not just whoever placed
-        // it. Ordinary personal housing keeps its original owner-only check.
+        // A Guild Residence is demolishable only by the owning guild's leader, not any member.
+        // Ordinary personal housing keeps its original owner-only check.
         var character = connection?.ActiveChar;
         var isAuthorized = connection is null;
         if (!isAuthorized && character != null)
         {
             isAuthorized = HousingGameData.Instance.IsExpeditionResidenceTemplate(house.TemplateId)
                 ? character.Expedition != null && character.Expedition.ResidenceHouseId == house.Id
+                  && character.Id == character.Expedition.OwnerId
                 : house.OwnerId == character.Id;
         }
 

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -809,20 +809,37 @@ public class HousingManager(
 
             house.IsDirty = true;
 
-            // Guild Residence demolish refund: 80% of the design's shop price (Contribution Shop pack
-            // 304), paid back as guild Contribution Points. Currently 0 for all 3 residence designs in
-            // the shipped data.
-            if (character?.Expedition != null && HousingGameData.Instance.IsExpeditionResidenceTemplate(house.TemplateId)
-                && character.Expedition.ResidenceHouseId == house.Id)
+            // Guild Residence: clear the owning expedition's ResidenceHouseId on EVERY demolition path,
+            // not just the connection-driven one - resolved from the house/expedition relationship
+            // itself rather than the acting character, since the tax-expiry auto-demolish path
+            // (Demolish(null, house, true, false)) has no connection/character at all. Without this,
+            // an offline owner's tax-expired residence left the expedition's ResidenceHouseId stuck
+            // pointing at a house that no longer exists - blocking both a replacement placement (Build
+            // rejects any nonzero ResidenceHouseId) and correctly gating housing-required buff grades.
+            if (HousingGameData.Instance.IsExpeditionResidenceTemplate(house.TemplateId))
             {
-                var residenceItemId = HousingGameData.Instance.GetItemIdByDesign(house.TemplateId);
-                var shopPrice = NpcManager.Instance.GetGoods(304)?.GetItem(residenceItemId, 0)?.Cost ?? 0;
-                var refund = (int)(shopPrice * 0.8);
-                if (refund > 0)
-                    ExpeditionManager.Instance.TryChangeContributionPoints(character, refund, false);
+                var owningExpedition = character?.Expedition?.ResidenceHouseId == house.Id
+                    ? character.Expedition
+                    : ExpeditionManager.Instance.Expeditions.FirstOrDefault(e => e.ResidenceHouseId == house.Id);
 
-                character.Expedition.ResidenceHouseId = 0;
-                ExpeditionManager.Save(character.Expedition);
+                if (owningExpedition != null)
+                {
+                    // 80% of the design's shop price (Contribution Shop pack 304), paid back as guild
+                    // Contribution Points. Currently 0 for all 3 residence designs in the shipped data.
+                    // Only refunds when the demolishing character is themselves a member of the owning
+                    // expedition - preserves existing refund semantics, independent of the id-clearing below.
+                    if (character?.Expedition == owningExpedition)
+                    {
+                        var residenceItemId = HousingGameData.Instance.GetItemIdByDesign(house.TemplateId);
+                        var shopPrice = NpcManager.Instance.GetGoods(304)?.GetItem(residenceItemId, 0)?.Cost ?? 0;
+                        var refund = (int)(shopPrice * 0.8);
+                        if (refund > 0)
+                            ExpeditionManager.Instance.TryChangeContributionPoints(character, refund, false);
+                    }
+
+                    owningExpedition.ResidenceHouseId = 0;
+                    ExpeditionManager.Save(owningExpedition);
+                }
             }
 
             // TODO: better house killing handling
@@ -843,6 +860,19 @@ public class HousingManager(
     {
         var zoneId = house.Transform?.ZoneId ?? 0;
         var houseObjId = house.ObjId;
+
+        // Same guild-residence lifecycle fix as Demolish: this path has no requesting character at
+        // all (a house dying from combat/siege damage, not a player-initiated demolish), so the owning
+        // expedition must be resolved from the residence relationship itself, not skipped entirely.
+        if (HousingGameData.Instance.IsExpeditionResidenceTemplate(house.TemplateId))
+        {
+            var owningExpedition = ExpeditionManager.Instance.Expeditions.FirstOrDefault(e => e.ResidenceHouseId == house.Id);
+            if (owningExpedition != null)
+            {
+                owningExpedition.ResidenceHouseId = 0;
+                ExpeditionManager.Save(owningExpedition);
+            }
+        }
 
         // Remove house from housing tables
         _removedHousings.Add(house.Id);

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -498,15 +498,11 @@ public class HousingManager(
 
     /// <summary>
     /// Proactively pushes the guild residence's real TlId to one character via the same
-    /// SCHouseTaxInfoPacket the client's own on-demand request would get. This is the missing half of
-    /// the Guild Residence feature, found 2026-08-28 via decompile: the client's "do I have a guild
-    /// residence" gate (X2Faction:GetExpeditionHouseId, native global DAT_3b4f6108) starts at 0 and has
-    /// no client-native setter anywhere - the ONLY way it gets populated is by receiving a real
-    /// SCHouseTaxInfoPacket. But the client's own request for one (RequestExpeditionHouseInfo -&gt;
-    /// CSRequestHouseTaxPacket) sends that same starting-at-0 cached value as the tl to ask about, so it
-    /// always asks about tl=0, which matches no real house (HouseTaxInfo above silently no-ops), and the
-    /// loop never closes on its own. The server has to push the correct one unprompted at least once -
-    /// on placement, and again at login for members who weren't online when it was placed.
+    /// SCHouseTaxInfoPacket the client's own on-demand request would get. The client's cached "which
+    /// house is my guild residence" id starts at 0 with no client-side way to set it, and its own
+    /// request for one asks using that same starting-at-0 value - so the loop never closes on its own.
+    /// The server must push the correct id unprompted at least once: on placement, and again at login
+    /// for members who weren't online when it was placed.
     /// </summary>
     public void SendExpeditionHouseInfo(Character character)
     {
@@ -569,10 +565,8 @@ public class HousingManager(
 
         if (HousingGameData.Instance.IsExpeditionResidenceTemplate(designId))
         {
-            // 2026-08-27: Guild Residence - a universal per-guild clubhouse, unrelated to castle/dominion
-            // territory (see HousingGameData.IsExpeditionResidenceTemplate's doc comment). Any guild member
-            // may place it (no leader-only restriction was requested for this one), but only one per guild,
-            // regardless of which of the 3 color designs is chosen.
+            // Guild Residence: a per-guild clubhouse, unrelated to castle/dominion territory. Any guild
+            // member may place it, but only one per guild regardless of which color design is chosen.
             var expedition = connection.ActiveChar.Expedition;
             if (expedition == null)
             {
@@ -767,10 +761,8 @@ public class HousingManager(
             connection?.ActiveChar?.SendErrorMessage(ErrorMessageType.InvalidHouseInfo);
             return;
         }
-        // 2026-08-27: a Guild Residence is demolishable by any member of the owning guild (no leader-only
-        // restriction requested for this one), not just whoever happened to place it - matches the
-        // guild-membership (not solo-ownership) gate HousingManager.Build already enforces for placing one.
-        // Ordinary personal housing keeps its original owner-only check.
+        // A Guild Residence is demolishable by any member of the owning guild, not just whoever placed
+        // it. Ordinary personal housing keeps its original owner-only check.
         var character = connection?.ActiveChar;
         var isAuthorized = connection is null;
         if (!isAuthorized && character != null)
@@ -817,13 +809,9 @@ public class HousingManager(
 
             house.IsDirty = true;
 
-            // 2026-08-27: Guild Residence demolish refund - "철거 시 도면은 상점가 80%만큼의 원정대 공헌도로
-            // 즉시 반환됩니다" (on demolish, 80% of shop price is immediately refunded as guild Contribution
-            // Points). Reuses the same Contribution Point spend/refund path the existing Guild Contribution
-            // Shop already uses (CSBuyItemsPacket -> ExpeditionManager.TryChangeContributionPoints), rather
-            // than inventing a separate pooled-currency model. "Shop price" is merchant_goods.cost for this
-            // item in pack 304 ("Live - 공헌도 상점" / Live - Contribution Shop) - currently 0 for all 3
-            // residence designs in the shipped data, so this refunds 0 until/unless that data says otherwise.
+            // Guild Residence demolish refund: 80% of the design's shop price (Contribution Shop pack
+            // 304), paid back as guild Contribution Points. Currently 0 for all 3 residence designs in
+            // the shipped data.
             if (character?.Expedition != null && HousingGameData.Instance.IsExpeditionResidenceTemplate(house.TemplateId)
                 && character.Expedition.ResidenceHouseId == house.Id)
             {

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -453,6 +453,11 @@ public class HousingManager(
         if (!_housesTl.TryGetValue(tlId, out var house))
             return;
 
+        SendHouseTaxInfo(connection.ActiveChar, house);
+    }
+
+    private void SendHouseTaxInfo(Character character, House house)
+    {
         CalculateBuildingTaxInfo(house.AccountId, house.Template, false, out var totalTaxAmountDue, out _, out _, out var hostileTaxRate, out _);
 
         var baseTax = (int)(house.Template.Taxation?.Tax ?? 0);
@@ -474,7 +479,7 @@ public class HousingManager(
 
         // Logger.Debug($"SCHouseTaxInfoPacket; tlId:{house.TlId}, domTaxRate: 0, deposit: {depositTax}, taxDue:{totalTaxAmountDue}, protectEnd:{house.ProtectionEndDate}, isPaid:{requiresPayment}, weeksWithoutPay:{weeksWithoutPay}, isHeavy:{house.Template.HeavyTax}");
 
-        connection.SendPacket(
+        character.SendPacket(
             new SCHouseTaxInfoPacket(
                 house.TlId,
                 0u,  // dominionTaxRate — TODO: implement when castles are added
@@ -489,6 +494,34 @@ public class HousingManager(
                 0   // TODO(v10): taxType — the binary leaves the enum unnamed
             )
         );
+    }
+
+    /// <summary>
+    /// Proactively pushes the guild residence's real TlId to one character via the same
+    /// SCHouseTaxInfoPacket the client's own on-demand request would get. This is the missing half of
+    /// the Guild Residence feature, found 2026-08-28 via decompile: the client's "do I have a guild
+    /// residence" gate (X2Faction:GetExpeditionHouseId, native global DAT_3b4f6108) starts at 0 and has
+    /// no client-native setter anywhere - the ONLY way it gets populated is by receiving a real
+    /// SCHouseTaxInfoPacket. But the client's own request for one (RequestExpeditionHouseInfo -&gt;
+    /// CSRequestHouseTaxPacket) sends that same starting-at-0 cached value as the tl to ask about, so it
+    /// always asks about tl=0, which matches no real house (HouseTaxInfo above silently no-ops), and the
+    /// loop never closes on its own. The server has to push the correct one unprompted at least once -
+    /// on placement, and again at login for members who weren't online when it was placed.
+    /// </summary>
+    public void SendExpeditionHouseInfo(Character character)
+    {
+        var houseId = character.Expedition?.ResidenceHouseId ?? 0;
+        if (houseId == 0)
+            return;
+
+        var house = GetHouseById(houseId);
+        if (house == null)
+        {
+            Logger.Warn("SendExpeditionHouseInfo: expedition {0}'s ResidenceHouseId {1} does not resolve to a loaded house", character.Expedition!.Name, houseId);
+            return;
+        }
+
+        SendHouseTaxInfo(character, house);
     }
 
     /// <summary>
@@ -532,6 +565,27 @@ public class HousingManager(
                 designId, houseTemplate.CategoryId, zone?.Name ?? "<unknown>", zoneKey);
             connection.ActiveChar.SendErrorMessage(ErrorMessageType.HouseCannotLocateInvalidArea);
             return;
+        }
+
+        if (HousingGameData.Instance.IsExpeditionResidenceTemplate(designId))
+        {
+            // 2026-08-27: Guild Residence - a universal per-guild clubhouse, unrelated to castle/dominion
+            // territory (see HousingGameData.IsExpeditionResidenceTemplate's doc comment). Any guild member
+            // may place it (no leader-only restriction was requested for this one), but only one per guild,
+            // regardless of which of the 3 color designs is chosen.
+            var expedition = connection.ActiveChar.Expedition;
+            if (expedition == null)
+            {
+                Logger.Debug("Build refused: design {0} is a Guild Residence, but {1} is not in a guild", designId, connection.ActiveChar.Name);
+                connection.ActiveChar.SendErrorMessage(ErrorMessageType.NoPerm);
+                return;
+            }
+            if (expedition.ResidenceHouseId != 0)
+            {
+                Logger.Debug("Build refused: design {0} is a Guild Residence, but {1}'s guild already has one (House {2})", designId, connection.ActiveChar.Name, expedition.ResidenceHouseId);
+                connection.ActiveChar.SendErrorMessage(ErrorMessageType.HouseCannotCreate);
+                return;
+            }
         }
 
         CalculateBuildingTaxInfo(connection.ActiveChar.AccountId, houseTemplate, true, out var totalTaxAmountDue, out _, out _, out _, out _);
@@ -644,6 +698,22 @@ public class HousingManager(
         if (WorldIntegration.ZoneAuthority)
             HousingZoneBridge.NotifyZoneHouseCreated(house);
         UpdateTaxInfo(house);
+
+        if (HousingGameData.Instance.IsExpeditionResidenceTemplate(designId) && connection.ActiveChar.Expedition != null)
+        {
+            var expedition = connection.ActiveChar.Expedition;
+            expedition.ResidenceHouseId = house.Id;
+            ExpeditionManager.Save(expedition);
+            Logger.Info("Guild Residence: {0}'s guild ({1}) placed House {2} (design {3})", connection.ActiveChar.Name, expedition.Name, house.Id, designId);
+
+            // See SendExpeditionHouseInfo's own doc comment - the client can't learn its guild's
+            // residence exists on its own, so every currently-online member needs this pushed now.
+            foreach (var member in expedition.Members)
+            {
+                if (WorldManager.Instance.GetCharacterById(member.CharacterId) is { } onlineMember)
+                    SendExpeditionHouseInfo(onlineMember);
+            }
+        }
     }
 
     /// <summary>
@@ -697,8 +767,20 @@ public class HousingManager(
             connection?.ActiveChar?.SendErrorMessage(ErrorMessageType.InvalidHouseInfo);
             return;
         }
-        // Check if owner
-        if (connection is null || house.OwnerId == connection.ActiveChar.Id)
+        // 2026-08-27: a Guild Residence is demolishable by any member of the owning guild (no leader-only
+        // restriction requested for this one), not just whoever happened to place it - matches the
+        // guild-membership (not solo-ownership) gate HousingManager.Build already enforces for placing one.
+        // Ordinary personal housing keeps its original owner-only check.
+        var character = connection?.ActiveChar;
+        var isAuthorized = connection is null;
+        if (!isAuthorized && character != null)
+        {
+            isAuthorized = HousingGameData.Instance.IsExpeditionResidenceTemplate(house.TemplateId)
+                ? character.Expedition != null && character.Expedition.ResidenceHouseId == house.Id
+                : house.OwnerId == character.Id;
+        }
+
+        if (isAuthorized)
         {
             // VERIFY: check if tax paid, cannot manually demolish or sell a house with unpaid taxes ?
             // Note - ZeromusXYZ: I'm disabling this "feature", as it would prevent you from demolishing freshly placed buildings that you want to move 
@@ -734,6 +816,26 @@ public class HousingManager(
             SetForSaleMarkers(house, false);
 
             house.IsDirty = true;
+
+            // 2026-08-27: Guild Residence demolish refund - "철거 시 도면은 상점가 80%만큼의 원정대 공헌도로
+            // 즉시 반환됩니다" (on demolish, 80% of shop price is immediately refunded as guild Contribution
+            // Points). Reuses the same Contribution Point spend/refund path the existing Guild Contribution
+            // Shop already uses (CSBuyItemsPacket -> ExpeditionManager.TryChangeContributionPoints), rather
+            // than inventing a separate pooled-currency model. "Shop price" is merchant_goods.cost for this
+            // item in pack 304 ("Live - 공헌도 상점" / Live - Contribution Shop) - currently 0 for all 3
+            // residence designs in the shipped data, so this refunds 0 until/unless that data says otherwise.
+            if (character?.Expedition != null && HousingGameData.Instance.IsExpeditionResidenceTemplate(house.TemplateId)
+                && character.Expedition.ResidenceHouseId == house.Id)
+            {
+                var residenceItemId = HousingGameData.Instance.GetItemIdByDesign(house.TemplateId);
+                var shopPrice = NpcManager.Instance.GetGoods(304)?.GetItem(residenceItemId, 0)?.Cost ?? 0;
+                var refund = (int)(shopPrice * 0.8);
+                if (refund > 0)
+                    ExpeditionManager.Instance.TryChangeContributionPoints(character, refund, false);
+
+                character.Expedition.ResidenceHouseId = 0;
+                ExpeditionManager.Save(character.Expedition);
+            }
 
             // TODO: better house killing handling
             _removedHousings.Add(house.Id);

--- a/AAEmu.Game/Core/Network/Game/GameNetwork.cs
+++ b/AAEmu.Game/Core/Network/Game/GameNetwork.cs
@@ -38,14 +38,7 @@ public class GameNetwork : Singleton<GameNetwork>
         RegisterPacket(CSOffsets.CSLeaveExpeditionPacket, 1, typeof(CSLeaveExpeditionPacket));
         RegisterPacket(CSOffsets.CSKickFromExpeditionPacket, 1, typeof(CSKickFromExpeditionPacket));
         RegisterPacket(CSOffsets.CSDeclareExpeditionWarPacket, 1, typeof(CSDeclareExpeditionWarPacket));
-        // 2026-09-02: step 1 of the declare-war round trip (menu click -> RequestDeclarationMoney).
-        // Without this the client's press dispatched as UNKNOWN and the confirm dialog never opened,
-        // so CSDeclareExpeditionWarPacket was never sent - the whole reason "declaring war did nothing".
         RegisterPacket(CSOffsets.CSRequestDeclarationMoneyPacket, 1, typeof(CSRequestDeclarationMoneyPacket));
-        // 2026-08-27 fix: CSExpeditionLevelUpPacket existed (and ExpeditionManager.TryLevelUp behind it is
-        // fully implemented) but was never registered here - every guild-level-up button press silently
-        // dispatched as opcode 0x02D -> UNKNOWN (confirmed live via GameProtocolHandler's own C2S RAW warn log),
-        // so the item was never even checked, let alone consumed.
         RegisterPacket(CSOffsets.CSExpeditionLevelUpPacket, 1, typeof(CSExpeditionLevelUpPacket));
         // 0x10 unk packet
         RegisterPacket(CSOffsets.CSUpdateDominionTaxRatePacket, 1, typeof(CSUpdateDominionTaxRatePacket));
@@ -383,13 +376,8 @@ public class GameNetwork : Singleton<GameNetwork>
         RegisterPacket(CSOffsets.CSReqExpdWarHistoriesPacket, 1, typeof(CSReqExpdWarHistoriesPacket));
         RegisterPacket(CSOffsets.CSCancelExpeditionProtectionPacket, 1, typeof(CSCancelExpeditionProtectionPacket));
         RegisterPacket(CSOffsets.CSExpeditionBuffUnitPacket, 1, typeof(CSExpeditionBuffUnitPacket));
-        // 2026-08-27 fix: both existed fully parsed (guild prestige-shop buff view/purchase) but were never
-        // registered - same bug class found and fixed for CSExpeditionLevelUpPacket the same night.
         RegisterPacket(CSOffsets.CSExpeditionBuffPacket, 1, typeof(CSExpeditionBuffPacket));
         RegisterPacket(CSOffsets.CSExpeditionBuffGradePacket, 1, typeof(CSExpeditionBuffGradePacket));
-        // 2026-08-27: CSExpeditionExpAddPacket already calls ExpeditionManager.AddExp - fully wired, just
-        // missing this line (found in a full-codebase audit for the same fully-parsed-but-never-registered
-        // C2G packet bug class).
         RegisterPacket(CSOffsets.CSExpeditionExpAddPacket, 1, typeof(CSExpeditionExpAddPacket));
         RegisterPacket(CSOffsets.CSExpeditionInterestUpatePacket, 1, typeof(CSExpeditionInterestUpatePacket));
         RegisterPacket(CSOffsets.CSShowResidentZoneGroupsPacket, 1, typeof(CSShowResidentZoneGroupsPacket));

--- a/AAEmu.Game/Core/Network/Game/GameNetwork.cs
+++ b/AAEmu.Game/Core/Network/Game/GameNetwork.cs
@@ -38,6 +38,15 @@ public class GameNetwork : Singleton<GameNetwork>
         RegisterPacket(CSOffsets.CSLeaveExpeditionPacket, 1, typeof(CSLeaveExpeditionPacket));
         RegisterPacket(CSOffsets.CSKickFromExpeditionPacket, 1, typeof(CSKickFromExpeditionPacket));
         RegisterPacket(CSOffsets.CSDeclareExpeditionWarPacket, 1, typeof(CSDeclareExpeditionWarPacket));
+        // 2026-09-02: step 1 of the declare-war round trip (menu click -> RequestDeclarationMoney).
+        // Without this the client's press dispatched as UNKNOWN and the confirm dialog never opened,
+        // so CSDeclareExpeditionWarPacket was never sent - the whole reason "declaring war did nothing".
+        RegisterPacket(CSOffsets.CSRequestDeclarationMoneyPacket, 1, typeof(CSRequestDeclarationMoneyPacket));
+        // 2026-08-27 fix: CSExpeditionLevelUpPacket existed (and ExpeditionManager.TryLevelUp behind it is
+        // fully implemented) but was never registered here - every guild-level-up button press silently
+        // dispatched as opcode 0x02D -> UNKNOWN (confirmed live via GameProtocolHandler's own C2S RAW warn log),
+        // so the item was never even checked, let alone consumed.
+        RegisterPacket(CSOffsets.CSExpeditionLevelUpPacket, 1, typeof(CSExpeditionLevelUpPacket));
         // 0x10 unk packet
         RegisterPacket(CSOffsets.CSUpdateDominionTaxRatePacket, 1, typeof(CSUpdateDominionTaxRatePacket));
         RegisterPacket(CSOffsets.CSFactionMobilizationOrderPacket, 1, typeof(CSFactionMobilizationOrderPacket));
@@ -374,17 +383,29 @@ public class GameNetwork : Singleton<GameNetwork>
         RegisterPacket(CSOffsets.CSReqExpdWarHistoriesPacket, 1, typeof(CSReqExpdWarHistoriesPacket));
         RegisterPacket(CSOffsets.CSCancelExpeditionProtectionPacket, 1, typeof(CSCancelExpeditionProtectionPacket));
         RegisterPacket(CSOffsets.CSExpeditionBuffUnitPacket, 1, typeof(CSExpeditionBuffUnitPacket));
+        // 2026-08-27 fix: both existed fully parsed (guild prestige-shop buff view/purchase) but were never
+        // registered - same bug class found and fixed for CSExpeditionLevelUpPacket the same night.
+        RegisterPacket(CSOffsets.CSExpeditionBuffPacket, 1, typeof(CSExpeditionBuffPacket));
+        RegisterPacket(CSOffsets.CSExpeditionBuffGradePacket, 1, typeof(CSExpeditionBuffGradePacket));
+        // 2026-08-27: CSExpeditionExpAddPacket already calls ExpeditionManager.AddExp - fully wired, just
+        // missing this line (found in a full-codebase audit for the same fully-parsed-but-never-registered
+        // C2G packet bug class).
+        RegisterPacket(CSOffsets.CSExpeditionExpAddPacket, 1, typeof(CSExpeditionExpAddPacket));
+        RegisterPacket(CSOffsets.CSExpeditionInterestUpatePacket, 1, typeof(CSExpeditionInterestUpatePacket));
         RegisterPacket(CSOffsets.CSShowResidentZoneGroupsPacket, 1, typeof(CSShowResidentZoneGroupsPacket));
         RegisterPacket(CSOffsets.CSResidentBalanceAllPacket, 1, typeof(CSResidentBalanceAllPacket));
         RegisterPacket(CSOffsets.CSFactionRelationHistoryGetPacket, 1, typeof(CSFactionRelationHistoryGetPacket));
         RegisterPacket(CSOffsets.CSFactionRelationCountGetPacket, 1, typeof(CSFactionRelationCountGetPacket));
         RegisterPacket(CSOffsets.CSExpeditionNoticeUpatePacket, 1, typeof(CSExpeditionNoticeUpatePacket));
         RegisterPacket(CSOffsets.CSExpeditionRecruitmentsGetPacket, 1, typeof(CSExpeditionRecruitmentsGetPacket));
+        RegisterPacket(CSOffsets.CSExpeditionRecruitmentAddPacket, 1, typeof(CSExpeditionRecruitmentAddPacket));
         RegisterPacket(CSOffsets.CSExpeditionRecruitmentDelPacket, 1, typeof(CSExpeditionRecruitmentDelPacket));
         RegisterPacket(CSOffsets.CSExpeditionApplicantsGetPacket, 1, typeof(CSExpeditionApplicantsGetPacket));
         RegisterPacket(CSOffsets.CSExpeditionApplicantAddPacket, 1, typeof(CSExpeditionApplicantAddPacket));
+        RegisterPacket(CSOffsets.CSExpeditionApplicantDelPacket, 1, typeof(CSExpeditionApplicantDelPacket));
         RegisterPacket(CSOffsets.CSExpeditionApplicantAcceptPacket, 1, typeof(CSExpeditionApplicantAcceptPacket));
         RegisterPacket(CSOffsets.CSExpeditionApplicantRejectPacket, 1, typeof(CSExpeditionApplicantRejectPacket));
+        RegisterPacket(CSOffsets.CSDeleteExpeditionPortalPacket, 1, typeof(CSDeleteExpeditionPortalPacket));
         RegisterPacket(CSOffsets.CSExpeditionSummonGetPacket, 1, typeof(CSExpeditionSummonGetPacket));
         RegisterPacket(CSOffsets.CSExpeditionSummonReplyPacket, 1, typeof(CSExpeditionSummonReplyPacket));
         RegisterPacket(CSOffsets.CSFamilyNameSetPacket, 1, typeof(CSFamilyNameSetPacket));

--- a/AAEmu.Game/Core/Packets/C2G/CSCancelExpeditionProtectionPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSCancelExpeditionProtectionPacket.cs
@@ -1,10 +1,11 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO(v10): the body is parsed but nothing acts on it yet.
+/// 2026-09-02: was a fully-parsed no-op stub - see ExpeditionManager.CancelProtection's doc comment.
 /// </summary>
 /// <remarks>
 /// packet has no body. Every parameterless C2S type folds onto that one function, so the
@@ -14,5 +15,6 @@ public class CSCancelExpeditionProtectionPacket() : GamePacket(CSOffsets.CSCance
 {
     public override void Read(PacketStream stream)
     {
+        ExpeditionManager.Instance.CancelProtection(Connection.ActiveChar);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSCancelExpeditionProtectionPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSCancelExpeditionProtectionPacket.cs
@@ -5,7 +5,7 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// 2026-09-02: was a fully-parsed no-op stub - see ExpeditionManager.CancelProtection's doc comment.
+/// Cancels the caller's guild's post-war protection window early.
 /// </summary>
 /// <remarks>
 /// packet has no body. Every parameterless C2S type folds onto that one function, so the

--- a/AAEmu.Game/Core/Packets/C2G/CSDeclareExpeditionWarPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSDeclareExpeditionWarPacket.cs
@@ -5,7 +5,7 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// 2026-09-02: was a fully-parsed no-op stub - see ExpeditionManager.DeclareWar's doc comment for the fix.
+/// Declares Guild War on the target's guild.
 /// </summary>
 /// <remarks>
 /// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each

--- a/AAEmu.Game/Core/Packets/C2G/CSDeclareExpeditionWarPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSDeclareExpeditionWarPacket.cs
@@ -1,10 +1,11 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO: the body is parsed but nothing acts on it yet.
+/// 2026-09-02: was a fully-parsed no-op stub - see ExpeditionManager.DeclareWar's doc comment for the fix.
 /// </summary>
 /// <remarks>
 /// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
@@ -19,5 +20,7 @@ public class CSDeclareExpeditionWarPacket() : GamePacket(CSOffsets.CSDeclareExpe
     {
         Bc = stream.ReadBc();
         Money = stream.ReadUInt32();
+
+        ExpeditionManager.Instance.DeclareWar(Connection, Bc, Money);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffGradePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffGradePacket.cs
@@ -5,15 +5,9 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// Requests purchasing/upgrading one prestige-shop buff to a specific grade. Wire format confirmed
-/// against the client dump (both construction sites, console `FUN_396be580` and UI `FUN_399857c0`):
-/// the packet carries three int32 fields, set via `FUN_39c4f500` at offsets +0x10/+0x14/+0x18 as
-/// [expeditionId][buffType][grade] - field 1 is `DAT_3b4f531c`, which is literally the client's
-/// `MyExpeditionId` cache slot (`DAT_3b4f4fb0 + 0x36c`). The old code passed field 1 (the expedition
-/// id) into TryPurchaseBuffGrade as the buff id, so every purchase failed the
-/// ExpeditionBuffGameData.GetGrade lookup with ErrorMessageType.Invalid.
-/// 2026-08-27: was fully parsed but never wired to anything, and never even registered in
-/// GameNetwork's dispatch table - same bug class as CSExpeditionLevelUpPacket.
+/// Requests purchasing/upgrading one prestige-shop buff to a specific grade. Wire: expeditionId,
+/// buffId, grade (all int32/uint32) - the old code mixed up expeditionId and buffId, so every
+/// purchase failed the grade lookup.
 /// </summary>
 public class CSExpeditionBuffGradePacket() : GamePacket(CSOffsets.CSExpeditionBuffGradePacket, 1)
 {

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffGradePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffGradePacket.cs
@@ -1,25 +1,46 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO: the body is parsed but nothing acts on it yet.
+/// Requests purchasing/upgrading one prestige-shop buff to a specific grade. Wire format confirmed
+/// against the client dump (both construction sites, console `FUN_396be580` and UI `FUN_399857c0`):
+/// the packet carries three int32 fields, set via `FUN_39c4f500` at offsets +0x10/+0x14/+0x18 as
+/// [expeditionId][buffType][grade] - field 1 is `DAT_3b4f531c`, which is literally the client's
+/// `MyExpeditionId` cache slot (`DAT_3b4f4fb0 + 0x36c`). The old code passed field 1 (the expedition
+/// id) into TryPurchaseBuffGrade as the buff id, so every purchase failed the
+/// ExpeditionBuffGameData.GetGrade lookup with ErrorMessageType.Invalid.
+/// 2026-08-27: was fully parsed but never wired to anything, and never even registered in
+/// GameNetwork's dispatch table - same bug class as CSExpeditionLevelUpPacket.
 /// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
 public class CSExpeditionBuffGradePacket() : GamePacket(CSOffsets.CSExpeditionBuffGradePacket, 1)
 {
-    public int TypeValue { get; private set; }
-    public int TypeValue2 { get; private set; }
+    public int ExpeditionId { get; private set; }
+    public int BuffId { get; private set; }
     public uint Grade { get; private set; }
 
     public override void Read(PacketStream stream)
     {
-        TypeValue = stream.ReadInt32();
-        TypeValue2 = stream.ReadInt32();
+        ExpeditionId = stream.ReadInt32();
+        BuffId = stream.ReadInt32();
         Grade = stream.ReadUInt32();
+
+        var character = Connection.ActiveChar;
+        if (character?.Expedition == null || BuffId <= 0 || Grade is 0 or > byte.MaxValue)
+        {
+            Logger.Warn(
+                "ExpeditionBuffGrade: rejected before dispatch - expeditionId={0}, buffId={1}, grade={2}, character={3}, hasExpedition={4}",
+                ExpeditionId, BuffId, Grade, character?.Name ?? "<none>", character?.Expedition != null);
+            return;
+        }
+
+        if (ExpeditionId != 0 && ExpeditionId != (int)character.Expedition.Id)
+            Logger.Warn(
+                "ExpeditionBuffGrade: client sent expeditionId {0} but character {1} is in expedition {2} - using server-side truth",
+                ExpeditionId, character.Name, character.Expedition.Id);
+
+        ExpeditionManager.Instance.TryPurchaseBuffGrade(character, (uint)BuffId, (byte)Grade);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffPacket.cs
@@ -1,15 +1,20 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO: the body is parsed but nothing acts on it yet.
+/// Opens/refreshes the prestige-shop buff view - read as "the client wants the current buff-grade state
+/// resent" regardless of TypeValue/ResponseOnly's exact unconfirmed semantics, since SCExpeditionBuffsPacket
+/// is a full resync anyway. 2026-08-27: was fully parsed but never wired to anything, and never even
+/// registered in GameNetwork's dispatch table - same bug class as CSExpeditionLevelUpPacket.
+/// 2026-08-28: gating the resend on Enter was wrong - live logs show the real client never sets it true
+/// on any of the many shop-open requests observed, so SendExpeditionBuffs never fired and the shop
+/// permanently showed stale (all-unpurchased) grades, causing repeat "buy grade 1" attempts on buffs
+/// already owned. Resync unconditionally instead - cheap, and this packet's own risk model is
+/// "renders incorrectly or dropped, not a crash" either way.
 /// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
 public class CSExpeditionBuffPacket() : GamePacket(CSOffsets.CSExpeditionBuffPacket, 1)
 {
     public int TypeValue { get; private set; }
@@ -21,5 +26,8 @@ public class CSExpeditionBuffPacket() : GamePacket(CSOffsets.CSExpeditionBuffPac
         TypeValue = stream.ReadInt32();
         Enter = stream.ReadBoolean();
         ResponseOnly = stream.ReadBoolean();
+
+        if (Connection.ActiveChar?.Expedition != null)
+            ExpeditionManager.Instance.SendExpeditionBuffs(Connection.ActiveChar);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffPacket.cs
@@ -5,15 +5,8 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// Opens/refreshes the prestige-shop buff view - read as "the client wants the current buff-grade state
-/// resent" regardless of TypeValue/ResponseOnly's exact unconfirmed semantics, since SCExpeditionBuffsPacket
-/// is a full resync anyway. 2026-08-27: was fully parsed but never wired to anything, and never even
-/// registered in GameNetwork's dispatch table - same bug class as CSExpeditionLevelUpPacket.
-/// 2026-08-28: gating the resend on Enter was wrong - live logs show the real client never sets it true
-/// on any of the many shop-open requests observed, so SendExpeditionBuffs never fired and the shop
-/// permanently showed stale (all-unpurchased) grades, causing repeat "buy grade 1" attempts on buffs
-/// already owned. Resync unconditionally instead - cheap, and this packet's own risk model is
-/// "renders incorrectly or dropped, not a crash" either way.
+/// Opens/refreshes the prestige-shop buff view - resent unconditionally on every request rather than
+/// gated on Enter, since the client doesn't reliably set that flag.
 /// </summary>
 public class CSExpeditionBuffPacket() : GamePacket(CSOffsets.CSExpeditionBuffPacket, 1)
 {

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffUnitPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffUnitPacket.cs
@@ -1,15 +1,16 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Core.Packets.G2C;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO(v10): the body is parsed but nothing acts on it yet.
+/// The client sends this repeatedly (observed 6x back-to-back) whenever the prestige-shop buff
+/// window is open. Wire-verified 2026-08-28 (see SCExpeditionBuffUnitPacket.cs) that the expected
+/// response shares the exact same "buffs" vector format as SCExpeditionBuffsPacket - answered with
+/// that, scoped to the requesting character's own unit id. Previously "nothing acts on it yet".
 /// </summary>
-/// <remarks>
-/// which passes each field name alongside the value:
-/// bc bc (3 bytes)
-/// </remarks>
 public class CSExpeditionBuffUnitPacket() : GamePacket(CSOffsets.CSExpeditionBuffUnitPacket, 1)
 {
     public uint Bc { get; private set; }
@@ -17,5 +18,11 @@ public class CSExpeditionBuffUnitPacket() : GamePacket(CSOffsets.CSExpeditionBuf
     public override void Read(PacketStream stream)
     {
         Bc = stream.ReadBc();
+
+        var character = Connection.ActiveChar;
+        if (character?.Expedition == null)
+            return;
+
+        character.SendPacket(new SCExpeditionBuffUnitPacket(Bc, character.Expedition.PurchasedBuffGrades));
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffUnitPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionBuffUnitPacket.cs
@@ -6,10 +6,8 @@ using AAEmu.Game.Core.Packets.G2C;
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// The client sends this repeatedly (observed 6x back-to-back) whenever the prestige-shop buff
-/// window is open. Wire-verified 2026-08-28 (see SCExpeditionBuffUnitPacket.cs) that the expected
-/// response shares the exact same "buffs" vector format as SCExpeditionBuffsPacket - answered with
-/// that, scoped to the requesting character's own unit id. Previously "nothing acts on it yet".
+/// The client sends this repeatedly while the prestige-shop buff window is open. Answered with the
+/// requesting character's own unit id plus the guild's current buff-grade state.
 /// </summary>
 public class CSExpeditionBuffUnitPacket() : GamePacket(CSOffsets.CSExpeditionBuffUnitPacket, 1)
 {

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionExpAddPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionExpAddPacket.cs
@@ -5,24 +5,11 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
+/// The client only ever sends this once per day as a "new day, refresh" heartbeat with Addexp
+/// hardcoded to 0, not a genuine EXP submission. The client-supplied amount must never be trusted
+/// directly into guild EXP - any guild member could otherwise submit an arbitrary amount and
+/// instantly level their guild. Discarded entirely below rather than guessed at.
 /// </summary>
-/// <remarks>
-/// FIXED (was flagged by review, and confirmed against the client decompile): this used to trust the
-/// client-reported Addexp value directly and hand it straight to ExpeditionManager.AddExp - any guild
-/// member could submit an arbitrary amount and instantly level their guild, unlocking guild-wide
-/// benefits with no payment/authorization check at all.
-///
-/// The real client has exactly one send site for this packet (FUN_395b7930): once per local calendar
-/// day (compares the guild's last-known date against "now" via XlGetLocalTime), it sends this packet
-/// with Addexp hardcoded to 0 - `FUN_39a8f240(&amp;local_78, myExpeditionId, 0)`. It is a "new day,
-/// please refresh" heartbeat, not an EXP submission - retail never sends a nonzero value here, so
-/// accepting one at all was pure client-trusted input with no legitimate use. There is no known item/
-/// consumable this packet confirms the consumption of either, and no confirmed server-side "daily guild
-/// EXP" formula to grant instead, so the amount is discarded entirely below rather than guessed at.
-/// TypeValue's meaning is unconfirmed - not used below.
-/// </remarks>
 public class CSExpeditionExpAddPacket() : GamePacket(CSOffsets.CSExpeditionExpAddPacket, 1)
 {
     public int TypeValue { get; private set; }
@@ -32,6 +19,6 @@ public class CSExpeditionExpAddPacket() : GamePacket(CSOffsets.CSExpeditionExpAd
     {
         TypeValue = stream.ReadInt32();
         Addexp = stream.ReadUInt32();
-        // Client-supplied amount intentionally ignored - see the FIXED remark above.
+        // Intentionally discarded - see class summary.
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionExpAddPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionExpAddPacket.cs
@@ -1,14 +1,27 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO: the body is parsed but nothing acts on it yet.
-/// </summary>
-/// <remarks>
 /// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
 /// value's name alongside the value:
+/// </summary>
+/// <remarks>
+/// FIXED (was flagged by review, and confirmed against the client decompile): this used to trust the
+/// client-reported Addexp value directly and hand it straight to ExpeditionManager.AddExp - any guild
+/// member could submit an arbitrary amount and instantly level their guild, unlocking guild-wide
+/// benefits with no payment/authorization check at all.
+///
+/// The real client has exactly one send site for this packet (FUN_395b7930): once per local calendar
+/// day (compares the guild's last-known date against "now" via XlGetLocalTime), it sends this packet
+/// with Addexp hardcoded to 0 - `FUN_39a8f240(&amp;local_78, myExpeditionId, 0)`. It is a "new day,
+/// please refresh" heartbeat, not an EXP submission - retail never sends a nonzero value here, so
+/// accepting one at all was pure client-trusted input with no legitimate use. There is no known item/
+/// consumable this packet confirms the consumption of either, and no confirmed server-side "daily guild
+/// EXP" formula to grant instead, so the amount is discarded entirely below rather than guessed at.
+/// TypeValue's meaning is unconfirmed - not used below.
 /// </remarks>
 public class CSExpeditionExpAddPacket() : GamePacket(CSOffsets.CSExpeditionExpAddPacket, 1)
 {
@@ -19,5 +32,6 @@ public class CSExpeditionExpAddPacket() : GamePacket(CSOffsets.CSExpeditionExpAd
     {
         TypeValue = stream.ReadInt32();
         Addexp = stream.ReadUInt32();
+        // Client-supplied amount intentionally ignored - see the FIXED remark above.
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionInterestUpatePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionInterestUpatePacket.cs
@@ -1,15 +1,14 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO: the body is parsed but nothing acts on it yet.
+/// Backs X2Faction:SetMyExpeditionInterest / the info panel's interest-tag icons - Interest is the new
+/// bitmask, carried onward via SCExpeditionDescPacket's "interest" field (see Expedition.Interest). TypeValue's
+/// meaning is unconfirmed and not used below.
 /// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
 public class CSExpeditionInterestUpatePacket() : GamePacket(CSOffsets.CSExpeditionInterestUpatePacket, 1)
 {
     public int TypeValue { get; private set; }
@@ -19,5 +18,8 @@ public class CSExpeditionInterestUpatePacket() : GamePacket(CSOffsets.CSExpediti
     {
         TypeValue = stream.ReadInt32();
         Interest = stream.ReadInt16();
+
+        if (Connection.ActiveChar != null)
+            ExpeditionManager.Instance.SetInterest(Connection.ActiveChar, Interest);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionLevelUpPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionLevelUpPacket.cs
@@ -1,15 +1,13 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO: the body is parsed but nothing acts on it yet.
-/// </summary>
-/// <remarks>
 /// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
 /// value's name alongside the value:
-/// </remarks>
+/// </summary>
 public class CSExpeditionLevelUpPacket() : GamePacket(CSOffsets.CSExpeditionLevelUpPacket, 1)
 {
     public int TypeValue { get; private set; }
@@ -17,5 +15,8 @@ public class CSExpeditionLevelUpPacket() : GamePacket(CSOffsets.CSExpeditionLeve
     public override void Read(PacketStream stream)
     {
         TypeValue = stream.ReadInt32();
+
+        if (Connection.ActiveChar?.Expedition != null)
+            ExpeditionManager.Instance.TryLevelUp(Connection.ActiveChar);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionNoticeUpatePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionNoticeUpatePacket.cs
@@ -1,15 +1,14 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO(v10): the body is parsed but nothing acts on it yet.
+/// Backs X2Faction:SetExpeditionNotice - the info panel's guild-notice text. Field names come from
+/// the 10.0.2.13 client's serializer (int type, string notice); Type's meaning is unconfirmed and
+/// unused, matching SetInterest's convention for its own TypeValue.
 /// </summary>
-/// <remarks>
-/// which passes each field name alongside the value:
-/// int type, string notice
-/// </remarks>
 public class CSExpeditionNoticeUpatePacket() : GamePacket(CSOffsets.CSExpeditionNoticeUpatePacket, 1)
 {
     public int Type { get; private set; }
@@ -19,5 +18,8 @@ public class CSExpeditionNoticeUpatePacket() : GamePacket(CSOffsets.CSExpedition
     {
         Type = stream.ReadInt32();
         Notice = stream.ReadString();
+
+        if (Connection.ActiveChar != null)
+            ExpeditionManager.Instance.SetNotice(Connection.ActiveChar, Notice);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionWarKillScorePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionWarKillScorePacket.cs
@@ -6,7 +6,7 @@ namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
 /// Empty-body poll the client fires while the guild-war kill scoreboard is open (and periodically).
-/// 2026-09-02: now answered with SCExpeditionWarKillScorePacket instead of being a no-op.
+/// Answered with SCExpeditionWarKillScorePacket.
 /// </summary>
 public class CSExpeditionWarKillScorePacket() : GamePacket(CSOffsets.CSExpeditionWarKillScorePacket, 1)
 {

--- a/AAEmu.Game/Core/Packets/C2G/CSExpeditionWarKillScorePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSExpeditionWarKillScorePacket.cs
@@ -1,18 +1,17 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// TODO(v10): the body is parsed but nothing acts on it yet.
+/// Empty-body poll the client fires while the guild-war kill scoreboard is open (and periodically).
+/// 2026-09-02: now answered with SCExpeditionWarKillScorePacket instead of being a no-op.
 /// </summary>
-/// <remarks>
-/// packet has no body. Every parameterless C2S type folds onto that one function, so the
-/// shared address is identical-COMDAT folding, not a base-class fall-through.
-/// </remarks>
 public class CSExpeditionWarKillScorePacket() : GamePacket(CSOffsets.CSExpeditionWarKillScorePacket, 1)
 {
     public override void Read(PacketStream stream)
     {
+        ExpeditionManager.Instance.SendWarKillScore(Connection);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSOffsets.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSOffsets.cs
@@ -321,10 +321,6 @@ public static class CSOffsets
     public const ushort CSExpeditionLevelUpPacket = 0x02D;
     public const ushort CSExpeditionRecruitmentAddPacket = 0x31;
     public const ushort CSExpeditionRecruitmentsGetPacket = 0x030;
-    // 2026-09-02: opcode 0x11 confirmed via Ghidra literal in the real client x2game.dll
-    // (FUN_395be140: local_18 = 0x11 at the CSRequestDeclarationMoneyPacket::vftable construction site,
-    // immediately adjacent to CSDeclareExpeditionWarPacket's own local_18 = 0x10). Single-Bc body
-    // (the 1-arg packed-ref writer FUN_39a8f270, vs CSDeclareExpeditionWar's 2-arg Bc+u32 writer).
     public const ushort CSRequestDeclarationMoneyPacket = 0x011;
     public const ushort CSExpelSquadMemberPacket = 0x1E1;
     public const ushort CSFactionMobilizationOrderPacket = 0x027;

--- a/AAEmu.Game/Core/Packets/C2G/CSOffsets.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSOffsets.cs
@@ -321,6 +321,11 @@ public static class CSOffsets
     public const ushort CSExpeditionLevelUpPacket = 0x02D;
     public const ushort CSExpeditionRecruitmentAddPacket = 0x31;
     public const ushort CSExpeditionRecruitmentsGetPacket = 0x030;
+    // 2026-09-02: opcode 0x11 confirmed via Ghidra literal in the real client x2game.dll
+    // (FUN_395be140: local_18 = 0x11 at the CSRequestDeclarationMoneyPacket::vftable construction site,
+    // immediately adjacent to CSDeclareExpeditionWarPacket's own local_18 = 0x10). Single-Bc body
+    // (the 1-arg packed-ref writer FUN_39a8f270, vs CSDeclareExpeditionWar's 2-arg Bc+u32 writer).
+    public const ushort CSRequestDeclarationMoneyPacket = 0x011;
     public const ushort CSExpelSquadMemberPacket = 0x1E1;
     public const ushort CSFactionMobilizationOrderPacket = 0x027;
     public const ushort CSFactionRelationRequestPacket = 0x2A;

--- a/AAEmu.Game/Core/Packets/C2G/CSReplyExpeditionInvitationPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSReplyExpeditionInvitationPacket.cs
@@ -14,13 +14,8 @@ public class CSReplyExpeditionInvitationPacket() : GamePacket(CSOffsets.CSReplyE
         var wireFlag = stream.ReadBoolean();
 
         Logger.Debug("ReplyExpeditionInvitation, Id: {0}, Id2: {1}, wireFlag: {2}", id, id2, wireFlag);
-        // 2026-08-28: the wire flag's polarity was assumed backwards. Two live-captured real "Accept"
-        // clicks (the only data points that exist) both sent this byte as false, and ReplyInvite's own
-        // `if (!reply) return;` guard then silently did nothing - explaining "invite arrives, confirming
-        // does not add the member" exactly. No opcode/RTTI evidence pins down what this byte's true name
-        // is (the native constructor, FUN_396c5f90, takes it as a single opaque byte with no confirmed
-        // caller), so this is inference from wire behavior, not a decompile-confirmed fix - watch for a
-        // real decline case (should now correctly NOT join) to fully confirm the polarity.
+        // TODO: wireFlag's polarity is inverted here based on observed Accept clicks (both sent false);
+        // not yet confirmed against a real decline case.
         ExpeditionManager.Instance.ReplyInvite(Connection, id, id2, !wireFlag);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSReplyExpeditionInvitationPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSReplyExpeditionInvitationPacket.cs
@@ -11,9 +11,16 @@ public class CSReplyExpeditionInvitationPacket() : GamePacket(CSOffsets.CSReplyE
     {
         var id = (FactionsEnum)stream.ReadUInt32(); // type(id)
         var id2 = stream.ReadUInt32(); // type(id)
-        var join = stream.ReadBoolean();
+        var wireFlag = stream.ReadBoolean();
 
-        Logger.Debug("ReplyExpeditionInvitation, Id: {0}, Id2: {1}, Join: {2}", id, id2, join);
-        ExpeditionManager.Instance.ReplyInvite(Connection, id, id2, join);
+        Logger.Debug("ReplyExpeditionInvitation, Id: {0}, Id2: {1}, wireFlag: {2}", id, id2, wireFlag);
+        // 2026-08-28: the wire flag's polarity was assumed backwards. Two live-captured real "Accept"
+        // clicks (the only data points that exist) both sent this byte as false, and ReplyInvite's own
+        // `if (!reply) return;` guard then silently did nothing - explaining "invite arrives, confirming
+        // does not add the member" exactly. No opcode/RTTI evidence pins down what this byte's true name
+        // is (the native constructor, FUN_396c5f90, takes it as a single opaque byte with no confirmed
+        // caller), so this is inference from wire behavior, not a decompile-confirmed fix - watch for a
+        // real decline case (should now correctly NOT join) to fully confirm the polarity.
+        ExpeditionManager.Instance.ReplyInvite(Connection, id, id2, !wireFlag);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSRequestDeclarationMoneyPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRequestDeclarationMoneyPacket.cs
@@ -5,18 +5,11 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.C2G;
 
 /// <summary>
-/// 2026-09-02: first step of the guild "declare war" round trip. The right-click menu on an enemy
-/// guild member does NOT send CSDeclareExpeditionWarPacket directly - it first calls
-/// X2Faction:RequestDeclarationMoney(), which sends this packet. The server must answer with
-/// SCExpeditionWarDeclarationMoney (target unitId + computed cost); only that response opens the
-/// confirm dialog, and only clicking OK there sends CSDeclareExpeditionWarPacket.
+/// First step of the guild "declare war" round trip. The client sends this before
+/// CSDeclareExpeditionWarPacket; the server must answer with SCExpeditionWarDeclarationMoney
+/// (target unitId + computed cost) to open the confirm dialog. Body is just the target unit -
+/// the server computes and returns the cost.
 /// </summary>
-/// <remarks>
-/// Opcode 0x11, confirmed via Ghidra literal in the real client (FUN_395be140). Body is a single
-/// packed reference (Bc) - the target unit - written with the client's 1-arg packed-ref writer
-/// FUN_39a8f270 (CSDeclareExpeditionWarPacket by contrast uses the 2-arg Bc+u32 writer). No money
-/// field: the server computes and returns the cost.
-/// </remarks>
 public class CSRequestDeclarationMoneyPacket() : GamePacket(CSOffsets.CSRequestDeclarationMoneyPacket, 1)
 {
     public uint Bc { get; private set; }

--- a/AAEmu.Game/Core/Packets/C2G/CSRequestDeclarationMoneyPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRequestDeclarationMoneyPacket.cs
@@ -1,0 +1,30 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.C2G;
+
+/// <summary>
+/// 2026-09-02: first step of the guild "declare war" round trip. The right-click menu on an enemy
+/// guild member does NOT send CSDeclareExpeditionWarPacket directly - it first calls
+/// X2Faction:RequestDeclarationMoney(), which sends this packet. The server must answer with
+/// SCExpeditionWarDeclarationMoney (target unitId + computed cost); only that response opens the
+/// confirm dialog, and only clicking OK there sends CSDeclareExpeditionWarPacket.
+/// </summary>
+/// <remarks>
+/// Opcode 0x11, confirmed via Ghidra literal in the real client (FUN_395be140). Body is a single
+/// packed reference (Bc) - the target unit - written with the client's 1-arg packed-ref writer
+/// FUN_39a8f270 (CSDeclareExpeditionWarPacket by contrast uses the 2-arg Bc+u32 writer). No money
+/// field: the server computes and returns the cost.
+/// </remarks>
+public class CSRequestDeclarationMoneyPacket() : GamePacket(CSOffsets.CSRequestDeclarationMoneyPacket, 1)
+{
+    public uint Bc { get; private set; }
+
+    public override void Read(PacketStream stream)
+    {
+        Bc = stream.ReadBc();
+
+        ExpeditionManager.Instance.RequestDeclarationMoney(Connection, Bc);
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffChangedPacket.cs
@@ -4,11 +4,7 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// Per-purchase buff-grade change notice. Wire format confirmed 2026-08-28 from the client's
-/// serializer FUN_39c597b0: two generic-id fields via the 4-byte slot 0x80, then named
-/// "beforeGrade" and "nextGrade" (slot 0xa0, 4-byte) - i.e. four 4-byte fields. Field semantics
-/// follow the family's lead-with-expeditionId convention (Buffs/MemberList/RolePolicyList):
-/// [expeditionId][buffId][beforeGrade][nextGrade].
+/// Per-purchase buff-grade change notice. Wire: expeditionId, buffId, beforeGrade, nextGrade (all u32).
 /// </summary>
 public class SCExpeditionBuffChangedPacket(int expeditionId, int buffId, uint beforeGrade, uint nextGrade) : GamePacket(SCOffsets.SCExpeditionBuffChangedPacket, 1)
 {

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffChangedPacket.cs
@@ -4,18 +4,18 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// TODO: nothing constructs this packet yet.
+/// Per-purchase buff-grade change notice. Wire format confirmed 2026-08-28 from the client's
+/// serializer FUN_39c597b0: two generic-id fields via the 4-byte slot 0x80, then named
+/// "beforeGrade" and "nextGrade" (slot 0xa0, 4-byte) - i.e. four 4-byte fields. Field semantics
+/// follow the family's lead-with-expeditionId convention (Buffs/MemberList/RolePolicyList):
+/// [expeditionId][buffId][beforeGrade][nextGrade].
 /// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
-public class SCExpeditionBuffChangedPacket(int @type, int @type2, uint beforeGrade, uint nextGrade) : GamePacket(SCOffsets.SCExpeditionBuffChangedPacket, 1)
+public class SCExpeditionBuffChangedPacket(int expeditionId, int buffId, uint beforeGrade, uint nextGrade) : GamePacket(SCOffsets.SCExpeditionBuffChangedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(@type);
-        stream.Write(@type2);
+        stream.Write(expeditionId);
+        stream.Write(buffId);
         stream.Write(beforeGrade);
         stream.Write(nextGrade);
         return stream;

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffUnitPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffUnitPacket.cs
@@ -4,24 +4,12 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// Answers CSExpeditionBuffUnitPacket (a bare unit Bc, sent repeatedly by the client whenever the
-/// prestige-shop buff window is open - never previously wired to anything, "nothing acts on it yet").
+/// Answers CSExpeditionBuffUnitPacket, sent repeatedly by the client while the prestige-shop buff
+/// window is open. Wire: unitId (Bc), then the same 12-byte {buffType, grade, learnedGrade} entries
+/// as SCExpeditionBuffsPacket.
+/// TODO: semantics of "why per-unit" (vs the guild-wide SCExpeditionBuffsPacket) unconfirmed; modeled
+/// as an echo of the requesting character's own unit plus the guild's buff-grade state. Untested live.
 /// </summary>
-/// <remarks>
-/// 2026-08-28: wire layout found by decompiling FUN_39c87fd0 (x2game-dev.dll) - the real Unpack for
-/// this packet, sitting right next to SCExpeditionBuffsPacket's own Unpack (FUN_39c87f60) in the
-/// dump, previously misread as unrelated. Layout: [unitId: optional-presence-wrapped 3-byte Bc @
-/// +0x10, via the same slot 0x1a0/0x1a8 pattern already confirmed for SCUnitExpeditionChangedPacket]
-/// + ["buffs" vector @ +0x18, byte-identical 12-byte entries to SCExpeditionBuffsPacket's own format].
-///
-/// 2026-09-02: per-entry field bindings corrected the same way as SCExpeditionBuffsPacket.cs - the
-/// real layout (via FUN_39aa9810, see that file's remarks for the full trail) is
-/// {buffType, grade, learnedGrade}, not {buffId, unknown, grade}. Same fix applied here for
-/// consistency since this packet shares the identical 12-byte struct. Semantics of "why per-unit"
-/// still not confirmed - modeled as an echo of the requesting character's own unit id plus the
-/// guild's current buff-grade state, since the client only ever sends its own unit's Bc in the
-/// request. Untested live.
-/// </remarks>
 public class SCExpeditionBuffUnitPacket(uint unitId, IReadOnlyDictionary<uint, byte> purchasedGrades)
     : GamePacket(SCOffsets.SCExpeditionBuffUnitPacket, 1)
 {
@@ -32,8 +20,8 @@ public class SCExpeditionBuffUnitPacket(uint unitId, IReadOnlyDictionary<uint, b
         foreach (var (buffId, grade) in purchasedGrades)
         {
             stream.Write(buffId);
-            stream.Write((uint)grade); // +0x4 = "grade" - was hardcoded 0
-            stream.Write((uint)grade); // +0x8 = "learnedGrade" - was the real grade, in the wrong slot
+            stream.Write((uint)grade);
+            stream.Write((uint)grade);
         }
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffUnitPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffUnitPacket.cs
@@ -1,0 +1,40 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+/// <summary>
+/// Answers CSExpeditionBuffUnitPacket (a bare unit Bc, sent repeatedly by the client whenever the
+/// prestige-shop buff window is open - never previously wired to anything, "nothing acts on it yet").
+/// </summary>
+/// <remarks>
+/// 2026-08-28: wire layout found by decompiling FUN_39c87fd0 (x2game-dev.dll) - the real Unpack for
+/// this packet, sitting right next to SCExpeditionBuffsPacket's own Unpack (FUN_39c87f60) in the
+/// dump, previously misread as unrelated. Layout: [unitId: optional-presence-wrapped 3-byte Bc @
+/// +0x10, via the same slot 0x1a0/0x1a8 pattern already confirmed for SCUnitExpeditionChangedPacket]
+/// + ["buffs" vector @ +0x18, byte-identical 12-byte entries to SCExpeditionBuffsPacket's own format].
+///
+/// 2026-09-02: per-entry field bindings corrected the same way as SCExpeditionBuffsPacket.cs - the
+/// real layout (via FUN_39aa9810, see that file's remarks for the full trail) is
+/// {buffType, grade, learnedGrade}, not {buffId, unknown, grade}. Same fix applied here for
+/// consistency since this packet shares the identical 12-byte struct. Semantics of "why per-unit"
+/// still not confirmed - modeled as an echo of the requesting character's own unit id plus the
+/// guild's current buff-grade state, since the client only ever sends its own unit's Bc in the
+/// request. Untested live.
+/// </remarks>
+public class SCExpeditionBuffUnitPacket(uint unitId, IReadOnlyDictionary<uint, byte> purchasedGrades)
+    : GamePacket(SCOffsets.SCExpeditionBuffUnitPacket, 1)
+{
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.WriteBc(unitId);
+        stream.Write(purchasedGrades.Count);
+        foreach (var (buffId, grade) in purchasedGrades)
+        {
+            stream.Write(buffId);
+            stream.Write((uint)grade); // +0x4 = "grade" - was hardcoded 0
+            stream.Write((uint)grade); // +0x8 = "learnedGrade" - was the real grade, in the wrong slot
+        }
+        return stream;
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffsPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffsPacket.cs
@@ -8,36 +8,11 @@ namespace AAEmu.Game.Core.Packets.G2C;
 /// "view" request and should also be pushed on Expedition join/login (see ExpeditionManager.SendExpeditionBuffs).
 /// </summary>
 /// <remarks>
-/// Wire layout: [expeditionId:4 @+0x10][8-byte field @+0x38]["buffs" vector @+0x18, 12-byte
-/// int32 triples, int32 count]. The header/count/8-byte-freshness-timestamp part of this was
-/// GROUND-TRUTH-CONFIRMED 2026-08-28 via a real Frida live capture (hooked Unpack, FUN_39c87f60,
-/// and read the destination struct after every real call) - that capture only verified the raw
-/// bytes arrive intact, not what each per-entry slot MEANS to the client, which is a separate
-/// question this comment used to answer wrong.
-///
-/// 2026-09-02: found the real per-entry field bindings via `FUN_39aa9810` (the concrete converter
-/// `FUN_39ace420`'s per-element loop calls for this exact 12-byte struct, reached from this
-/// packet's own Unpack, FUN_39c87f60 -&gt; FUN_39ace420("buffs", ...) -&gt; FUN_39aae740 -&gt;
-/// FUN_39aa9810 - a hardcoded, non-generic call chain, not a templated one, so this binding is
-/// specific to this struct):
-/// <code>
-/// (**(code **)(*param_2 + 0x80))(param_2, &amp;DAT_3a24f540, param_1, 0);      // +0x0 = buffType
-/// (**(code **)(*param_2 + 0xa0))(param_2, "grade", param_1 + 4, 0);        // +0x4 = grade
-/// (**(code **)(*param_2 + 0xa0))(param_2, "learnedGrade", param_1 + 8, 0); // +0x8 = learnedGrade
-/// </code>
-/// The real layout is {buffType, grade, learnedGrade} - NOT {buffId, unknown, grade} as this
-/// packet previously assumed. That earlier assumption always wrote a hardcoded 0 into the +0x4
-/// slot (thinking it was an unused/unknown field) and the real purchased grade into +0x8 - so the
-/// client's `RefreshLeftList` (which displays `v.grade` directly as the buff-shop's "x/y" numerator)
-/// always read 0, matching the reported "0/x" symptom exactly, independent of the notify-timestamp
-/// bug fixed earlier the same day (that fix was real and necessary, just not sufficient - the
-/// cache was updating correctly, just with the grade value in the wrong slot).
-///
-/// `learnedGrade`'s exact semantics are unconfirmed (the client also uses it for an
-/// "EXPEDITION_HOUSE_NOT_EXIST" comparison against `grade` elsewhere) - sending the same value as
-/// `grade` here is a deliberate, evidence-based safe default (avoids inventing a spurious
-/// housing-required error for grades already legitimately owned) until a live capture nails down
-/// whether it should ever legitimately differ.
+/// Wire layout: expeditionId (u32), freshness timestamp (i64), buff count (i32), then per buff a
+/// 12-byte {buffType, grade, learnedGrade} triple. Each field must be sent in that exact order -
+/// swapping grade/learnedGrade makes the client's buff-shop numerator read 0.
+/// TODO: learnedGrade's exact semantics are unconfirmed; sending the same value as grade is a safe
+/// default but may need to differ in some case.
 /// </remarks>
 public class SCExpeditionBuffsPacket(uint expeditionId, IReadOnlyDictionary<uint, byte> purchasedGrades)
     : GamePacket(SCOffsets.SCExpeditionBuffsPacket, 1)
@@ -45,13 +20,13 @@ public class SCExpeditionBuffsPacket(uint expeditionId, IReadOnlyDictionary<uint
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(expeditionId);
-        stream.Write(DateTime.UtcNow.Ticks); // was a hardcoded 0L - see remarks, this was a real bug too
+        stream.Write(DateTime.UtcNow.Ticks);
         stream.Write(purchasedGrades.Count);
         foreach (var (buffId, grade) in purchasedGrades)
         {
             stream.Write(buffId);
-            stream.Write((uint)grade); // +0x4 = "grade" - was hardcoded 0, see remarks
-            stream.Write((uint)grade); // +0x8 = "learnedGrade" - was the real grade, in the wrong slot
+            stream.Write((uint)grade);
+            stream.Write((uint)grade);
         }
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffsPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionBuffsPacket.cs
@@ -1,0 +1,58 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+/// <summary>
+/// Full sync of a guild's currently-purchased prestige-shop buff grades - answers CSExpeditionBuffPacket's
+/// "view" request and should also be pushed on Expedition join/login (see ExpeditionManager.SendExpeditionBuffs).
+/// </summary>
+/// <remarks>
+/// Wire layout: [expeditionId:4 @+0x10][8-byte field @+0x38]["buffs" vector @+0x18, 12-byte
+/// int32 triples, int32 count]. The header/count/8-byte-freshness-timestamp part of this was
+/// GROUND-TRUTH-CONFIRMED 2026-08-28 via a real Frida live capture (hooked Unpack, FUN_39c87f60,
+/// and read the destination struct after every real call) - that capture only verified the raw
+/// bytes arrive intact, not what each per-entry slot MEANS to the client, which is a separate
+/// question this comment used to answer wrong.
+///
+/// 2026-09-02: found the real per-entry field bindings via `FUN_39aa9810` (the concrete converter
+/// `FUN_39ace420`'s per-element loop calls for this exact 12-byte struct, reached from this
+/// packet's own Unpack, FUN_39c87f60 -&gt; FUN_39ace420("buffs", ...) -&gt; FUN_39aae740 -&gt;
+/// FUN_39aa9810 - a hardcoded, non-generic call chain, not a templated one, so this binding is
+/// specific to this struct):
+/// <code>
+/// (**(code **)(*param_2 + 0x80))(param_2, &amp;DAT_3a24f540, param_1, 0);      // +0x0 = buffType
+/// (**(code **)(*param_2 + 0xa0))(param_2, "grade", param_1 + 4, 0);        // +0x4 = grade
+/// (**(code **)(*param_2 + 0xa0))(param_2, "learnedGrade", param_1 + 8, 0); // +0x8 = learnedGrade
+/// </code>
+/// The real layout is {buffType, grade, learnedGrade} - NOT {buffId, unknown, grade} as this
+/// packet previously assumed. That earlier assumption always wrote a hardcoded 0 into the +0x4
+/// slot (thinking it was an unused/unknown field) and the real purchased grade into +0x8 - so the
+/// client's `RefreshLeftList` (which displays `v.grade` directly as the buff-shop's "x/y" numerator)
+/// always read 0, matching the reported "0/x" symptom exactly, independent of the notify-timestamp
+/// bug fixed earlier the same day (that fix was real and necessary, just not sufficient - the
+/// cache was updating correctly, just with the grade value in the wrong slot).
+///
+/// `learnedGrade`'s exact semantics are unconfirmed (the client also uses it for an
+/// "EXPEDITION_HOUSE_NOT_EXIST" comparison against `grade` elsewhere) - sending the same value as
+/// `grade` here is a deliberate, evidence-based safe default (avoids inventing a spurious
+/// housing-required error for grades already legitimately owned) until a live capture nails down
+/// whether it should ever legitimately differ.
+/// </remarks>
+public class SCExpeditionBuffsPacket(uint expeditionId, IReadOnlyDictionary<uint, byte> purchasedGrades)
+    : GamePacket(SCOffsets.SCExpeditionBuffsPacket, 1)
+{
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(expeditionId);
+        stream.Write(DateTime.UtcNow.Ticks); // was a hardcoded 0L - see remarks, this was a real bug too
+        stream.Write(purchasedGrades.Count);
+        foreach (var (buffId, grade) in purchasedGrades)
+        {
+            stream.Write(buffId);
+            stream.Write((uint)grade); // +0x4 = "grade" - was hardcoded 0, see remarks
+            stream.Write((uint)grade); // +0x8 = "learnedGrade" - was the real grade, in the wrong slot
+        }
+        return stream;
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionDescPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionDescPacket.cs
@@ -5,79 +5,36 @@ using AAEmu.Game.Models.Game.Expeditions;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// The guild info panel's descriptor - level/exp/notice and the rest of X2::ExpeditionDesc. Opcode 0x4B and the
-/// full field layout were recovered 2026-08-13 via Ghidra RTTI/constructor analysis of x2game-dev.dll (see the
-/// aaemu-fixes-applied memory for the recovery writeup), cross-confirmed against a community-supplied opcode
-/// dump. No client-side request opcode exists for this data (CTQueryExpeditionInfoPacket turned out to be an
-/// unrelated internal client cache mechanism, not a network packet) - this must be server-pushed, matching the
+/// The guild info panel's descriptor - level/exp/notice and the rest of X2::ExpeditionDesc. No
+/// client-side request opcode exists for this data, so it must be server-pushed, matching the
 /// existing SendExpeditionInfo pattern (login, create, invite-accept).
 /// </summary>
 public sealed class SCExpeditionDescPacket(Expedition expedition) : GamePacket(SCOffsets.SCExpeditionDescPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        // FactionDesc base portion (id, motherId, name, owner, ..., integrationFaction) - byte-identical field
-        // order/widths to what Ghidra recovered, and this Write() already existed and is shared with
-        // SCExpeditionListPacket/SCFactionCreatedPacket - independent confirmation it was already correct.
+        // FactionDesc base portion (id, motherId, name, owner, ..., integrationFaction) - shared with
+        // SCExpeditionListPacket/SCFactionCreatedPacket.
         stream.Write(expedition);
 
-        // ExpeditionDesc-specific tail, network order per the Ghidra recovery. Level/Exp/contributionPoint
-        // are the fields with real backing data right now (Expedition.Level/Exp, TotalContributionPoint -
-        // the live sum of every member's own ContributionPoint, not a separately persisted bank).
-        // Everything else below belongs to subsystems that don't exist in this codebase yet (guild war
-        // win/lose/draw scoreboard, war deposit/protection, a rename cooldown) - written as zero/default
-        // rather than guessed, and two fields (rows 1/2 in the recovery, both keyed "type" on the wire) had
-        // no confirmed meaning at all, so those two are omitted here already (they're Id/MotherId, already
-        // covered by the base Write() above - matches the recovery's own note that the generic "type" key
-        // is a serializer artifact for enum-typed fields, not a real distinct field).
         stream.Write((int)expedition.Level);
         stream.Write((int)expedition.Exp);
-        // 2026-08-27: REVERTED a field-order "fix" attempted earlier tonight (had swapped these 4 fields to
-        // dailyExp/lastExpUpdateTime/protectDate/warDeposit based on a decompile read that was supposed to be
-        // byte-count-neutral). User reported the guild dominion protection-time display went haywire (absurd
-        // hour counts) immediately after that change went live - so despite the careful-looking byte-count
-        // math, something about that reorder (or the underlying width assumptions for these slots) was wrong
-        // in practice. Reverted to this original order rather than guess again. Do not re-attempt reordering
-        // these 4 fields without real (live-debugged) evidence - two speculative "fixes" to this packet
-        // tonight have each made a different part of the guild UI worse, not better.
-        // 2026-09-02: value-only change (same slot/order the note above warns not to reorder) - now that
-        // Expedition tracks real Guild War state, show the actual deadline instead of always "now". While a
-        // war is active this is when it ends; once it ends this is the post-war re-declaration protection
-        // deadline; with no war ever fought it's still just "now" as before.
+        // TODO: do not reorder these 4 fields (protectDate/warDeposit/dailyExp/lastExpUpdateTime) without
+        // live-debugged evidence - a prior reorder attempt broke the guild protection-time display.
         stream.Write(expedition.WarEndsAt ?? expedition.WarProtectedUntil ?? DateTime.UtcNow); // protectDate
         stream.Write(0);                   // warDeposit - not tracked
         stream.Write(0);                   // dailyExp - not tracked separately from Exp yet
         stream.Write(DateTime.UtcNow);     // lastExpUpdateTime
-        // 2026-08-27: was hardcoded 0 ("not tracked") - now backed by Expedition.Interest, settable via
-        // CSExpeditionInterestUpatePacket (see ExpeditionManager.SetInterest), which was found fully parsed
-        // but never registered during the full-codebase unregistered-packet audit.
         stream.Write(expedition.Interest);
         stream.Write(Truncate(expedition.Notice, 800));
-        stream.Write(0);                   // win - GuildWar not built yet
+        stream.Write(0);                   // win - GuildWar win/lose/draw totals not tracked yet
         stream.Write(0);                   // lose
         stream.Write(0);                   // draw
-        // Row 25 was previously written as 0 ("unconfirmed field"). Ghidra-confirmed 2026-08-21: this is a
-        // client-cached gate on the guild-level-up button - FUN_396b81c0 (the native handler behind
-        // X2Faction:SetExpeditionLevelUp) only actually sends CSExpeditionLevelUpPacket when
-        // *(int*)(cache+0x370) == 0xff (an OR-branch alongside an unrelated account/session flag read via a
-        // separate global). cache+0x370 sits right after this SAME struct's cache+0x36c field. 2026-08-27
-        // CORRECTION: cache+0x36c is NOT "the cached Level field" as previously assumed here - independently
-        // re-derived by decompiling the getter function it goes through (FUN_396b6040), which is ALSO what
-        // backs the native X2Faction:GetMyExpeditionId() Lua binding. cache+0x36c is the client's cached
-        // "which guild am I in" id, populated by some OTHER mechanism entirely (not by this packet's own
-        // fields) - most likely SCUnitExpeditionChangedPacket sent to oneself at login, unconfirmed which
-        // exact packet/handler sets it since the native vtable dispatch for that isn't visible in this text
-        // decompile dump. This also means X2Faction:IsExpedInfoLoaded() (FUN_396b6b90, checks cache+0x0 ==
-        // cache+0x36c) is a "does the cached desc's own guild id match my cached guild id" freshness check,
-        // not a Level check - see aaemu-guild-systems-gaps memory for the fuller trail (member list stuck
-        // loading + invite permanently disabled both gate on this same check). Writing 0 here silently
-        // blocked every level-up attempt client-side before any packet was ever sent - no error, no
-        // server-side symptom at all. 0xff appears to mean "no restriction" (a war-protection cooldown/lock
-        // code sentinel is the most likely real semantic, matching this field's neighbors in the recovery,
-        // but unconfirmed beyond satisfying the gate).
+        // Client-cached gate on the guild-level-up button; must be 0xff ("no restriction") or the client
+        // silently blocks every level-up attempt without sending a packet or showing an error.
         stream.Write(0xff);
-        stream.Write(0L);                  // unconfirmed field (recovery row 26, generic "type" key)
-        stream.Write((long)expedition.TotalContributionPoint); // contributionPoint (guild-level total) - sum of all members' own ContributionPoint
+        stream.Write(0L);                  // unconfirmed field
+        stream.Write((long)expedition.TotalContributionPoint); // guild-level total, sum of all members' own ContributionPoint
         stream.Write(0);                   // dailyContributionPoint
         stream.Write(DateTime.UtcNow);     // lastContributionPointAdded
         stream.Write(DateTime.UtcNow);     // lastAssignmentUpdateTime

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionDescPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionDescPacket.cs
@@ -1,0 +1,89 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Expeditions;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+/// <summary>
+/// The guild info panel's descriptor - level/exp/notice and the rest of X2::ExpeditionDesc. Opcode 0x4B and the
+/// full field layout were recovered 2026-08-13 via Ghidra RTTI/constructor analysis of x2game-dev.dll (see the
+/// aaemu-fixes-applied memory for the recovery writeup), cross-confirmed against a community-supplied opcode
+/// dump. No client-side request opcode exists for this data (CTQueryExpeditionInfoPacket turned out to be an
+/// unrelated internal client cache mechanism, not a network packet) - this must be server-pushed, matching the
+/// existing SendExpeditionInfo pattern (login, create, invite-accept).
+/// </summary>
+public sealed class SCExpeditionDescPacket(Expedition expedition) : GamePacket(SCOffsets.SCExpeditionDescPacket, 1)
+{
+    public override PacketStream Write(PacketStream stream)
+    {
+        // FactionDesc base portion (id, motherId, name, owner, ..., integrationFaction) - byte-identical field
+        // order/widths to what Ghidra recovered, and this Write() already existed and is shared with
+        // SCExpeditionListPacket/SCFactionCreatedPacket - independent confirmation it was already correct.
+        stream.Write(expedition);
+
+        // ExpeditionDesc-specific tail, network order per the Ghidra recovery. Level/Exp/contributionPoint
+        // are the fields with real backing data right now (Expedition.Level/Exp, TotalContributionPoint -
+        // the live sum of every member's own ContributionPoint, not a separately persisted bank).
+        // Everything else below belongs to subsystems that don't exist in this codebase yet (guild war
+        // win/lose/draw scoreboard, war deposit/protection, a rename cooldown) - written as zero/default
+        // rather than guessed, and two fields (rows 1/2 in the recovery, both keyed "type" on the wire) had
+        // no confirmed meaning at all, so those two are omitted here already (they're Id/MotherId, already
+        // covered by the base Write() above - matches the recovery's own note that the generic "type" key
+        // is a serializer artifact for enum-typed fields, not a real distinct field).
+        stream.Write((int)expedition.Level);
+        stream.Write((int)expedition.Exp);
+        // 2026-08-27: REVERTED a field-order "fix" attempted earlier tonight (had swapped these 4 fields to
+        // dailyExp/lastExpUpdateTime/protectDate/warDeposit based on a decompile read that was supposed to be
+        // byte-count-neutral). User reported the guild dominion protection-time display went haywire (absurd
+        // hour counts) immediately after that change went live - so despite the careful-looking byte-count
+        // math, something about that reorder (or the underlying width assumptions for these slots) was wrong
+        // in practice. Reverted to this original order rather than guess again. Do not re-attempt reordering
+        // these 4 fields without real (live-debugged) evidence - two speculative "fixes" to this packet
+        // tonight have each made a different part of the guild UI worse, not better.
+        // 2026-09-02: value-only change (same slot/order the note above warns not to reorder) - now that
+        // Expedition tracks real Guild War state, show the actual deadline instead of always "now". While a
+        // war is active this is when it ends; once it ends this is the post-war re-declaration protection
+        // deadline; with no war ever fought it's still just "now" as before.
+        stream.Write(expedition.WarEndsAt ?? expedition.WarProtectedUntil ?? DateTime.UtcNow); // protectDate
+        stream.Write(0);                   // warDeposit - not tracked
+        stream.Write(0);                   // dailyExp - not tracked separately from Exp yet
+        stream.Write(DateTime.UtcNow);     // lastExpUpdateTime
+        // 2026-08-27: was hardcoded 0 ("not tracked") - now backed by Expedition.Interest, settable via
+        // CSExpeditionInterestUpatePacket (see ExpeditionManager.SetInterest), which was found fully parsed
+        // but never registered during the full-codebase unregistered-packet audit.
+        stream.Write(expedition.Interest);
+        stream.Write(Truncate(expedition.Notice, 800));
+        stream.Write(0);                   // win - GuildWar not built yet
+        stream.Write(0);                   // lose
+        stream.Write(0);                   // draw
+        // Row 25 was previously written as 0 ("unconfirmed field"). Ghidra-confirmed 2026-08-21: this is a
+        // client-cached gate on the guild-level-up button - FUN_396b81c0 (the native handler behind
+        // X2Faction:SetExpeditionLevelUp) only actually sends CSExpeditionLevelUpPacket when
+        // *(int*)(cache+0x370) == 0xff (an OR-branch alongside an unrelated account/session flag read via a
+        // separate global). cache+0x370 sits right after this SAME struct's cache+0x36c field. 2026-08-27
+        // CORRECTION: cache+0x36c is NOT "the cached Level field" as previously assumed here - independently
+        // re-derived by decompiling the getter function it goes through (FUN_396b6040), which is ALSO what
+        // backs the native X2Faction:GetMyExpeditionId() Lua binding. cache+0x36c is the client's cached
+        // "which guild am I in" id, populated by some OTHER mechanism entirely (not by this packet's own
+        // fields) - most likely SCUnitExpeditionChangedPacket sent to oneself at login, unconfirmed which
+        // exact packet/handler sets it since the native vtable dispatch for that isn't visible in this text
+        // decompile dump. This also means X2Faction:IsExpedInfoLoaded() (FUN_396b6b90, checks cache+0x0 ==
+        // cache+0x36c) is a "does the cached desc's own guild id match my cached guild id" freshness check,
+        // not a Level check - see aaemu-guild-systems-gaps memory for the fuller trail (member list stuck
+        // loading + invite permanently disabled both gate on this same check). Writing 0 here silently
+        // blocked every level-up attempt client-side before any packet was ever sent - no error, no
+        // server-side symptom at all. 0xff appears to mean "no restriction" (a war-protection cooldown/lock
+        // code sentinel is the most likely real semantic, matching this field's neighbors in the recovery,
+        // but unconfirmed beyond satisfying the gate).
+        stream.Write(0xff);
+        stream.Write(0L);                  // unconfirmed field (recovery row 26, generic "type" key)
+        stream.Write((long)expedition.TotalContributionPoint); // contributionPoint (guild-level total) - sum of all members' own ContributionPoint
+        stream.Write(0);                   // dailyContributionPoint
+        stream.Write(DateTime.UtcNow);     // lastContributionPointAdded
+        stream.Write(DateTime.UtcNow);     // lastAssignmentUpdateTime
+        return stream;
+    }
+
+    private static string Truncate(string value, int maxLength) =>
+        string.IsNullOrEmpty(value) ? string.Empty : value[..Math.Min(value.Length, maxLength)];
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionInvitationPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionInvitationPacket.cs
@@ -8,19 +8,7 @@ public class SCExpeditionInvitationPacket(uint invitorId, string invitorName, ui
 {
     public override PacketStream Write(PacketStream stream)
     {
-        // 2026-08-27, third pass, now unambiguously confirmed: the native client (x2game-dev.dll,
-        // FUN_39c59630) reads this field through interface slot 0x98. Two earlier guesses at this slot were
-        // both wrong (WriteBc 3-byte, then WriteBc of ObjId instead of the persistent id) - the first assumed
-        // slot 0x98 was the same "Bc" id-encoder used elsewhere in this codebase, without checking. It isn't:
-        // that real Bc encoder is a DIFFERENT slot (0x1a0/0x1a8, confirmed via SCUnitExpeditionChangedPacket's
-        // FUN_393908b0 sub-call), independently matching this project's own already-established WriteBc
-        // short/long-form finding. Slot 0x98 itself is confirmed a plain 8-byte scalar by direct, unambiguous
-        // struct-offset evidence: in FUN_393775e0, a field literally named "playerId" sits at slot 0x98,
-        // offset+0x10, with the very next field starting at offset+0x18 - an exact 8-byte gap (the same 8-byte
-        // gap independently shows up for "preciseHealth"/"preciseMana" elsewhere). "playerId" also matches
-        // the persistent Character.Id semantically far better than ObjId. So: plain 8-byte value, persistent
-        // id - both this codebase's original width (wrong, was 4 bytes) and attempt #2's value (wrong, was
-        // ObjId) needed correcting, not just one or the other.
+        // invitorId is a plain 8-byte persistent Character.Id, not a Bc-encoded reference and not ObjId.
         stream.Write((ulong)invitorId);
         stream.Write(invitorName);
         stream.Write(factionId);

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionInvitationPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionInvitationPacket.cs
@@ -8,7 +8,20 @@ public class SCExpeditionInvitationPacket(uint invitorId, string invitorName, ui
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(invitorId);
+        // 2026-08-27, third pass, now unambiguously confirmed: the native client (x2game-dev.dll,
+        // FUN_39c59630) reads this field through interface slot 0x98. Two earlier guesses at this slot were
+        // both wrong (WriteBc 3-byte, then WriteBc of ObjId instead of the persistent id) - the first assumed
+        // slot 0x98 was the same "Bc" id-encoder used elsewhere in this codebase, without checking. It isn't:
+        // that real Bc encoder is a DIFFERENT slot (0x1a0/0x1a8, confirmed via SCUnitExpeditionChangedPacket's
+        // FUN_393908b0 sub-call), independently matching this project's own already-established WriteBc
+        // short/long-form finding. Slot 0x98 itself is confirmed a plain 8-byte scalar by direct, unambiguous
+        // struct-offset evidence: in FUN_393775e0, a field literally named "playerId" sits at slot 0x98,
+        // offset+0x10, with the very next field starting at offset+0x18 - an exact 8-byte gap (the same 8-byte
+        // gap independently shows up for "preciseHealth"/"preciseMana" elsewhere). "playerId" also matches
+        // the persistent Character.Id semantically far better than ObjId. So: plain 8-byte value, persistent
+        // id - both this codebase's original width (wrong, was 4 bytes) and attempt #2's value (wrong, was
+        // ObjId) needed correcting, not just one or the other.
+        stream.Write((ulong)invitorId);
         stream.Write(invitorName);
         stream.Write(factionId);
         stream.Write(factionName);

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionOwnerChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionOwnerChangedPacket.cs
@@ -3,13 +3,19 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
+/// <summary>
+/// 2026-09-02: both id fields widened to 8 bytes - confirmed against the real client
+/// (x2game.dll: PacketFunctor&lt;...,SCExpeditionOwnerChangedPacket&gt; -&gt; FUN_3933a7d0), which reads
+/// two 8-byte values before the name string starts. The previous 4-byte writes would have under-filled
+/// the body by 8 bytes total, misaligning the trailing name string.
+/// </summary>
 public class SCExpeditionOwnerChangedPacket(uint id, uint id2, string charName)
     : GamePacket(SCOffsets.SCExpeditionOwnerChangedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(id);
-        stream.Write(id2);
+        stream.Write((ulong)id);
+        stream.Write((ulong)id2);
         stream.Write(charName);
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionOwnerChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionOwnerChangedPacket.cs
@@ -4,10 +4,8 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// 2026-09-02: both id fields widened to 8 bytes - confirmed against the real client
-/// (x2game.dll: PacketFunctor&lt;...,SCExpeditionOwnerChangedPacket&gt; -&gt; FUN_3933a7d0), which reads
-/// two 8-byte values before the name string starts. The previous 4-byte writes would have under-filled
-/// the body by 8 bytes total, misaligning the trailing name string.
+/// Both id fields are 8 bytes on the wire; writing them as 4 bytes under-fills the body and
+/// misaligns the trailing name string.
 /// </summary>
 public class SCExpeditionOwnerChangedPacket(uint id, uint id2, string charName)
     : GamePacket(SCOffsets.SCExpeditionOwnerChangedPacket, 1)

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionRoleChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionRoleChangedPacket.cs
@@ -3,14 +3,34 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCExpeditionRoleChangedPacket(uint id, byte role, string charName)
+/// <summary>
+/// Announces one member's role change (NOT a role-policy definition - see remarks).
+/// </summary>
+/// <remarks>
+/// 2026-09-02: wire format re-derived from the REAL client (x2game.dll, not x2game-dev.dll - see
+/// aaemu-guild-buff-housing-fixes-2026-09-02 for why that distinction matters) by tracing this packet's
+/// actual Unpack (PacketFunctor&lt;...,SCExpeditionRoleChangedPacket&gt; -&gt; FUN_3933a7a0 -&gt;
+/// FUN_395bf260). That consumer reads, in order: an 8-byte value compared against the client's own
+/// character id (to pick "Your role changed" vs "Member $1's role changed"), a string used as the "$1"
+/// member-name substitution, and a 4-byte value stored as the member's new role id - the role's DISPLAY
+/// NAME is looked up client-side from the role-policy list already cached via
+/// SCExpeditionRolePolicyListPacket, not sent here.
+///
+/// The previous version of this packet (2026-08-28) sent a full ExpeditionRolePolicy (id/role/name/10
+/// permission bools) plus a trailing "success" bool - a genuinely different, wrong shape, based on a
+/// misleading client-side construction-site match rather than this packet's real Unpack. That is very
+/// likely why "leader can't assign a rank" showed correct server-side state (confirmed via logs/MySQL in
+/// an earlier session) but never displayed correctly client-side - flagged at the time as an unresolved
+/// dead end, not fixed until now.
+/// </remarks>
+public class SCExpeditionRoleChangedPacket(uint characterId, string name, byte role)
     : GamePacket(SCOffsets.SCExpeditionRoleChangedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(id);
-        stream.Write(role);
-        stream.Write(charName);
+        stream.Write((ulong)characterId);
+        stream.Write(name);
+        stream.Write((uint)role);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionRoleChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionRoleChangedPacket.cs
@@ -4,25 +4,11 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// Announces one member's role change (NOT a role-policy definition - see remarks).
+/// Announces one member's role change (NOT a role-policy definition). Wire: characterId (u64, compared
+/// client-side against the local player to pick "Your role changed" vs "Member $1's role changed"),
+/// member name (string, the "$1" substitution), new role id (u32) - the role's display name is looked
+/// up client-side from the role-policy list already cached via SCExpeditionRolePolicyListPacket.
 /// </summary>
-/// <remarks>
-/// 2026-09-02: wire format re-derived from the REAL client (x2game.dll, not x2game-dev.dll - see
-/// aaemu-guild-buff-housing-fixes-2026-09-02 for why that distinction matters) by tracing this packet's
-/// actual Unpack (PacketFunctor&lt;...,SCExpeditionRoleChangedPacket&gt; -&gt; FUN_3933a7a0 -&gt;
-/// FUN_395bf260). That consumer reads, in order: an 8-byte value compared against the client's own
-/// character id (to pick "Your role changed" vs "Member $1's role changed"), a string used as the "$1"
-/// member-name substitution, and a 4-byte value stored as the member's new role id - the role's DISPLAY
-/// NAME is looked up client-side from the role-policy list already cached via
-/// SCExpeditionRolePolicyListPacket, not sent here.
-///
-/// The previous version of this packet (2026-08-28) sent a full ExpeditionRolePolicy (id/role/name/10
-/// permission bools) plus a trailing "success" bool - a genuinely different, wrong shape, based on a
-/// misleading client-side construction-site match rather than this packet's real Unpack. That is very
-/// likely why "leader can't assign a rank" showed correct server-side state (confirmed via logs/MySQL in
-/// an earlier session) but never displayed correctly client-side - flagged at the time as an unresolved
-/// dead end, not fixed until now.
-/// </remarks>
 public class SCExpeditionRoleChangedPacket(uint characterId, string name, byte role)
     : GamePacket(SCOffsets.SCExpeditionRoleChangedPacket, 1)
 {

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionWarDeclarationMoney.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionWarDeclarationMoney.cs
@@ -4,17 +4,9 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// 2026-09-02: server's answer to CSRequestDeclarationMoneyPacket. Fires the client UI event
-/// EXPEDITION_WAR_DECLARATION_MONEY (native id 0x1d0) -> ShowDeclarationExpeditionWarDialog(unitId,
-/// name, money), which opens the "declare war on &lt;guild&gt; for &lt;money&gt;?" confirm dialog. Clicking OK
-/// then sends CSDeclareExpeditionWarPacket(Bc = unitId, Money = money).
+/// Server's answer to CSRequestDeclarationMoneyPacket. Opens the "declare war for &lt;money&gt;?"
+/// confirm dialog client-side; the guild name is resolved client-side from unitId, not sent here.
 /// </summary>
-/// <remarks>
-/// Opcode 0x19: from the real client's inbound dispatcher FUN_39410ef0
-/// (handler = *(registry + 8 + opcode*8)); this packet's functor sits at registry+0xd0 -> 0x19.
-/// Body from the client Unpack FUN_39aa7350: unitId via the packed-ref reader (Bc), then a u32 "money".
-/// The dialog's guild name is resolved client-side from unitId; it is NOT sent here.
-/// </remarks>
 public class SCExpeditionWarDeclarationMoney(uint bc, uint money) : GamePacket(SCOffsets.SCExpeditionWarDeclarationMoney, 1)
 {
     public override PacketStream Write(PacketStream stream)

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionWarDeclarationMoney.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionWarDeclarationMoney.cs
@@ -1,0 +1,26 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+/// <summary>
+/// 2026-09-02: server's answer to CSRequestDeclarationMoneyPacket. Fires the client UI event
+/// EXPEDITION_WAR_DECLARATION_MONEY (native id 0x1d0) -> ShowDeclarationExpeditionWarDialog(unitId,
+/// name, money), which opens the "declare war on &lt;guild&gt; for &lt;money&gt;?" confirm dialog. Clicking OK
+/// then sends CSDeclareExpeditionWarPacket(Bc = unitId, Money = money).
+/// </summary>
+/// <remarks>
+/// Opcode 0x19: from the real client's inbound dispatcher FUN_39410ef0
+/// (handler = *(registry + 8 + opcode*8)); this packet's functor sits at registry+0xd0 -> 0x19.
+/// Body from the client Unpack FUN_39aa7350: unitId via the packed-ref reader (Bc), then a u32 "money".
+/// The dialog's guild name is resolved client-side from unitId; it is NOT sent here.
+/// </remarks>
+public class SCExpeditionWarDeclarationMoney(uint bc, uint money) : GamePacket(SCOffsets.SCExpeditionWarDeclarationMoney, 1)
+{
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.WriteBc(bc);
+        stream.Write(money);
+        return stream;
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionWarKillScorePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionWarKillScorePacket.cs
@@ -13,17 +13,13 @@ namespace AAEmu.Game.Core.Packets.G2C;
 /// the scoreboard is open + periodic) and is pushed on every war kill.
 /// </summary>
 /// <remarks>
-/// Wire layout from the real client Unpack FUN_39a9a470, cross-checked against the scoreboard Lua
-/// (expedition_war.lua FillResult / GetExpeditionWarKillScore):
-///   remainTime      (i64, +0xe8)  - ms remaining (Lua divides by 1000)
-///   ourTotalKills   (u32)         - Lua ourTotalKill  -> gauge left score
-///   enemyTotalKills (u32)         - Lua enemyTotalKill -> gauge right score
-///   10x { memberId (u64), kills (u16) }   - our side, client resolves name+ability from id;
-///                                           only members with >=1 kill, rest zero-padded
+/// Wire layout:
+///   remainMs        (i64) - ms remaining
+///   ourTotalKills   (u32)
+///   enemyTotalKills (u32)
+///   10x { memberId (u64), kills (u16) }   - our side, zero-padded, only members with >=1 kill
 ///   enemyCount (u8, 0..10)
 ///   enemyCount x { memberId (u64), name (string), kills (u16), ability0..2 (u8) }
-/// Per-row "kills" comes from these arrays (Lua FillScoreInfo -> data["kills"]); retail only lists
-/// members who have scored, so both sides are filtered to WarKillsByMember > 0.
 /// </remarks>
 public class SCExpeditionWarKillScorePacket : GamePacket
 {

--- a/AAEmu.Game/Core/Packets/G2C/SCExpeditionWarKillScorePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpeditionWarKillScorePacket.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Expeditions;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+/// <summary>
+/// Guild War kill scoreboard. Opcode 0x1a. Answers CSExpeditionWarKillScorePacket (client poll while
+/// the scoreboard is open + periodic) and is pushed on every war kill.
+/// </summary>
+/// <remarks>
+/// Wire layout from the real client Unpack FUN_39a9a470, cross-checked against the scoreboard Lua
+/// (expedition_war.lua FillResult / GetExpeditionWarKillScore):
+///   remainTime      (i64, +0xe8)  - ms remaining (Lua divides by 1000)
+///   ourTotalKills   (u32)         - Lua ourTotalKill  -> gauge left score
+///   enemyTotalKills (u32)         - Lua enemyTotalKill -> gauge right score
+///   10x { memberId (u64), kills (u16) }   - our side, client resolves name+ability from id;
+///                                           only members with >=1 kill, rest zero-padded
+///   enemyCount (u8, 0..10)
+///   enemyCount x { memberId (u64), name (string), kills (u16), ability0..2 (u8) }
+/// Per-row "kills" comes from these arrays (Lua FillScoreInfo -> data["kills"]); retail only lists
+/// members who have scored, so both sides are filtered to WarKillsByMember > 0.
+/// </remarks>
+public class SCExpeditionWarKillScorePacket : GamePacket
+{
+    private readonly long _remainMs;
+    private readonly uint _ourTotal;
+    private readonly uint _enemyTotal;
+    private readonly (ulong Id, ushort Kills)[] _ourSlots;     // exactly 10, zero-padded
+    private readonly (ulong Id, string Name, ushort Kills, byte[] Ab)[] _enemyScorers; // <= 10
+
+    public SCExpeditionWarKillScorePacket(Expedition ours, Expedition enemy) : base(SCOffsets.SCExpeditionWarKillScorePacket, 1)
+    {
+        var end = ours?.WarEndsAt ?? enemy?.WarEndsAt;
+        _remainMs = end.HasValue ? Math.Max(0L, (long)(end.Value - DateTime.UtcNow).TotalMilliseconds) : 0L;
+        _ourTotal = ours?.WarKillScore ?? 0;
+        _enemyTotal = enemy?.WarKillScore ?? 0;
+
+        _ourSlots = new (ulong, ushort)[10];
+        var ourScorers = ScorersOf(ours);
+        for (var i = 0; i < ourScorers.Count && i < 10; i++)
+            _ourSlots[i] = (ourScorers[i].Id, ourScorers[i].Kills);
+
+        _enemyScorers = ScorersOf(enemy)
+            .Select(s =>
+            {
+                var m = enemy?.Members?.FirstOrDefault(x => x.CharacterId == (uint)s.Id);
+                return (s.Id, m?.Name ?? "", s.Kills, m?.Abilities ?? [0, 0, 0]);
+            })
+            .Take(10)
+            .ToArray();
+    }
+
+    private static List<(ulong Id, ushort Kills)> ScorersOf(Expedition e)
+    {
+        if (e == null)
+            return [];
+        return e.WarKillsByMember
+            .Where(kv => kv.Value > 0)
+            .OrderByDescending(kv => kv.Value)
+            .Select(kv => ((ulong)kv.Key, (ushort)Math.Min(kv.Value, ushort.MaxValue)))
+            .ToList();
+    }
+
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(_remainMs);
+        stream.Write(_ourTotal);
+        stream.Write(_enemyTotal);
+
+        for (var i = 0; i < 10; i++)
+        {
+            stream.Write((ulong)_ourSlots[i].Id);
+            stream.Write(_ourSlots[i].Kills);
+        }
+
+        stream.Write((byte)_enemyScorers.Length);
+        foreach (var (id, name, kills, ab) in _enemyScorers)
+        {
+            stream.Write((ulong)id);
+            stream.Write(name ?? "");
+            stream.Write(kills);
+            stream.Write((byte)(ab.Length > 0 ? ab[0] : 0));
+            stream.Write((byte)(ab.Length > 1 ? ab[1] : 0));
+            stream.Write((byte)(ab.Length > 2 ? ab[2] : 0));
+        }
+
+        return stream;
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCNotifyExpeditionWarResultPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCNotifyExpeditionWarResultPacket.cs
@@ -1,0 +1,25 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+/// <summary>
+/// Guild War end result. Opcode 0x1f. Fires the client's EXPEDITION_WAR_STATE event with a
+/// (state, declarer, defendant, winner) tuple -&gt; the win/lose/draw banner + result icons
+/// (expedition_war.lua). Without it the client shows every war as a draw.
+/// </summary>
+/// <remarks>
+/// Wire from client Unpack FUN_39a9a6d0: u32 id, u32 id2, u8 result (result is an optional field).
+/// Handler FUN_3933abe0 -&gt; FUN_395b72d0(mgr, id, id2, result): result == 1 makes 'id' the winner,
+/// otherwise 'id2'. result 0 = draw.
+/// </remarks>
+public class SCNotifyExpeditionWarResultPacket(uint id, uint id2, byte result) : GamePacket(SCOffsets.SCNotifyExpeditionWarResultPacket, 1)
+{
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(id);
+        stream.Write(id2);
+        stream.Write(result);
+        return stream;
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCNotifyExpeditionWarResultPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCNotifyExpeditionWarResultPacket.cs
@@ -4,15 +4,9 @@ using AAEmu.Game.Core.Network.Game;
 namespace AAEmu.Game.Core.Packets.G2C;
 
 /// <summary>
-/// Guild War end result. Opcode 0x1f. Fires the client's EXPEDITION_WAR_STATE event with a
-/// (state, declarer, defendant, winner) tuple -&gt; the win/lose/draw banner + result icons
-/// (expedition_war.lua). Without it the client shows every war as a draw.
+/// Guild War end result. Without it the client shows every war as a draw. Wire: u32 id, u32 id2,
+/// u8 result (1 = id won, 2 = id2 won, 0 = draw).
 /// </summary>
-/// <remarks>
-/// Wire from client Unpack FUN_39a9a6d0: u32 id, u32 id2, u8 result (result is an optional field).
-/// Handler FUN_3933abe0 -&gt; FUN_395b72d0(mgr, id, id2, result): result == 1 makes 'id' the winner,
-/// otherwise 'id2'. result 0 = draw.
-/// </remarks>
 public class SCNotifyExpeditionWarResultPacket(uint id, uint id2, byte result) : GamePacket(SCOffsets.SCNotifyExpeditionWarResultPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)

--- a/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
@@ -633,45 +633,22 @@ public static class SCOffsets
     public const ushort SCExpeditionApplicantAddPacket = 0x43;
     public const ushort SCExpeditionApplicantDelPacket = 0x44;
     public const ushort SCExpeditionApplicantRejectPacket = 0x46;
-    // 77 0x04d -> SCExpeditionBuffsPacket, per the user-supplied community opcode dump - no packet class
-    // existed until 2026-08-27 (see SCExpeditionBuffsPacket.cs's own doc comment for the wire-format caveat).
     public const ushort SCExpeditionBuffsPacket = 0x4D;
     public const ushort SCExpeditionBuffChangedPacket = 0x4E;
-    // 79 0x04f -> SCExpeditionBuffUnitPacket, per the user-supplied community opcode dump - see
-    // SCExpeditionBuffUnitPacket.cs's own doc comment for the wire-format RE trail (2026-08-28).
     public const ushort SCExpeditionBuffUnitPacket = 0x4F;
     public const ushort SCExpeditionCreatedPacket = 0x015; // 10.0.2.13
-    // Confirmed 0x4B via two independent sources 2026-08-13: a user-supplied community opcode dump, and
-    // separately a Ghidra RTTI/constructor-literal walk of x2game-dev.dll (SCExpeditionDescPacket's ctor writes
-    // opcode 0x4b at vtable+8, cross-checked against 3 already-known opcodes' identical code shape). No packet
-    // class exists yet - the wire field layout (guild level/exp/notice, presumably) is still unconfirmed, so
-    // this is recorded as a constant only; don't guess the struct. See aaemu-siege-castle-hero-nation memory.
     public const ushort SCExpeditionDescPacket = 0x4B;
     public const ushort SCExpeditionExpAddPacket = 0x4C;
     public const ushort SCExpeditionMemberListEndPacket = 0x24;
     public const ushort SCExpeditionPortalTimerPacket = 0x373;
-    // 2026-09-02: CORRECTED 0x68 -> 0x20. Was a community-dump value; the real client's inbound
-    // dispatcher FUN_39410ef0 does handler = *(registry + 8 + opcode*8), and this packet's functor
-    // sits at registry+0x108 -> opcode 0x20. Confirmed live via frida against x2game.dll (dispatch
-    // table walk, 23/23 expedition functors located, this one at slot 0x20).
-    public const ushort SCExpeditionRejoinFailPacket = 0x20;
+    public const ushort SCExpeditionRejoinFailPacket = 0x20; // corrected from a stale 0x68
     public const ushort SCExpeditionShopHistoriesPacket = 0x01C; // 10.0.2.13
     public const ushort SCExpeditionSummonSuggestPacket = 0x4A;
-    // 2026-09-02: CORRECTED 0x78 -> 0x18 (same reason/method as SCExpeditionRejoinFailPacket above;
-    // functor at registry+0xc8 -> opcode 0x18). This one matters: ExpeditionManager.DeclareWar/EndWar
-    // actually broadcast this packet, so the bogus 0x78 was landing on an unrelated client handler.
+    // Corrected from a stale 0x78 - EndWar/DeclareWar actually broadcast this packet, so the wrong
+    // value was landing on an unrelated client handler.
     public const ushort SCExpeditionWarStatePacket = 0x18;
-    // 2026-09-02: derived from the REAL client x2game.dll inbound dispatcher FUN_39410ef0
-    //   handler = *(registry + 8 + opcode*8)   (registry singleton @ ghidra 0x3a2f2f50)
-    // functor stored at registry+0xd0 -> opcode = (0xd0-8)/8 = 0x19. LIVE-CONFIRMED via frida
-    // (dispatch table walk, [CONFIRMED] SCExpeditionWarDeclarationMoney live=0x19).
-    // Body: WriteBc(unitId) + Write(uint money). No name string - client resolves the name from unitId.
     public const ushort SCExpeditionWarDeclarationMoney = 0x19;
-    // 2026-09-02: registry+0xd8 -> opcode 0x1a (same FUN_39410ef0 dispatcher math, frida-confirmed in
-    // the 23/23 dispatch-table walk). Answers the client's CSExpeditionWarKillScorePacket poll.
     public const ushort SCExpeditionWarKillScorePacket = 0x1A;
-    // 2026-09-03: registry+0x100 -> opcode 0x1f. Win/lose/draw result banner - without it every war
-    // shows as a draw. Body {u32 id, u32 id2, u8 result} per client Unpack FUN_39a9a6d0.
     public const ushort SCNotifyExpeditionWarResultPacket = 0x1F;
     public const ushort SCFactionCompetitionUpdatePointPacket = 0x338;
     public const ushort SCFactionImmigrateLimitDataPacket = 0x51;

--- a/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
@@ -633,15 +633,46 @@ public static class SCOffsets
     public const ushort SCExpeditionApplicantAddPacket = 0x43;
     public const ushort SCExpeditionApplicantDelPacket = 0x44;
     public const ushort SCExpeditionApplicantRejectPacket = 0x46;
+    // 77 0x04d -> SCExpeditionBuffsPacket, per the user-supplied community opcode dump - no packet class
+    // existed until 2026-08-27 (see SCExpeditionBuffsPacket.cs's own doc comment for the wire-format caveat).
+    public const ushort SCExpeditionBuffsPacket = 0x4D;
     public const ushort SCExpeditionBuffChangedPacket = 0x4E;
+    // 79 0x04f -> SCExpeditionBuffUnitPacket, per the user-supplied community opcode dump - see
+    // SCExpeditionBuffUnitPacket.cs's own doc comment for the wire-format RE trail (2026-08-28).
+    public const ushort SCExpeditionBuffUnitPacket = 0x4F;
     public const ushort SCExpeditionCreatedPacket = 0x015; // 10.0.2.13
+    // Confirmed 0x4B via two independent sources 2026-08-13: a user-supplied community opcode dump, and
+    // separately a Ghidra RTTI/constructor-literal walk of x2game-dev.dll (SCExpeditionDescPacket's ctor writes
+    // opcode 0x4b at vtable+8, cross-checked against 3 already-known opcodes' identical code shape). No packet
+    // class exists yet - the wire field layout (guild level/exp/notice, presumably) is still unconfirmed, so
+    // this is recorded as a constant only; don't guess the struct. See aaemu-siege-castle-hero-nation memory.
+    public const ushort SCExpeditionDescPacket = 0x4B;
     public const ushort SCExpeditionExpAddPacket = 0x4C;
     public const ushort SCExpeditionMemberListEndPacket = 0x24;
     public const ushort SCExpeditionPortalTimerPacket = 0x373;
-    public const ushort SCExpeditionRejoinFailPacket = 0x68;
+    // 2026-09-02: CORRECTED 0x68 -> 0x20. Was a community-dump value; the real client's inbound
+    // dispatcher FUN_39410ef0 does handler = *(registry + 8 + opcode*8), and this packet's functor
+    // sits at registry+0x108 -> opcode 0x20. Confirmed live via frida against x2game.dll (dispatch
+    // table walk, 23/23 expedition functors located, this one at slot 0x20).
+    public const ushort SCExpeditionRejoinFailPacket = 0x20;
     public const ushort SCExpeditionShopHistoriesPacket = 0x01C; // 10.0.2.13
     public const ushort SCExpeditionSummonSuggestPacket = 0x4A;
-    public const ushort SCExpeditionWarStatePacket = 0x78;
+    // 2026-09-02: CORRECTED 0x78 -> 0x18 (same reason/method as SCExpeditionRejoinFailPacket above;
+    // functor at registry+0xc8 -> opcode 0x18). This one matters: ExpeditionManager.DeclareWar/EndWar
+    // actually broadcast this packet, so the bogus 0x78 was landing on an unrelated client handler.
+    public const ushort SCExpeditionWarStatePacket = 0x18;
+    // 2026-09-02: derived from the REAL client x2game.dll inbound dispatcher FUN_39410ef0
+    //   handler = *(registry + 8 + opcode*8)   (registry singleton @ ghidra 0x3a2f2f50)
+    // functor stored at registry+0xd0 -> opcode = (0xd0-8)/8 = 0x19. LIVE-CONFIRMED via frida
+    // (dispatch table walk, [CONFIRMED] SCExpeditionWarDeclarationMoney live=0x19).
+    // Body: WriteBc(unitId) + Write(uint money). No name string - client resolves the name from unitId.
+    public const ushort SCExpeditionWarDeclarationMoney = 0x19;
+    // 2026-09-02: registry+0xd8 -> opcode 0x1a (same FUN_39410ef0 dispatcher math, frida-confirmed in
+    // the 23/23 dispatch-table walk). Answers the client's CSExpeditionWarKillScorePacket poll.
+    public const ushort SCExpeditionWarKillScorePacket = 0x1A;
+    // 2026-09-03: registry+0x100 -> opcode 0x1f. Win/lose/draw result banner - without it every war
+    // shows as a draw. Body {u32 id, u32 id2, u8 result} per client Unpack FUN_39a9a6d0.
+    public const ushort SCNotifyExpeditionWarResultPacket = 0x1F;
     public const ushort SCFactionCompetitionUpdatePointPacket = 0x338;
     public const ushort SCFactionImmigrateLimitDataPacket = 0x51;
     public const ushort SCFactionMobilizationOrderPacket = 0x3D;

--- a/AAEmu.Game/Core/Packets/G2C/SCUnitExpeditionChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCUnitExpeditionChangedPacket.cs
@@ -17,8 +17,15 @@ public class SCUnitExpeditionChangedPacket(
 
     public override PacketStream Write(PacketStream stream)
     {
+        // 2026-08-27 fix: found while chasing the SCExpeditionInvitationPacket bug (see that class's doc
+        // comment for the full RE trail) - characterId shares interface slot 0x98 with that packet's
+        // "invitor"/"playerId"-style field, confirmed (via FUN_393775e0's "playerId" at offset+0x10 followed
+        // by the next field at +0x18, an exact 8-byte gap) to be a plain 8-byte value, not the 4 bytes this
+        // was previously written as. This packet was never actually wire-verified despite underpinning the
+        // existing guild-nameplate fix in Character.cs's AddVisibleObject - likely the real reason that fix
+        // never worked live.
         stream.WriteBc(unitId);
-        stream.Write(characterId);
+        stream.Write((ulong)characterId);
         stream.Write(kicker);
         stream.Write(unitName);
         stream.Write(id);

--- a/AAEmu.Game/Core/Packets/G2C/SCUnitExpeditionChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCUnitExpeditionChangedPacket.cs
@@ -17,13 +17,7 @@ public class SCUnitExpeditionChangedPacket(
 
     public override PacketStream Write(PacketStream stream)
     {
-        // 2026-08-27 fix: found while chasing the SCExpeditionInvitationPacket bug (see that class's doc
-        // comment for the full RE trail) - characterId shares interface slot 0x98 with that packet's
-        // "invitor"/"playerId"-style field, confirmed (via FUN_393775e0's "playerId" at offset+0x10 followed
-        // by the next field at +0x18, an exact 8-byte gap) to be a plain 8-byte value, not the 4 bytes this
-        // was previously written as. This packet was never actually wire-verified despite underpinning the
-        // existing guild-nameplate fix in Character.cs's AddVisibleObject - likely the real reason that fix
-        // never worked live.
+        // characterId is a plain 8-byte value, not 4 bytes.
         stream.WriteBc(unitId);
         stream.Write((ulong)characterId);
         stream.Write(kicker);

--- a/AAEmu.Game/GameData/ExpeditionBuffGameData.cs
+++ b/AAEmu.Game/GameData/ExpeditionBuffGameData.cs
@@ -9,10 +9,9 @@ using Microsoft.Data.Sqlite;
 namespace AAEmu.Game.GameData;
 
 /// <summary>
-/// Guild prestige-shop buffs, loaded from <c>expedition_buffs</c> (one row per perk category, e.g. "PVE
-/// damage bonus") and <c>expedition_buff_grades</c> (purchasable tiers within a category - cost in
-/// Contribution Points, optional item cost, minimum guild level). 2026-08-27: confirmed via direct
-/// compact.sqlite3 lookup, no dedicated C# model existed for either table before this.
+/// Guild prestige-shop buffs, loaded from <c>expedition_buffs</c> (one row per perk category) and
+/// <c>expedition_buff_grades</c> (purchasable tiers within a category - cost in Contribution Points,
+/// optional item cost, minimum guild level).
 /// </summary>
 [GameData]
 public class ExpeditionBuffGameData : Singleton<ExpeditionBuffGameData>, IGameDataLoader
@@ -88,20 +87,11 @@ public class ExpeditionBuffGameData : Singleton<ExpeditionBuffGameData>, IGameDa
 
     /// <summary>
     /// Maps a purchased grade to the actual stat bonus every online guild member should receive.
-    /// 2026-08-28: expedition_buff_grades has no buff/skill-id column to key off (confirmed via direct
-    /// schema dump) - the only place the real numbers live is each grade's own "desc" text, e.g.
-    /// "힘/지능/민첩/정신/체력 + 8". These formulas are transcribed directly from that text (verified against
-    /// every grade row for each category, not guessed), not reverse-engineered from an external mapping.
-    /// Categories left unimplemented on purpose, because no existing UnitAttribute models them without
-    /// misapplying the bonus to the wrong mechanic:
-    ///  - buff 1 (PVE damage %) - only MeleeDamageMul/RangedDamageMul/SpellDamageMul exist, all-damage not
-    ///    PVE-only; applying them would wrongly buff PVP too.
-    ///  - buff 2 (guild summon-member headcount) and 14 (portal-scroll max stack) are capacity caps for
-    ///    unrelated features, not Unit stats at all.
-    ///  - buff 3 ("기다림의 기운" reduction) and buff 4 (flat Attack/Spell/Heal power) have no matching
-    ///    flat attribute in this codebase's UnitAttribute enum.
-    ///  - buff 8/9's second component (sprint-only speed, glide speed) has no attribute either - only
-    ///    their move-speed/swim-speed halves are applied below.
+    /// expedition_buff_grades has no buff/skill-id column to key off - these formulas are transcribed
+    /// from each grade row's own "desc" text.
+    /// TODO: buffs 1-4 and 14, and part of 8/9, are intentionally unimplemented - no existing
+    /// UnitAttribute models them without misapplying the bonus to the wrong mechanic (e.g. buff 1's
+    /// "PVE damage" would need to be all-damage, wrongly buffing PVP too).
     /// </summary>
     public static IEnumerable<(UnitAttribute Attribute, UnitModifierType ModifierType, long Value)> GetBonusEffects(uint buffId, byte grade)
     {
@@ -184,12 +174,7 @@ public class ExpeditionBuffGrade
     /// <summary>Minimum guild level required to purchase this specific grade.</summary>
     public uint ExpeditionLevelId { get; set; }
 
-    /// <summary>
-    /// 2026-09-02: `expedition_buff_grades.housing` (28 of 93 rows, the higher tiers of most categories) was a
-    /// real shipped-data column never read anywhere - confirmed via direct schema dump before this. The
-    /// client's own buff-shop tooltip (expedition_management_infomation_sub_view.lua's
-    /// "expedition_buff_get_condition_tooltip_housing" string) already advertises this as a real acquisition
-    /// requirement, so it needed enforcing, not just displaying. See ExpeditionManager.TryPurchaseBuffGrade.
-    /// </summary>
+    /// <summary>True when this grade requires the guild to already have its Guild Residence placed.
+    /// See ExpeditionManager.TryPurchaseBuffGrade.</summary>
     public bool Housing { get; set; }
 }

--- a/AAEmu.Game/GameData/ExpeditionBuffGameData.cs
+++ b/AAEmu.Game/GameData/ExpeditionBuffGameData.cs
@@ -1,0 +1,195 @@
+using AAEmu.Commons.Utils;
+using AAEmu.Game.GameData.Framework;
+using AAEmu.Game.Models.Game.Expeditions;
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Utils.DB;
+
+using Microsoft.Data.Sqlite;
+
+namespace AAEmu.Game.GameData;
+
+/// <summary>
+/// Guild prestige-shop buffs, loaded from <c>expedition_buffs</c> (one row per perk category, e.g. "PVE
+/// damage bonus") and <c>expedition_buff_grades</c> (purchasable tiers within a category - cost in
+/// Contribution Points, optional item cost, minimum guild level). 2026-08-27: confirmed via direct
+/// compact.sqlite3 lookup, no dedicated C# model existed for either table before this.
+/// </summary>
+[GameData]
+public class ExpeditionBuffGameData : Singleton<ExpeditionBuffGameData>, IGameDataLoader
+{
+    private Dictionary<uint, ExpeditionBuffTemplate> _buffsById = [];
+    private Dictionary<uint, List<ExpeditionBuffGrade>> _gradesByBuffId = [];
+
+    public IEnumerable<ExpeditionBuffTemplate> Buffs => _buffsById.Values;
+
+    public ExpeditionBuffTemplate GetBuff(uint buffId) => _buffsById.GetValueOrDefault(buffId);
+
+    public IReadOnlyList<ExpeditionBuffGrade> GetGrades(uint buffId) =>
+        _gradesByBuffId.TryGetValue(buffId, out var grades) ? grades : [];
+
+    public ExpeditionBuffGrade GetGrade(uint buffId, byte grade) =>
+        GetGrades(buffId).FirstOrDefault(g => g.Grade == grade);
+
+    public byte GetMaxGrade(uint buffId) => GetGrades(buffId).Count == 0 ? (byte)0 : GetGrades(buffId).Max(g => g.Grade);
+
+    public void Load(SqliteConnection connection)
+    {
+        _buffsById = [];
+        _gradesByBuffId = [];
+
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "SELECT * FROM expedition_buffs";
+            command.Prepare();
+            using var reader = new SQLiteWrapperReader(command.ExecuteReader());
+            while (reader.Read())
+            {
+                var buff = new ExpeditionBuffTemplate
+                {
+                    Id = reader.GetUInt32("id"),
+                    Name = reader.GetString("name"),
+                    DisplayOrder = reader.GetInt32("display_order", 1),
+                    ExpeditionLevelId = reader.GetUInt32("expedition_level_id", 0),
+                    Active = reader.GetBoolean("active")
+                };
+                _buffsById[buff.Id] = buff;
+            }
+        }
+
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = "SELECT * FROM expedition_buff_grades ORDER BY expedition_buff_id, grade";
+            command.Prepare();
+            using var reader = new SQLiteWrapperReader(command.ExecuteReader());
+            while (reader.Read())
+            {
+                var grade = new ExpeditionBuffGrade
+                {
+                    Id = reader.GetUInt32("id"),
+                    ExpeditionBuffId = reader.GetUInt32("expedition_buff_id"),
+                    Grade = (byte)reader.GetInt32("grade", 1),
+                    Description = reader.GetString("desc"),
+                    Contribution = reader.GetInt32("contribution", 0),
+                    ItemId = reader.GetUInt32("item_id", 0),
+                    Count = reader.GetInt32("count", 0),
+                    ExpeditionLevelId = reader.GetUInt32("expedition_level_id", 0),
+                    Housing = reader.GetBoolean("housing", false)
+                };
+                if (!_gradesByBuffId.TryGetValue(grade.ExpeditionBuffId, out var list))
+                    _gradesByBuffId[grade.ExpeditionBuffId] = list = [];
+                list.Add(grade);
+            }
+        }
+    }
+
+    public void PostLoad()
+    {
+    }
+
+    /// <summary>
+    /// Maps a purchased grade to the actual stat bonus every online guild member should receive.
+    /// 2026-08-28: expedition_buff_grades has no buff/skill-id column to key off (confirmed via direct
+    /// schema dump) - the only place the real numbers live is each grade's own "desc" text, e.g.
+    /// "힘/지능/민첩/정신/체력 + 8". These formulas are transcribed directly from that text (verified against
+    /// every grade row for each category, not guessed), not reverse-engineered from an external mapping.
+    /// Categories left unimplemented on purpose, because no existing UnitAttribute models them without
+    /// misapplying the bonus to the wrong mechanic:
+    ///  - buff 1 (PVE damage %) - only MeleeDamageMul/RangedDamageMul/SpellDamageMul exist, all-damage not
+    ///    PVE-only; applying them would wrongly buff PVP too.
+    ///  - buff 2 (guild summon-member headcount) and 14 (portal-scroll max stack) are capacity caps for
+    ///    unrelated features, not Unit stats at all.
+    ///  - buff 3 ("기다림의 기운" reduction) and buff 4 (flat Attack/Spell/Heal power) have no matching
+    ///    flat attribute in this codebase's UnitAttribute enum.
+    ///  - buff 8/9's second component (sprint-only speed, glide speed) has no attribute either - only
+    ///    their move-speed/swim-speed halves are applied below.
+    /// </summary>
+    public static IEnumerable<(UnitAttribute Attribute, UnitModifierType ModifierType, long Value)> GetBonusEffects(uint buffId, byte grade)
+    {
+        switch (buffId)
+        {
+            case 5: // 신체 강화: 힘/지능/민첩/정신/체력 + (2 + 6*grade) - matches +8/14/20/26/32/38 for grade 1-6
+                var stat = 2 + 6L * grade;
+                yield return (UnitAttribute.Str, UnitModifierType.Value, stat);
+                yield return (UnitAttribute.Dex, UnitModifierType.Value, stat);
+                yield return (UnitAttribute.Sta, UnitModifierType.Value, stat);
+                yield return (UnitAttribute.Int, UnitModifierType.Value, stat);
+                yield return (UnitAttribute.Spi, UnitModifierType.Value, stat);
+                break;
+            case 6: // 단단한 근육: 물리/마법 방어도 + (90 + 120*grade) - matches +210/330/450/570/690/810
+                var defense = 90 + 120L * grade;
+                yield return (UnitAttribute.Armor, UnitModifierType.Value, defense);
+                yield return (UnitAttribute.MagicResist, UnitModifierType.Value, defense);
+                break;
+            case 7: // 건강한 신체: 생명력/활력 + (180*grade) - matches +180..1440 across grade 1-8; applied to
+                     // both HP and MP as the closest resource-pool pair (no separate "Vitality" attribute exists)
+                var vitality = 180L * grade;
+                yield return (UnitAttribute.MaxHealth, UnitModifierType.Value, vitality);
+                yield return (UnitAttribute.MaxMana, UnitModifierType.Value, vitality);
+                break;
+            case 8: // 봄날의 산책: only the 이동속도 (move speed) half is modeled, +(0.5*grade)% - matches
+                     // 1/1.5/2/2.5/3/3.5/4%; rounded to the nearest whole percent since Bonus.Value is long
+                yield return (UnitAttribute.MoveSpeedMul, UnitModifierType.Percent, (long)Math.Round(0.5 * grade, MidpointRounding.AwayFromZero));
+                break;
+            case 9: // 자유 운동: only the 수영속도 (swim speed) half is modeled - grade-indexed since it isn't
+                     // linear (4/6/6/8/8% for grade 1-5); glide half has no attribute
+                long[] swim = [0, 4, 6, 6, 8, 8];
+                if (grade < swim.Length)
+                    yield return (UnitAttribute.SwimSpeedMul, UnitModifierType.Percent, swim[grade]);
+                break;
+            case 10: // 명예로운 생활: 명예 점수 획득률 + (2 + grade)% - matches +3/4/5/6/7/8%, applied across
+                     // every honor-gain source since there's no single generic HonorPointGainMul
+                var honor = 2L + grade;
+                yield return (UnitAttribute.HonorPointGainBattleFieldMul, UnitModifierType.Percent, honor);
+                yield return (UnitAttribute.HonorPointGainNpcKillMul, UnitModifierType.Percent, honor);
+                yield return (UnitAttribute.HonorPointGainTrialMul, UnitModifierType.Percent, honor);
+                yield return (UnitAttribute.HonorPointGainWarMul, UnitModifierType.Percent, honor);
+                yield return (UnitAttribute.HonorPointGainQuestMul, UnitModifierType.Percent, honor);
+                break;
+            case 11: // 보물 탐욕: 전리품 획득 확률 + (1 + grade)% - matches +2/3/4/5/6/7/8%
+                yield return (UnitAttribute.DropRateMul, UnitModifierType.Percent, 1L + grade);
+                break;
+            case 12: // 앞서나가는 자: 경험치 획득률 + (2*grade)% - matches +2/4/6/8/10/12/14/16%
+                yield return (UnitAttribute.ExpMul, UnitModifierType.Percent, 2L * grade);
+                break;
+            case 13: // 슬기로운 생활: 생활 점수 획득률 + (2 + grade)% - matches +3/4/5/6/7/8%
+                yield return (UnitAttribute.LivingPointGainMul, UnitModifierType.Percent, 2L + grade);
+                break;
+        }
+    }
+}
+
+public class ExpeditionBuffTemplate
+{
+    public uint Id { get; set; }
+    public string Name { get; set; }
+    public int DisplayOrder { get; set; }
+
+    /// <summary>Minimum guild level for this perk category to even appear (its grade 1 may still separately require a higher level).</summary>
+    public uint ExpeditionLevelId { get; set; }
+    public bool Active { get; set; }
+}
+
+public class ExpeditionBuffGrade
+{
+    public uint Id { get; set; }
+    public uint ExpeditionBuffId { get; set; }
+    public byte Grade { get; set; }
+    public string Description { get; set; }
+
+    /// <summary>Contribution Point cost, paid by the purchasing character (same model as the existing Guild Contribution Shop - CSBuyItemsPacket/MerchantPackKind.ItemPoint).</summary>
+    public int Contribution { get; set; }
+    public uint ItemId { get; set; }
+    public int Count { get; set; }
+
+    /// <summary>Minimum guild level required to purchase this specific grade.</summary>
+    public uint ExpeditionLevelId { get; set; }
+
+    /// <summary>
+    /// 2026-09-02: `expedition_buff_grades.housing` (28 of 93 rows, the higher tiers of most categories) was a
+    /// real shipped-data column never read anywhere - confirmed via direct schema dump before this. The
+    /// client's own buff-shop tooltip (expedition_management_infomation_sub_view.lua's
+    /// "expedition_buff_get_condition_tooltip_housing" string) already advertises this as a real acquisition
+    /// requirement, so it needed enforcing, not just displaying. See ExpeditionManager.TryPurchaseBuffGrade.
+    /// </summary>
+    public bool Housing { get; set; }
+}

--- a/AAEmu.Game/GameData/ExpeditionLevelGameData.cs
+++ b/AAEmu.Game/GameData/ExpeditionLevelGameData.cs
@@ -1,0 +1,91 @@
+using AAEmu.Commons.Utils;
+using AAEmu.Game.GameData.Framework;
+using AAEmu.Game.Models.Game.Expeditions;
+using AAEmu.Game.Utils.DB;
+
+using Microsoft.Data.Sqlite;
+
+namespace AAEmu.Game.GameData;
+
+/// <summary>
+/// Guild (Expedition) level thresholds, loaded from <c>expedition_levels</c>.
+/// </summary>
+/// <remarks>
+/// Row id doubles as the level number (contiguous from 1, total_exp 0). A level is reached
+/// automatically once its total_exp threshold is met, unless its require_item_id is non-zero, in
+/// which case exp keeps accumulating but the level itself waits for an explicit confirm
+/// (CSExpeditionLevelUpPacket, consuming the item) - same two-tier shape as HeirGameData's
+/// req_item_id gate, not independently wire-confirmed for Expedition but the column names mirror
+/// heir_levels closely enough that this is the best-effort reading rather than a guess from nothing.
+/// </remarks>
+[GameData]
+public class ExpeditionLevelGameData : Singleton<ExpeditionLevelGameData>, IGameDataLoader
+{
+    private Dictionary<uint, ExpeditionLevel> _levelsById = [];
+
+    public uint MaxLevel { get; private set; }
+
+    public ExpeditionLevel GetLevel(uint level) => _levelsById.GetValueOrDefault(level);
+
+    /// <summary>
+    /// Advances <paramref name="currentLevel"/> as far as <paramref name="totalExp"/> allows without
+    /// requiring an item, stopping at the first level that needs an explicit level-up confirm.
+    /// </summary>
+    public uint GetAutoLevelForExp(uint currentLevel, long totalExp)
+    {
+        var level = currentLevel;
+        while (true)
+        {
+            var next = GetLevel(level + 1);
+            if (next == null || next.RequireItemId != 0 || totalExp < next.TotalExp)
+                return level;
+            level++;
+        }
+    }
+
+    /// <summary>
+    /// The next level, only when its exp threshold is already met and it requires an explicit
+    /// confirm (i.e. a non-zero require_item_id).
+    /// </summary>
+    public bool TryGetLevelUpRequirement(uint currentLevel, long totalExp, out ExpeditionLevel requirement)
+    {
+        requirement = null;
+        var next = GetLevel(currentLevel + 1);
+        if (next == null || next.RequireItemId == 0 || totalExp < next.TotalExp)
+            return false;
+
+        requirement = next;
+        return true;
+    }
+
+    public void Load(SqliteConnection connection)
+    {
+        _levelsById = [];
+
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT * FROM expedition_levels";
+        command.Prepare();
+        using var reader = new SQLiteWrapperReader(command.ExecuteReader());
+        while (reader.Read())
+        {
+            var level = new ExpeditionLevel
+            {
+                Id = reader.GetUInt32("id"),
+                TotalExp = reader.GetInt64("total_exp", 0),
+                DailyExp = reader.GetInt64("daily_exp", 0),
+                MemberLimit = reader.GetInt32("member_limit", 0),
+                SummonLimit = reader.GetInt32("summon_limit", 0),
+                RequireItemId = reader.GetUInt32("require_item_id", 0),
+                RequireItemAmount = reader.GetInt32("require_item_amount", 0),
+                DailyContributionPoint = reader.GetInt32("daily_contribution_point", 0),
+                PortalPointLimit = reader.GetInt32("portal_point_limit", 0)
+            };
+            _levelsById[level.Id] = level;
+        }
+    }
+
+    public void PostLoad()
+    {
+        MaxLevel = _levelsById.Count == 0 ? 0 : _levelsById.Keys.Max();
+    }
+}

--- a/AAEmu.Game/GameData/ExpeditionLevelGameData.cs
+++ b/AAEmu.Game/GameData/ExpeditionLevelGameData.cs
@@ -15,8 +15,7 @@ namespace AAEmu.Game.GameData;
 /// automatically once its total_exp threshold is met, unless its require_item_id is non-zero, in
 /// which case exp keeps accumulating but the level itself waits for an explicit confirm
 /// (CSExpeditionLevelUpPacket, consuming the item) - same two-tier shape as HeirGameData's
-/// req_item_id gate, not independently wire-confirmed for Expedition but the column names mirror
-/// heir_levels closely enough that this is the best-effort reading rather than a guess from nothing.
+/// req_item_id gate.
 /// </remarks>
 [GameData]
 public class ExpeditionLevelGameData : Singleton<ExpeditionLevelGameData>, IGameDataLoader

--- a/AAEmu.Game/GameData/HousingGameData.cs
+++ b/AAEmu.Game/GameData/HousingGameData.cs
@@ -407,12 +407,9 @@ public class HousingGameData : Singleton<HousingGameData>, IGameDataLoader
     }
 
     /// <summary>
-    /// housings.id 830/831/832 ("드높은 기상의 [녹색/붉은/푸른] 깃발 저택" - Green/Red/Blue Flag Residence of
-    /// High Spirit, category_id 36, item_housings 564/565/566), confirmed 2026-08-27 via direct compact.sqlite3
-    /// lookup - no dedicated game-data table exists for this set, so it's hardcoded here. A universal per-guild
-    /// clubhouse, entirely unrelated to castle/dominion territory ownership - category 36 maps to
-    /// housing_group_categories rows for groups 1/8/17 (the ordinary continent housing groups), so no special
-    /// zone unlock is needed, only the guild-membership + one-per-guild gate in HousingManager.Build.
+    /// housings.id 830/831/832 (Green/Red/Blue Flag Residence of High Spirit) - a universal per-guild
+    /// clubhouse placeable in ordinary continent housing zones, unrelated to castle/dominion territory
+    /// ownership. No dedicated game-data table exists for this set, so it's hardcoded here.
     /// </summary>
     private static readonly HashSet<uint> ExpeditionResidenceTemplateIds = [830, 831, 832];
 

--- a/AAEmu.Game/GameData/HousingGameData.cs
+++ b/AAEmu.Game/GameData/HousingGameData.cs
@@ -407,6 +407,18 @@ public class HousingGameData : Singleton<HousingGameData>, IGameDataLoader
     }
 
     /// <summary>
+    /// housings.id 830/831/832 ("드높은 기상의 [녹색/붉은/푸른] 깃발 저택" - Green/Red/Blue Flag Residence of
+    /// High Spirit, category_id 36, item_housings 564/565/566), confirmed 2026-08-27 via direct compact.sqlite3
+    /// lookup - no dedicated game-data table exists for this set, so it's hardcoded here. A universal per-guild
+    /// clubhouse, entirely unrelated to castle/dominion territory ownership - category 36 maps to
+    /// housing_group_categories rows for groups 1/8/17 (the ordinary continent housing groups), so no special
+    /// zone unlock is needed, only the guild-membership + one-per-guild gate in HousingManager.Build.
+    /// </summary>
+    private static readonly HashSet<uint> ExpeditionResidenceTemplateIds = [830, 831, 832];
+
+    public bool IsExpeditionResidenceTemplate(uint templateId) => ExpeditionResidenceTemplateIds.Contains(templateId);
+
+    /// <summary>
     /// Gets data for the item for a housing decoration
     /// </summary>
     /// <param name="decoDesignId"></param>

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -2414,6 +2414,66 @@ public partial class Character : Unit, ICharacter
         return ChangeAAPoint(aaPointLocation, SlotType.None, amount, itemTaskType);
     }
 
+    /// <summary>
+    /// Charges <paramref name="price"/> in the currency a content table names, reporting the shortfall to
+    /// the player. Returns false without taking anything when the balance is short or the currency is one
+    /// this server does not handle, so callers can treat it as a checked reservation and bail out before
+    /// mutating anything else.
+    /// </summary>
+    /// <param name="currencyId">A <see cref="ContentCurrencyType"/>, as content tables store it.</param>
+    /// <param name="autoUseAaPoint">
+    /// The player's "use AA points" choice, sent with the request. Gold prices are paid from AA points
+    /// instead of coin when it is set.
+    /// </param>
+    public bool TryPayCurrency(uint currencyId, long price, bool autoUseAaPoint, ItemTaskType itemTaskType)
+    {
+        if (price < 0)
+        {
+            SendErrorMessage(ErrorMessageType.Invalid);
+            return false;
+        }
+
+        if (price == 0)
+            return true;
+
+        switch ((ContentCurrencyType)currencyId)
+        {
+            case ContentCurrencyType.Gold:
+            case ContentCurrencyType.GoldWithAaPoint:
+                return autoUseAaPoint
+                    ? SubtractAAPoint(SlotType.Inventory, price, itemTaskType)
+                    : SubtractMoney(SlotType.Inventory, price, itemTaskType);
+            case ContentCurrencyType.AaPoint:
+                return SubtractAAPoint(SlotType.Inventory, price, itemTaskType);
+            case ContentCurrencyType.HonorPoint:
+                if (HonorPoint < price)
+                {
+                    SendErrorMessage(ErrorMessageType.NotEnoughHonorPoint);
+                    return false;
+                }
+                ChangeGamePoints(GamePointKind.Honor, (int)-price);
+                return true;
+            case ContentCurrencyType.LivingPoint:
+                if (VocationPoint < price)
+                {
+                    SendErrorMessage(ErrorMessageType.NotEnoughLivingPoint);
+                    return false;
+                }
+                ChangeGamePoints(GamePointKind.Vocation, (int)-price);
+                return true;
+            case ContentCurrencyType.ContributionPoint:
+                if (Expedition?.GetMember(this)?.ContributionPoint < price)
+                {
+                    SendErrorMessage(ErrorMessageType.NotEnoughRequiredItem);
+                    return false;
+                }
+                return ExpeditionManager.Instance.TryChangeContributionPoints(this, (int)-price, false);
+            default:
+                SendErrorMessage(ErrorMessageType.Invalid);
+                return false;
+        }
+    }
+
     public void ChangeLabor(short change, int actabilityId)
     {
         var actabilityChange = 0;
@@ -3813,6 +3873,42 @@ public partial class Character : Unit, ICharacter
         if (this.Transform.StickyParent != null)
             character.SendPacket(new SCHungPacket(this.ObjId,this.Transform.StickyParent.GameObject.ObjId));
         */
+
+        // Same gap as faction above, previously missing entirely: SCUnitStatePacket carries no
+        // guild id, and SCUnitExpeditionChangedPacket only ever fires on a live join/leave/kick -
+        // so an observer who starts watching a character that was ALREADY in a guild before this
+        // observer logged in never learned the guild id at all, leaving the nameplate tag blank
+        // until the guild had its next membership change. This was the likely remaining cause
+        // behind the guild-nameplate bug beyond the mid-session-creation gap fixed earlier.
+        if (Expedition != null)
+            character.SendPacket(new SCUnitExpeditionChangedPacket(
+                ObjId, Id, "", Name ?? "", 0, (uint)Expedition.Id, false));
+
+        // Guild War: the client marks enemy-guild units as war targets only when it processes
+        // SCExpeditionWarStatePacket (FUN_395ba9f0 walks the currently-loaded unit set and tags
+        // each unit whose guild id == the enemy guild). A unit unloaded on a zone change / range
+        // exit comes back untagged (green) because the tag isn't in its spawn data. Re-push the
+        // war state when the two come into view of each other so both clients re-walk and re-tag.
+        // Both directions are sent - although "this unit visible to the observing character" is
+        // guaranteed to fire here, the reverse pairing may not, which otherwise leaves one client
+        // showing the enemy green (observed live: Pny red for Wuerstl but not vice versa).
+        // Idempotent; only fires between two guilds actually at war.
+        if (Expedition != null && character.Expedition != null &&
+            Expedition.IsAtWar && !Expedition.IsProtected && !character.Expedition.IsProtected &&
+            Expedition.WarEnemyExpeditionId == (uint)character.Expedition.Id &&
+            character.Expedition.WarEnemyExpeditionId == (uint)Expedition.Id)
+        {
+            var enemyExp = character.Expedition;
+            var until = Helpers.UnixTime(enemyExp.WarEndsAt ?? enemyExp.WarProtectedUntil ?? DateTime.UtcNow);
+            var myUntil = Helpers.UnixTime(Expedition.WarEndsAt ?? Expedition.WarProtectedUntil ?? DateTime.UtcNow);
+            // observer's client: tag this unit's guild as the enemy
+            character.SendPacket(new SCExpeditionWarStatePacket(
+                (int)enemyExp.Id, (int)Expedition.Id, true, until, false));
+            // this unit's own client: tag the observer's guild as the enemy
+            SendPacket(new SCExpeditionWarStatePacket(
+                (int)Expedition.Id, (int)enemyExp.Id, true, myUntil, false));
+        }
+
         base.AddVisibleObject(character);
     }
 

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -3874,25 +3874,16 @@ public partial class Character : Unit, ICharacter
             character.SendPacket(new SCHungPacket(this.ObjId,this.Transform.StickyParent.GameObject.ObjId));
         */
 
-        // Same gap as faction above, previously missing entirely: SCUnitStatePacket carries no
-        // guild id, and SCUnitExpeditionChangedPacket only ever fires on a live join/leave/kick -
-        // so an observer who starts watching a character that was ALREADY in a guild before this
-        // observer logged in never learned the guild id at all, leaving the nameplate tag blank
-        // until the guild had its next membership change. This was the likely remaining cause
-        // behind the guild-nameplate bug beyond the mid-session-creation gap fixed earlier.
+        // An observer who starts watching a character already in a guild before the observer logged
+        // in never learns the guild id otherwise, leaving the nameplate tag blank.
         if (Expedition != null)
             character.SendPacket(new SCUnitExpeditionChangedPacket(
                 ObjId, Id, "", Name ?? "", 0, (uint)Expedition.Id, false));
 
-        // Guild War: the client marks enemy-guild units as war targets only when it processes
-        // SCExpeditionWarStatePacket (FUN_395ba9f0 walks the currently-loaded unit set and tags
-        // each unit whose guild id == the enemy guild). A unit unloaded on a zone change / range
-        // exit comes back untagged (green) because the tag isn't in its spawn data. Re-push the
-        // war state when the two come into view of each other so both clients re-walk and re-tag.
-        // Both directions are sent - although "this unit visible to the observing character" is
-        // guaranteed to fire here, the reverse pairing may not, which otherwise leaves one client
-        // showing the enemy green (observed live: Pny red for Wuerstl but not vice versa).
-        // Idempotent; only fires between two guilds actually at war.
+        // A unit unloaded on a zone change/range exit loses its enemy-guild (red/attackable) tag, since
+        // that tag isn't part of its spawn data - re-push the war state when the two come into view of
+        // each other so both clients re-tag. Both directions are sent since only one is guaranteed to
+        // fire here. Idempotent; only fires between two guilds actually at war.
         if (Expedition != null && character.Expedition != null &&
             Expedition.IsAtWar && !Expedition.IsProtected && !character.Expedition.IsProtected &&
             Expedition.WarEnemyExpeditionId == (uint)character.Expedition.Id &&

--- a/AAEmu.Game/Models/Game/Char/CharacterCombat.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterCombat.cs
@@ -80,6 +80,7 @@ public partial class Character
             {
                 enemy.HostileFactionKills++;
                 AwardPvpHonor(enemy, victimZone, conflictData, zoneState);
+                ExpeditionManager.Instance.RegisterWarKill(enemy, this);
 
                 // Mark victim as PvP death (prevents Weakened Body debuff on temple-revive)
                 DiedInPvp = true;

--- a/AAEmu.Game/Models/Game/Expeditions/Expedition.cs
+++ b/AAEmu.Game/Models/Game/Expeditions/Expedition.cs
@@ -1,9 +1,15 @@
-﻿using AAEmu.Game.Core.Managers;
+﻿using System.Linq;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Faction;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.StaticValues;
 using MySql.Data.MySqlClient;
 
 namespace AAEmu.Game.Models.Game.Expeditions;
@@ -14,6 +20,68 @@ public class Expedition : SystemFaction
 
     public List<ExpeditionMember> Members { get; set; } = [];
     public List<ExpeditionRolePolicy> Policies { get; set; } = [];
+
+    /// <summary>Guild level shown in the info panel - not tied to any progression system yet, starts at 1.</summary>
+    public uint Level { get; set; } = 1;
+    public uint Exp { get; set; }
+    public string Notice { get; set; } = string.Empty;
+
+    /// <summary>House.Id of this guild's placed Guild Residence (item_housings designs 830/831/832), or 0 if none placed yet - one per guild regardless of color/design.</summary>
+    public uint ResidenceHouseId { get; set; }
+
+    /// <summary>Recruitment-board interest bitmask shown as icons in the info panel and set via CSExpeditionInterestUpatePacket (X2Faction:SetMyExpeditionInterest). Carried by SCExpeditionDescPacket's "interest" field - previously always hardcoded to 0 since nothing could set it.</summary>
+    public short Interest { get; set; }
+
+    /// <summary>Highest purchased grade per expedition_buffs.id (prestige-shop perks), keyed by expedition_buff_id. Loaded from/persisted to expedition_buff_purchases.</summary>
+    public Dictionary<uint, byte> PurchasedBuffGrades { get; set; } = [];
+
+    /// <summary>
+    /// Guild-level pooled prestige shown in the overview panel and checked by the prestige-shop
+    /// affordability gate - computed live as the sum of every member's own ContributionPoint rather than
+    /// a separately persisted field, so it can never drift out of sync with the member list.
+    /// </summary>
+    public uint TotalContributionPoint
+    {
+        get
+        {
+            var total = Members.Sum(m => (long)m.ContributionPoint);
+            return (uint)Math.Clamp(total, 0, uint.MaxValue);
+        }
+    }
+
+    /// <summary>
+    /// Guild War state (2026-09-02: CSDeclareExpeditionWarPacket was a fully-parsed no-op stub - declaring
+    /// war never did anything). Protection is a single blanket flag, not paired to a specific enemy -
+    /// matches the client's own model (X2Faction:GetExpeditionWarState/GetMyExpeditionProtectionTime carry
+    /// no enemy id at all). It covers two real sources: the 48h cooldown after a war ends, and the "정전
+    /// 협정서"/Ceasefire Agreement item (item 52121, use_skill_id 31460 -> special effect
+    /// protection_for_expedition) - see ProtectionForExpedition.cs, which was a declared-but-empty TODO
+    /// stub found while chasing why a declared war "had no effect" (the target guild had used the item).
+    /// </summary>
+    public uint WarEnemyExpeditionId { get; set; }
+    public DateTime? WarDeclaredAt { get; set; }
+    /// <summary>While the war is active this is the scheduled end date; once it ends this is cleared.</summary>
+    public DateTime? WarEndsAt { get; set; }
+    /// <summary>Blanket "cannot declare or be declared upon" deadline - post-war cooldown or Ceasefire item.</summary>
+    public DateTime? WarProtectedUntil { get; set; }
+    /// <summary>Kills credited to this expedition's members against the current/last war's enemy.</summary>
+    public uint WarKillScore { get; set; }
+
+    /// <summary>Per-member kill breakdown for the current war (characterId -> kills). In-memory only,
+    /// reset at DeclareWar - a mid-war restart keeps WarKillScore but loses this breakdown. Drives the
+    /// per-row "kills" column of the war scoreboard (SCExpeditionWarKillScorePacket).</summary>
+    public Dictionary<uint, uint> WarKillsByMember { get; } = new();
+
+    /// <summary>True on the guild that DECLARED the current war, false on the guild that was declared
+    /// upon. Set at DeclareWar and persisted (was in-memory only until a Greptile review caught that a
+    /// World restart mid-war lost it, defaulting BOTH sides to false and making both eligible for the
+    /// post-war protection that should only ever go to the declared-upon guild). Only the declared-upon
+    /// guild gets post-war protection.</summary>
+    public bool WarIsDeclarer { get; set; }
+
+    public bool IsAtWar => WarEndsAt.HasValue && WarEndsAt.Value > DateTime.UtcNow;
+
+    public bool IsProtected => WarProtectedUntil.HasValue && WarProtectedUntil.Value > DateTime.UtcNow;
 
     public bool isDisbanded { get; set; } = false;
 
@@ -35,6 +103,58 @@ public class Expedition : SystemFaction
 
         SendPacket(new SCExpeditionMemberStatusChangedPacket(member, 0));
         ChatManager.Instance.GetGuildChat(this).JoinChannel(character);
+        ApplyBuffBonuses(character);
+    }
+
+    /// <summary>
+    /// Recomputes one member's prestige-shop buff stat bonuses from <see cref="PurchasedBuffGrades"/> and
+    /// pushes a fresh UnitState so the client's character sheet reflects them immediately. 2026-08-28: this
+    /// is the actual effect application - TryPurchaseBuffGrade previously only tracked/persisted the
+    /// purchase and resynced the shop UI, nothing ever touched the member's stats.
+    /// </summary>
+    /// <remarks>
+    /// 2026-09-02: investigated making this live-refresh the OPEN character-info sheet (currently only
+    /// shows correctly after a relog/window reopen) - deliberately NOT done. Confirmed via the client's own
+    /// Lua (character_info.lua) that the sheet only redraws on a fixed list of named events
+    /// (UNIT_EQUIPMENT_CHANGED, LEVEL_CHANGED, ABILITY_CHANGED, BUFF_UPDATE when target=="character", etc.)
+    /// - there is no generic "stats changed" signal, and SCUnitStatePacket alone doesn't fire any of them.
+    /// Every viable trigger has an unwanted side effect for this use case: BUFF_UPDATE requires a real Buff
+    /// (would show a buff-bar icon - explicitly not wanted, this isn't meant to be a visible buff) and
+    /// ABILITY_CHANGED is fed by SCExpertLimitModifiedPacket, which is consumed by the real actability
+    /// management window (ability_change.lua, confirmed via a 10-file Lua reference check) - sending a
+    /// synthetic actability entry through it to fake the event risks showing wrong data in that real,
+    /// player-facing panel. Both were prototyped and reverted. Stats apply correctly and are visible after
+    /// a relog or closing/reopening the sheet in the meantime - not a data bug, just not instantaneous.
+    /// </remarks>
+    public void ApplyBuffBonuses(Character character)
+    {
+        character.Bonuses[Buffs.ExpeditionBonusesIndex] = [];
+        foreach (var (buffId, grade) in PurchasedBuffGrades)
+        {
+            foreach (var (attribute, modifierType, value) in ExpeditionBuffGameData.GetBonusEffects(buffId, grade))
+            {
+                var template = new BonusTemplate { Attribute = attribute, ModifierType = modifierType, Value = value };
+                character.AddBonus(Buffs.ExpeditionBonusesIndex, new Bonus { Template = template, Value = value });
+            }
+        }
+        character.SendPacket(new SCUnitStatePacket(character));
+        // SCUnitState alone updates the client's cached Max Hp/Mp (the sheet's denominator) but does NOT
+        // redraw the visible HP/MP bar - that only happens on SCUnitPointsPacket, per the same two-packet
+        // pattern Character.ApplyLevelUpBenefits already uses for the exact same "max stat changed" case.
+        // Current Hp/Mp are unchanged here (buffs raise the ceiling, not a free refill), just re-sent so
+        // the bar redraws against the new max.
+        character.BroadcastPacket(new SCUnitPointsPacket(character.ObjId, character.Hp, character.Mp), true);
+    }
+
+    /// <summary>Called after a buff purchase changes <see cref="PurchasedBuffGrades"/> - every online member's stats need the new total, not just the purchaser's.</summary>
+    public void ApplyBuffBonusesToAllOnline()
+    {
+        foreach (var member in Members)
+        {
+            var character = WorldManager.Instance.GetCharacterById(member.CharacterId);
+            if (character != null)
+                ApplyBuffBonuses(character);
+        }
     }
 
     public void OnCharacterLogout(Character character)
@@ -147,12 +267,24 @@ public class Expedition : SystemFaction
                 command.Transaction = transaction;
 
                 command.CommandText =
-                    "REPLACE INTO expeditions(`id`,`owner`,`owner_name`,`name`,`mother`,`created_at`) VALUES (@id, @owner, @owner_name, @name, @mother, @created_at)";
+                    "REPLACE INTO expeditions(`id`,`owner`,`owner_name`,`name`,`mother`,`level`,`exp`,`notice`,`residence_house_id`,`interest`,`war_enemy_expedition_id`,`war_declared_at`,`war_protected_until`,`war_ends_at`,`war_kill_score`,`war_is_declarer`,`created_at`) " +
+                    "VALUES (@id, @owner, @owner_name, @name, @mother, @level, @exp, @notice, @residence_house_id, @interest, @war_enemy_expedition_id, @war_declared_at, @war_protected_until, @war_ends_at, @war_kill_score, @war_is_declarer, @created_at)";
                 command.Parameters.AddWithValue("@id", this.Id);
                 command.Parameters.AddWithValue("@owner", this.OwnerId);
                 command.Parameters.AddWithValue("@owner_name", this.OwnerName);
                 command.Parameters.AddWithValue("@name", this.Name);
                 command.Parameters.AddWithValue("@mother", this.MotherId);
+                command.Parameters.AddWithValue("@level", this.Level);
+                command.Parameters.AddWithValue("@exp", this.Exp);
+                command.Parameters.AddWithValue("@notice", this.Notice);
+                command.Parameters.AddWithValue("@residence_house_id", this.ResidenceHouseId);
+                command.Parameters.AddWithValue("@interest", this.Interest);
+                command.Parameters.AddWithValue("@war_enemy_expedition_id", this.WarEnemyExpeditionId);
+                command.Parameters.AddWithValue("@war_declared_at", (object)this.WarDeclaredAt ?? DBNull.Value);
+                command.Parameters.AddWithValue("@war_protected_until", (object)this.WarProtectedUntil ?? DBNull.Value);
+                command.Parameters.AddWithValue("@war_ends_at", (object)this.WarEndsAt ?? DBNull.Value);
+                command.Parameters.AddWithValue("@war_kill_score", this.WarKillScore);
+                command.Parameters.AddWithValue("@war_is_declarer", this.WarIsDeclarer);
                 command.Parameters.AddWithValue("@created_at", this.Created);
                 command.ExecuteNonQuery();
             }

--- a/AAEmu.Game/Models/Game/Expeditions/Expedition.cs
+++ b/AAEmu.Game/Models/Game/Expeditions/Expedition.cs
@@ -50,13 +50,9 @@ public class Expedition : SystemFaction
     }
 
     /// <summary>
-    /// Guild War state (2026-09-02: CSDeclareExpeditionWarPacket was a fully-parsed no-op stub - declaring
-    /// war never did anything). Protection is a single blanket flag, not paired to a specific enemy -
-    /// matches the client's own model (X2Faction:GetExpeditionWarState/GetMyExpeditionProtectionTime carry
-    /// no enemy id at all). It covers two real sources: the 48h cooldown after a war ends, and the "정전
-    /// 협정서"/Ceasefire Agreement item (item 52121, use_skill_id 31460 -> special effect
-    /// protection_for_expedition) - see ProtectionForExpedition.cs, which was a declared-but-empty TODO
-    /// stub found while chasing why a declared war "had no effect" (the target guild had used the item).
+    /// Guild War state. Protection is a single blanket flag, not paired to a specific enemy, and covers
+    /// two sources: the post-war cooldown, and the Ceasefire Agreement item (id 52121) - see
+    /// ProtectionForExpedition.cs.
     /// </summary>
     public uint WarEnemyExpeditionId { get; set; }
     public DateTime? WarDeclaredAt { get; set; }
@@ -73,10 +69,7 @@ public class Expedition : SystemFaction
     public Dictionary<uint, uint> WarKillsByMember { get; } = new();
 
     /// <summary>True on the guild that DECLARED the current war, false on the guild that was declared
-    /// upon. Set at DeclareWar and persisted (was in-memory only until a Greptile review caught that a
-    /// World restart mid-war lost it, defaulting BOTH sides to false and making both eligible for the
-    /// post-war protection that should only ever go to the declared-upon guild). Only the declared-upon
-    /// guild gets post-war protection.</summary>
+    /// upon. Only the declared-upon guild gets post-war protection.</summary>
     public bool WarIsDeclarer { get; set; }
 
     public bool IsAtWar => WarEndsAt.HasValue && WarEndsAt.Value > DateTime.UtcNow;
@@ -108,24 +101,11 @@ public class Expedition : SystemFaction
 
     /// <summary>
     /// Recomputes one member's prestige-shop buff stat bonuses from <see cref="PurchasedBuffGrades"/> and
-    /// pushes a fresh UnitState so the client's character sheet reflects them immediately. 2026-08-28: this
-    /// is the actual effect application - TryPurchaseBuffGrade previously only tracked/persisted the
-    /// purchase and resynced the shop UI, nothing ever touched the member's stats.
+    /// pushes a fresh UnitState so the client's character sheet reflects them.
+    /// TODO: an already-open character-info sheet only picks this up after a relog/reopen, not live -
+    /// every trigger tried for a live refresh had an unwanted side effect (a spurious buff-bar icon, or
+    /// risking wrong data in the actability-management panel). Not a data bug, just not instantaneous.
     /// </summary>
-    /// <remarks>
-    /// 2026-09-02: investigated making this live-refresh the OPEN character-info sheet (currently only
-    /// shows correctly after a relog/window reopen) - deliberately NOT done. Confirmed via the client's own
-    /// Lua (character_info.lua) that the sheet only redraws on a fixed list of named events
-    /// (UNIT_EQUIPMENT_CHANGED, LEVEL_CHANGED, ABILITY_CHANGED, BUFF_UPDATE when target=="character", etc.)
-    /// - there is no generic "stats changed" signal, and SCUnitStatePacket alone doesn't fire any of them.
-    /// Every viable trigger has an unwanted side effect for this use case: BUFF_UPDATE requires a real Buff
-    /// (would show a buff-bar icon - explicitly not wanted, this isn't meant to be a visible buff) and
-    /// ABILITY_CHANGED is fed by SCExpertLimitModifiedPacket, which is consumed by the real actability
-    /// management window (ability_change.lua, confirmed via a 10-file Lua reference check) - sending a
-    /// synthetic actability entry through it to fake the event risks showing wrong data in that real,
-    /// player-facing panel. Both were prototyped and reverted. Stats apply correctly and are visible after
-    /// a relog or closing/reopening the sheet in the meantime - not a data bug, just not instantaneous.
-    /// </remarks>
     public void ApplyBuffBonuses(Character character)
     {
         character.Bonuses[Buffs.ExpeditionBonusesIndex] = [];

--- a/AAEmu.Game/Models/Game/Expeditions/ExpeditionLevel.cs
+++ b/AAEmu.Game/Models/Game/Expeditions/ExpeditionLevel.cs
@@ -1,0 +1,20 @@
+namespace AAEmu.Game.Models.Game.Expeditions;
+
+/// <summary>
+/// Row of <c>expedition_levels</c>: a guild level's cumulative exp threshold and the perks/limits
+/// that come with it. <c>Id</c> doubles as the level number (rows start at id 1, total_exp 0).
+/// </summary>
+public class ExpeditionLevel
+{
+    public uint Id { get; set; }
+    public long TotalExp { get; set; }
+    public long DailyExp { get; set; }
+    public int MemberLimit { get; set; }
+    public int SummonLimit { get; set; }
+
+    /// <summary>0 when this level is reached automatically once its exp threshold is met.</summary>
+    public uint RequireItemId { get; set; }
+    public int RequireItemAmount { get; set; }
+    public int DailyContributionPoint { get; set; }
+    public int PortalPointLimit { get; set; }
+}

--- a/AAEmu.Game/Models/Game/Expeditions/ExpeditionRolePolicy.cs
+++ b/AAEmu.Game/Models/Game/Expeditions/ExpeditionRolePolicy.cs
@@ -19,12 +19,9 @@ public class ExpeditionRolePolicy : PacketMarshaler
     public bool SiegeMaster { get; set; }
     public bool JoinSiege { get; set; }
     /// <summary>
-    /// Recovered 2026-08-13 via Ghidra deserializer trace of x2game-dev.dll - the client's role-policy struct
-    /// has 10 boolean permission flags, not 9. Missing this field made every 148-byte policy entry 1 byte
-    /// short on the wire, which - since SCExpeditionRolePolicyListPacket is a fixed-size count-prefixed array,
-    /// not length-delimited - desynced the client's packet parser for everything sent right after it
-    /// (SCExpeditionMemberListPacket in our send order), explaining why the member list also showed empty.
-    /// See aaemu-fixes-applied memory for the full recovery writeup.
+    /// The client's role-policy struct has 10 boolean permission flags, not 9. Missing this field makes
+    /// every policy entry 1 byte short on the wire, which desyncs the client's parser for everything
+    /// sent right after SCExpeditionRolePolicyListPacket (a fixed-size array, not length-delimited).
     /// </summary>
     public bool UseInstance { get; set; }
 

--- a/AAEmu.Game/Models/Game/Expeditions/ExpeditionRolePolicy.cs
+++ b/AAEmu.Game/Models/Game/Expeditions/ExpeditionRolePolicy.cs
@@ -18,6 +18,15 @@ public class ExpeditionRolePolicy : PacketMarshaler
     public bool ManagerChat { get; set; }
     public bool SiegeMaster { get; set; }
     public bool JoinSiege { get; set; }
+    /// <summary>
+    /// Recovered 2026-08-13 via Ghidra deserializer trace of x2game-dev.dll - the client's role-policy struct
+    /// has 10 boolean permission flags, not 9. Missing this field made every 148-byte policy entry 1 byte
+    /// short on the wire, which - since SCExpeditionRolePolicyListPacket is a fixed-size count-prefixed array,
+    /// not length-delimited - desynced the client's packet parser for everything sent right after it
+    /// (SCExpeditionMemberListPacket in our send order), explaining why the member list also showed empty.
+    /// See aaemu-fixes-applied memory for the full recovery writeup.
+    /// </summary>
+    public bool UseInstance { get; set; }
 
     public void Save(MySqlConnection connection, MySqlTransaction transaction)
     {
@@ -28,8 +37,8 @@ public class ExpeditionRolePolicy : PacketMarshaler
 
             command.CommandText =
                 "REPLACE INTO " +
-                "expedition_role_policies(`expedition_id`,`role`,`name`,`dominion_declare`,`invite`,`expel`,`promote`,`dismiss`, `chat`, `manager_chat`, `siege_master`, `join_siege`) " +
-                "VALUES (@expedition_id,@role,@name,@dominion_declare,@invite,@expel,@promote,@dismiss,@chat,@manager_chat,@siege_master,@join_siege)";
+                "expedition_role_policies(`expedition_id`,`role`,`name`,`dominion_declare`,`invite`,`expel`,`promote`,`dismiss`, `chat`, `manager_chat`, `siege_master`, `join_siege`, `use_instance`) " +
+                "VALUES (@expedition_id,@role,@name,@dominion_declare,@invite,@expel,@promote,@dismiss,@chat,@manager_chat,@siege_master,@join_siege,@use_instance)";
 
             command.Parameters.AddWithValue("@expedition_id", this.ExpeditionId);
             command.Parameters.AddWithValue("@role", this.Role);
@@ -43,6 +52,7 @@ public class ExpeditionRolePolicy : PacketMarshaler
             command.Parameters.AddWithValue("@manager_chat", this.ManagerChat);
             command.Parameters.AddWithValue("@siege_master", this.SiegeMaster);
             command.Parameters.AddWithValue("@join_siege", this.JoinSiege);
+            command.Parameters.AddWithValue("@use_instance", this.UseInstance);
             command.ExecuteNonQuery();
         }
     }
@@ -61,6 +71,7 @@ public class ExpeditionRolePolicy : PacketMarshaler
         ManagerChat = stream.ReadBoolean();
         SiegeMaster = stream.ReadBoolean();
         JoinSiege = stream.ReadBoolean();
+        UseInstance = stream.ReadBoolean();
     }
 
     public override PacketStream Write(PacketStream stream)
@@ -77,6 +88,7 @@ public class ExpeditionRolePolicy : PacketMarshaler
         stream.Write(ManagerChat);
         stream.Write(SiegeMaster);
         stream.Write(JoinSiege);
+        stream.Write(UseInstance);
         return stream;
     }
 
@@ -92,7 +104,8 @@ public class ExpeditionRolePolicy : PacketMarshaler
             Chat = Chat,
             ManagerChat = ManagerChat,
             SiegeMaster = SiegeMaster,
-            JoinSiege = JoinSiege
+            JoinSiege = JoinSiege,
+            UseInstance = UseInstance
         };
         return rolePolicy;
     }

--- a/AAEmu.Game/Models/Game/Units/BaseUnit.cs
+++ b/AAEmu.Game/Models/Game/Units/BaseUnit.cs
@@ -60,6 +60,11 @@ public class BaseUnit : GameObject, IBaseUnit
         var me = this as Character;
         var targetOtherOwner = target.GetOwnerCharacter();
 
+        // Guild War: declared war enemies stay mutually attackable everywhere PvP is possible,
+        // including each other's faction-protected home zones - that is the point of declaring.
+        // (The war's own protection window is already accounted for inside AreGuildWarEnemies.)
+        var guildWarEnemy = AreGuildWarEnemies(this, target);
+
         var zone = ZoneManager.Instance.GetZoneByKey(target.Transform.ZoneId);
         var zoneFactionId = zone?.FactionId ?? FactionsEnum.Neutral;
         if (zoneFactionId <= 0)
@@ -72,7 +77,7 @@ public class BaseUnit : GameObject, IBaseUnit
             zoneFaction = FactionManager.Instance.GetFaction(FactionsEnum.Neutral);
         }
         var targetMotherFaction = target.Faction?.MotherId ?? 0;
-        if (this is Character && targetMotherFaction != 0 && (targetMotherFaction == zoneFaction.MotherId || targetMotherFaction == zoneFaction.Id))
+        if (this is Character && !guildWarEnemy && targetMotherFaction != 0 && (targetMotherFaction == zoneFaction.MotherId || targetMotherFaction == zoneFaction.Id))
         {
             // Target is protected by mother zone, can't attack it
             return false;
@@ -83,7 +88,8 @@ public class BaseUnit : GameObject, IBaseUnit
             var trgIsFlagged = targetOtherOwner.Buffs.CheckBuff((uint)BuffConstants.Retribution);
 
             // Check Safe-zone
-            if (targetOtherOwner.Faction.MotherId != 0 &&
+            if (!guildWarEnemy &&
+                targetOtherOwner.Faction.MotherId != 0 &&
                 targetOtherOwner.Faction.MotherId == zoneFactionId
                 && !me.IsActivelyHostile(targetOtherOwner) &&
                 !trgIsFlagged)
@@ -138,7 +144,35 @@ public class BaseUnit : GameObject, IBaseUnit
         return !target.Buffs.CheckBuffTag((uint)TagsEnum.Stealth);
     }
 
-    public RelationState GetRelationStateTo(BaseUnit unit) => this.Faction?.GetRelationState(unit.Faction) ?? RelationState.Neutral;
+    public RelationState GetRelationStateTo(BaseUnit unit)
+    {
+        // Guild War: members of two expeditions at war with each other are mutually hostile for the
+        // war's duration, overriding their normal (usually identical) faction relation.
+        if (AreGuildWarEnemies(this, unit))
+            return RelationState.Hostile;
+        return this.Faction?.GetRelationState(unit.Faction) ?? RelationState.Neutral;
+    }
+
+    /// <summary>
+    /// True when <paramref name="a"/> and <paramref name="b"/> are owned by characters whose
+    /// expeditions have declared war on each other and neither guild is currently under war
+    /// protection. Additive only - it can promote Friendly/Neutral to Hostile between exactly
+    /// these two guilds and changes nothing else. Pets/summons/siege resolve via their owner.
+    /// </summary>
+    private static bool AreGuildWarEnemies(BaseUnit a, BaseUnit b)
+    {
+        var ca = a?.GetOwnerCharacter();
+        var cb = b?.GetOwnerCharacter();
+        if (ca == null || cb == null)
+            return false;
+        var ea = ca.Expedition;
+        var eb = cb.Expedition;
+        if (ea == null || eb == null || ea.Id == eb.Id)
+            return false;
+        return ea.IsAtWar && !ea.IsProtected && !eb.IsProtected
+            && ea.WarEnemyExpeditionId == (uint)eb.Id
+            && eb.WarEnemyExpeditionId == (uint)ea.Id;
+    }
 
     public virtual void AddBonus(uint bonusIndex, Bonus bonus)
     {

--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -29,6 +29,10 @@ public class Buffs : IBuffs
     public const uint GearBonusesIndex = 1;
     private const uint FirstBuffIndex = GearBonusesIndex + 1;
 
+    // 2026-08-28: reserved fixed slot for guild prestige-shop buff bonuses (see Expedition.ApplyBuffBonuses)
+    // - was unused (only 0 and 1 were ever reserved), so this doesn't need the FirstBuffIndex bump above.
+    public const uint ExpeditionBonusesIndex = 0;
+
     // ReSharper disable once ChangeFieldTypeToSystemThreadingLock
     private readonly object _lock = new();
     private uint _nextIndex;

--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -29,8 +29,7 @@ public class Buffs : IBuffs
     public const uint GearBonusesIndex = 1;
     private const uint FirstBuffIndex = GearBonusesIndex + 1;
 
-    // 2026-08-28: reserved fixed slot for guild prestige-shop buff bonuses (see Expedition.ApplyBuffBonuses)
-    // - was unused (only 0 and 1 were ever reserved), so this doesn't need the FirstBuffIndex bump above.
+    // Reserved fixed slot for guild prestige-shop buff bonuses (see Expedition.ApplyBuffBonuses).
     public const uint ExpeditionBonusesIndex = 0;
 
     // ReSharper disable once ChangeFieldTypeToSystemThreadingLock

--- a/AAEmu.Game/Models/Tasks/Expeditions/ExpeditionWarEndTask.cs
+++ b/AAEmu.Game/Models/Tasks/Expeditions/ExpeditionWarEndTask.cs
@@ -1,0 +1,13 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.StaticValues;
+
+namespace AAEmu.Game.Models.Tasks.Expeditions;
+
+/// <summary>Fires when a guild war's scheduled duration runs out - see ExpeditionManager.EndWar.</summary>
+public class ExpeditionWarEndTask(FactionsEnum expeditionId) : Task
+{
+    public override void Execute()
+    {
+        ExpeditionManager.Instance.EndWar(expeditionId);
+    }
+}

--- a/AAEmu.Game/Scripts/Commands/EndGuildProtection.cs
+++ b/AAEmu.Game/Scripts/Commands/EndGuildProtection.cs
@@ -1,0 +1,49 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Utils.Scripts;
+
+namespace AAEmu.Game.Scripts.Commands;
+
+/// <summary>
+/// GM command: clear a guild's war protection (post-war cooldown or Ceasefire item) immediately.
+/// Usage: /endgp &lt;guild name&gt;   (name may contain spaces - the rest of the line is the name)
+/// </summary>
+public class EndGuildProtection : ICommand
+{
+    public string[] CommandNames { get; set; } = ["endgp", "endguildprotection"];
+
+    public void OnLoad()
+    {
+        CommandManager.Instance.Register(CommandNames, this);
+    }
+
+    public string GetCommandLineHelp()
+    {
+        return "<guild name>";
+    }
+
+    public string GetCommandHelpText()
+    {
+        return "Clears the named guild's war protection (post-war cooldown or Ceasefire item) right now.";
+    }
+
+    public void Execute(Character character, string[] args, IMessageOutput messageOutput)
+    {
+        if (args.Length == 0)
+        {
+            CommandManager.SendDefaultHelpText(this, messageOutput);
+            return;
+        }
+
+        var guildName = string.Join(' ', args).Trim();
+        var resolved = ExpeditionManager.Instance.EndGuildProtection(guildName);
+        if (resolved == null)
+        {
+            CommandManager.SendErrorText(this, messageOutput, $"No guild named \"{guildName}\".");
+            return;
+        }
+
+        CommandManager.SendNormalText(this, messageOutput, $"{resolved}'s war protection cleared.");
+    }
+}

--- a/AAEmu.Game/Scripts/Commands/GuildExp.cs
+++ b/AAEmu.Game/Scripts/Commands/GuildExp.cs
@@ -6,8 +6,7 @@ using AAEmu.Game.Utils.Scripts;
 namespace AAEmu.Game.Scripts.Commands;
 
 /// <summary>
-/// GM command to add exp to the caller's own guild, auto-advancing its level per expedition_levels
-/// (see ExpeditionManager.AddExp, added this session for the guild-leveling feature).
+/// GM command to add exp to the caller's own guild, auto-advancing its level per expedition_levels.
 /// </summary>
 public class GuildExp : ICommand
 {

--- a/AAEmu.Game/Scripts/Commands/GuildExp.cs
+++ b/AAEmu.Game/Scripts/Commands/GuildExp.cs
@@ -1,0 +1,49 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Utils.Scripts;
+
+namespace AAEmu.Game.Scripts.Commands;
+
+/// <summary>
+/// GM command to add exp to the caller's own guild, auto-advancing its level per expedition_levels
+/// (see ExpeditionManager.AddExp, added this session for the guild-leveling feature).
+/// </summary>
+public class GuildExp : ICommand
+{
+    public string[] CommandNames { get; set; } = ["guildexp", "expedition_exp"];
+
+    public void OnLoad()
+    {
+        CommandManager.Instance.Register(CommandNames, this);
+    }
+
+    public string GetCommandLineHelp()
+    {
+        return "<amount>";
+    }
+
+    public string GetCommandHelpText()
+    {
+        return "Adds exp to your own guild, auto-advancing its level per expedition_levels.";
+    }
+
+    public void Execute(Character character, string[] args, IMessageOutput messageOutput)
+    {
+        if (character.Expedition == null)
+        {
+            CommandManager.SendErrorText(this, messageOutput, "You are not in a guild.");
+            return;
+        }
+
+        if (args.Length == 0 || !uint.TryParse(args[0], out var amount) || amount == 0)
+        {
+            CommandManager.SendErrorText(this, messageOutput, "Usage: /guildexp <amount>");
+            return;
+        }
+
+        ExpeditionManager.Instance.AddExp(character.Expedition, amount);
+        CommandManager.SendNormalText(this, messageOutput,
+            $"{character.Expedition.Name} is now level {character.Expedition.Level} ({character.Expedition.Exp} exp).");
+    }
+}

--- a/AAEmu.Game/Scripts/Commands/GuildPrestige.cs
+++ b/AAEmu.Game/Scripts/Commands/GuildPrestige.cs
@@ -1,0 +1,64 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Utils.Scripts;
+
+namespace AAEmu.Game.Scripts.Commands;
+
+/// <summary>
+/// GM command to add guild contribution/prestige points to a guild member (self, current target, or
+/// by name), via ExpeditionManager.TryChangeContributionPoints - the same path CashShop/item-purchase
+/// contribution spends already use, so it persists and broadcasts the same way real gains do.
+/// </summary>
+public class GuildPrestige : ICommand
+{
+    public string[] CommandNames { get; set; } = ["guildprestige", "contribution"];
+
+    public void OnLoad()
+    {
+        CommandManager.Instance.Register(CommandNames, this);
+    }
+
+    public string GetCommandLineHelp()
+    {
+        return "(target) <amount>";
+    }
+
+    public string GetCommandHelpText()
+    {
+        return "Adds guild contribution/prestige points to a guild member (self, current target, or by name).";
+    }
+
+    public void Execute(Character character, string[] args, IMessageOutput messageOutput)
+    {
+        if (args.Length == 0)
+        {
+            CommandManager.SendDefaultHelpText(this, messageOutput);
+            return;
+        }
+
+        var targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstArg);
+
+        if (targetPlayer.Expedition == null)
+        {
+            CommandManager.SendErrorText(this, messageOutput, $"{targetPlayer.Name} is not in a guild.");
+            return;
+        }
+
+        if (args.Length <= firstArg || !int.TryParse(args[firstArg], out var amount) || amount == 0)
+        {
+            CommandManager.SendErrorText(this, messageOutput, "Usage: /guildprestige (target) <amount>");
+            return;
+        }
+
+        if (!ExpeditionManager.Instance.TryChangeContributionPoints(targetPlayer, amount, amount > 0))
+        {
+            CommandManager.SendErrorText(this, messageOutput, "Failed to change contribution points.");
+            return;
+        }
+
+        var newTotal = targetPlayer.Expedition.GetMember(targetPlayer)?.ContributionPoint ?? 0;
+        CommandManager.SendNormalText(this, messageOutput, $"{targetPlayer.Name}'s guild contribution is now {newTotal}.");
+    }
+}

--- a/AAEmu.Game/Scripts/Commands/GuildResidence.cs
+++ b/AAEmu.Game/Scripts/Commands/GuildResidence.cs
@@ -1,0 +1,65 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Utils.Scripts;
+
+namespace AAEmu.Game.Scripts.Commands;
+
+/// <summary>
+/// GM command to force-demolish the caller's guild Residence, since the client's own demolish button
+/// never appears (the whole Residence info panel is gated client-side on a cache value that's never
+/// populated - see the guild Residence display-bug thread) - there is currently no other way to test
+/// placing a fresh Residence without this.
+/// </summary>
+public class GuildResidence : ICommand
+{
+    public string[] CommandNames { get; set; } = ["guildresidence", "residence"];
+
+    public void OnLoad()
+    {
+        CommandManager.Instance.Register(CommandNames, this);
+    }
+
+    public string GetCommandLineHelp()
+    {
+        return "demolish";
+    }
+
+    public string GetCommandHelpText()
+    {
+        return "Force-demolishes your guild's Residence (workaround for the client's missing demolish button).";
+    }
+
+    public void Execute(Character character, string[] args, IMessageOutput messageOutput)
+    {
+        if (args.Length == 0 || args[0] != "demolish")
+        {
+            CommandManager.SendDefaultHelpText(this, messageOutput);
+            return;
+        }
+
+        var expedition = character.Expedition;
+        if (expedition == null)
+        {
+            CommandManager.SendErrorText(this, messageOutput, $"{character.Name} is not in a guild.");
+            return;
+        }
+
+        if (expedition.ResidenceHouseId == 0)
+        {
+            CommandManager.SendErrorText(this, messageOutput, $"{expedition.Name} has no Residence placed.");
+            return;
+        }
+
+        var house = HousingManager.Instance.GetHouseById(expedition.ResidenceHouseId);
+        if (house == null)
+        {
+            CommandManager.SendErrorText(this, messageOutput, $"Residence house id {expedition.ResidenceHouseId} not found - clearing the stale reference.");
+            expedition.ResidenceHouseId = 0;
+            return;
+        }
+
+        HousingManager.Instance.Demolish(character.Connection, house, false, true);
+        CommandManager.SendNormalText(this, messageOutput, $"{expedition.Name}'s Residence (house {house.Id}) demolished.");
+    }
+}

--- a/AAEmu.Game/Scripts/Commands/GuildResidence.cs
+++ b/AAEmu.Game/Scripts/Commands/GuildResidence.cs
@@ -7,9 +7,7 @@ namespace AAEmu.Game.Scripts.Commands;
 
 /// <summary>
 /// GM command to force-demolish the caller's guild Residence, since the client's own demolish button
-/// never appears (the whole Residence info panel is gated client-side on a cache value that's never
-/// populated - see the guild Residence display-bug thread) - there is currently no other way to test
-/// placing a fresh Residence without this.
+/// does not reliably appear - there is currently no other way to test placing a fresh Residence.
 /// </summary>
 public class GuildResidence : ICommand
 {

--- a/AAEmu.Game/Scripts/Commands/GuildWarEnd.cs
+++ b/AAEmu.Game/Scripts/Commands/GuildWarEnd.cs
@@ -1,0 +1,61 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Utils.Scripts;
+
+namespace AAEmu.Game.Scripts.Commands;
+
+/// <summary>
+/// GM command to stop the caller's guild's current war immediately.
+///   /gwend        - normal end: applies rewards + the 48h re-declaration protection (like a real timeout)
+///   /gwend wipe   - clears the war state on both guilds with NO rewards and NO protection, so a fresh
+///                   war can be declared right away (for testing)
+/// </summary>
+public class GuildWarEnd : ICommand
+{
+    public string[] CommandNames { get; set; } = ["gwend", "guildwarend"];
+
+    public void OnLoad()
+    {
+        CommandManager.Instance.Register(CommandNames, this);
+    }
+
+    public string GetCommandLineHelp()
+    {
+        return "[wipe]";
+    }
+
+    public string GetCommandHelpText()
+    {
+        return "Ends your guild's current war now. Add 'wipe' to clear it with no rewards/protection so you can re-declare immediately.";
+    }
+
+    public void Execute(Character character, string[] args, IMessageOutput messageOutput)
+    {
+        var expedition = character.Expedition;
+        if (expedition == null)
+        {
+            CommandManager.SendErrorText(this, messageOutput, $"{character.Name} is not in a guild.");
+            return;
+        }
+
+        if (!expedition.IsAtWar && !expedition.IsProtected)
+        {
+            CommandManager.SendErrorText(this, messageOutput, $"{expedition.Name} is not at war or protected.");
+            return;
+        }
+
+        var wipe = args.Length > 0 && args[0].Equals("wipe", System.StringComparison.OrdinalIgnoreCase);
+
+        if (wipe)
+        {
+            ExpeditionManager.Instance.WipeWar(expedition.Id);
+            CommandManager.SendNormalText(this, messageOutput, $"{expedition.Name}'s war state wiped (no rewards, no protection) - you can declare again now.");
+        }
+        else
+        {
+            ExpeditionManager.Instance.EndWar(expedition.Id);
+            CommandManager.SendNormalText(this, messageOutput, $"{expedition.Name}'s war ended now (rewards paid, 48h protection applied).");
+        }
+    }
+}

--- a/AAEmu.Game/Scripts/Commands/GuildWarTime.cs
+++ b/AAEmu.Game/Scripts/Commands/GuildWarTime.cs
@@ -1,0 +1,46 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Utils.Scripts;
+
+namespace AAEmu.Game.Scripts.Commands;
+
+/// <summary>
+/// GM command: override the guild-war duration for testing. Affects wars declared AFTER it is set;
+/// 0 restores the config value (expedition_war_duration, 1h on retail).
+/// </summary>
+public class GuildWarTime : ICommand
+{
+    public string[] CommandNames { get; set; } = ["gwtime", "guildwartime"];
+
+    public void OnLoad()
+    {
+        CommandManager.Instance.Register(CommandNames, this);
+    }
+
+    public string GetCommandLineHelp()
+    {
+        return "<minutes>";
+    }
+
+    public string GetCommandHelpText()
+    {
+        return "Set the guild-war duration (minutes) for wars declared from now on. 0 = use the config value (1h).";
+    }
+
+    public void Execute(Character character, string[] args, IMessageOutput messageOutput)
+    {
+        if (args.Length == 0 || !int.TryParse(args[0], out var minutes) || minutes < 0)
+        {
+            CommandManager.SendNormalText(this, messageOutput,
+                $"Guild-war duration override is currently {(ExpeditionManager.WarDurationTestMinutes > 0 ? ExpeditionManager.WarDurationTestMinutes + " min" : "off (config value)")}. Usage: /gwtime <minutes>  (0 = off)");
+            return;
+        }
+
+        ExpeditionManager.WarDurationTestMinutes = minutes;
+        CommandManager.SendNormalText(this, messageOutput,
+            minutes > 0
+                ? $"Guild-war duration override set to {minutes} minute(s) - applies to wars declared from now on."
+                : "Guild-war duration override cleared - using the config value (1h).");
+    }
+}

--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -306,8 +306,19 @@ CREATE TABLE IF NOT EXISTS `expedition_role_policies` (
   `manager_chat` tinyint(1) NOT NULL,
   `siege_master` tinyint(1) NOT NULL,
   `join_siege` tinyint(1) NOT NULL,
+  `use_instance` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`expedition_id`,`role`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Guild role settings';
+
+
+-- Guild-level prestige-shop buff purchases: which grade of each expedition_buffs/expedition_buff_grades
+-- row (game data, shipped in compact.sqlite3) a guild has purchased. 0/no row = not purchased at all.
+CREATE TABLE IF NOT EXISTS `expedition_buff_purchases` (
+  `expedition_id` int unsigned NOT NULL,
+  `expedition_buff_id` int unsigned NOT NULL COMMENT 'expedition_buffs.id (game data)',
+  `grade` tinyint unsigned NOT NULL DEFAULT '0' COMMENT 'highest purchased expedition_buff_grades.grade for this buff',
+  PRIMARY KEY (`expedition_id`, `expedition_buff_id`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Guild-level prestige-shop buff purchases';
 
 
 CREATE TABLE IF NOT EXISTS `expeditions` (
@@ -316,6 +327,17 @@ CREATE TABLE IF NOT EXISTS `expeditions` (
   `owner_name` varchar(128) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
   `name` varchar(128) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL,
   `mother` int NOT NULL,
+  `level` int unsigned NOT NULL DEFAULT '1',
+  `exp` int unsigned NOT NULL DEFAULT '0',
+  `notice` varchar(800) NOT NULL DEFAULT '',
+  `residence_house_id` int unsigned NOT NULL DEFAULT '0' COMMENT 'Guild Residence house id, 0 = none placed',
+  `interest` smallint NOT NULL DEFAULT '0' COMMENT 'recruitment-board interest tag bitmask',
+  `war_enemy_expedition_id` int unsigned NOT NULL DEFAULT '0',
+  `war_declared_at` datetime NULL DEFAULT NULL,
+  `war_protected_until` datetime NULL DEFAULT NULL,
+  `war_ends_at` datetime NULL DEFAULT NULL,
+  `war_kill_score` int unsigned NOT NULL DEFAULT '0',
+  `war_is_declarer` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Guilds';

--- a/SQL/updates/2026-08-13_aaemu_game_expedition_level.sql
+++ b/SQL/updates/2026-08-13_aaemu_game_expedition_level.sql
@@ -1,0 +1,5 @@
+USE aaemu_game;
+
+ALTER TABLE `expeditions` ADD COLUMN `level` INT UNSIGNED NOT NULL DEFAULT '1' AFTER `mother`;
+ALTER TABLE `expeditions` ADD COLUMN `exp` INT UNSIGNED NOT NULL DEFAULT '0' AFTER `level`;
+ALTER TABLE `expeditions` ADD COLUMN `notice` VARCHAR(800) NOT NULL DEFAULT '' AFTER `exp`;

--- a/SQL/updates/2026-08-13_aaemu_game_expedition_role_use_instance.sql
+++ b/SQL/updates/2026-08-13_aaemu_game_expedition_role_use_instance.sql
@@ -1,0 +1,3 @@
+USE aaemu_game;
+
+ALTER TABLE `expedition_role_policies` ADD COLUMN `use_instance` TINYINT(1) NOT NULL DEFAULT '0' AFTER `join_siege`;

--- a/SQL/updates/2026-08-27_aaemu_game_expedition_buffs.sql
+++ b/SQL/updates/2026-08-27_aaemu_game_expedition_buffs.sql
@@ -1,0 +1,14 @@
+USE aaemu_game;
+
+-- Guild prestige-shop buffs: which grade of each expedition_buffs/expedition_buff_grades row (game data,
+-- shipped in compact.sqlite3) a guild has purchased. 0/no row = not purchased at all. Paid for the same
+-- way the existing Guild Contribution Shop (CSBuyItemsPacket, MerchantPackKind.ItemPoint) already spends
+-- Contribution Points - straight from the PURCHASING CHARACTER's own contribution_point balance via
+-- ExpeditionManager.TryChangeContributionPoints, not a separate pooled/guild-bank currency - but the
+-- unlocked grade itself applies guild-wide, hence tracked per-expedition here rather than per-character.
+CREATE TABLE IF NOT EXISTS `expedition_buff_purchases` (
+  `expedition_id` int unsigned NOT NULL,
+  `expedition_buff_id` int unsigned NOT NULL COMMENT 'expedition_buffs.id (game data)',
+  `grade` tinyint unsigned NOT NULL DEFAULT '0' COMMENT 'highest purchased expedition_buff_grades.grade for this buff',
+  PRIMARY KEY (`expedition_id`, `expedition_buff_id`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Guild-level prestige-shop buff purchases';

--- a/SQL/updates/2026-08-27_aaemu_game_expedition_interest.sql
+++ b/SQL/updates/2026-08-27_aaemu_game_expedition_interest.sql
@@ -1,0 +1,6 @@
+USE aaemu_game;
+
+-- Recruitment-board "interest" tag bitmask shown as icons in the guild info panel and set via
+-- CSExpeditionInterestUpatePacket (X2Faction:SetMyExpeditionInterest) - carried by SCExpeditionDescPacket's
+-- "interest" field, previously always hardcoded to 0 since nothing could set it.
+ALTER TABLE `expeditions` ADD COLUMN `interest` SMALLINT NOT NULL DEFAULT '0' AFTER `residence_house_id`;

--- a/SQL/updates/2026-08-27_aaemu_game_expedition_residence.sql
+++ b/SQL/updates/2026-08-27_aaemu_game_expedition_residence.sql
@@ -1,0 +1,6 @@
+USE aaemu_game;
+
+-- Guild Residence: a universal per-guild clubhouse (item_housings designs 830/831/832, "Green/Red/Blue
+-- Flag Residence of High Spirit"), unrelated to castle/dominion territory ownership - any guild may place
+-- exactly one, in any normal housing zone. 0 = no residence placed yet.
+ALTER TABLE `expeditions` ADD COLUMN `residence_house_id` INT UNSIGNED NOT NULL DEFAULT '0' AFTER `notice`;

--- a/SQL/updates/2026-09-02_aaemu_game_expedition_war.sql
+++ b/SQL/updates/2026-09-02_aaemu_game_expedition_war.sql
@@ -1,0 +1,16 @@
+USE aaemu_game;
+
+-- Guild War: CSDeclareExpeditionWarPacket was a fully-parsed no-op stub - X2Faction:DeclareExpeditionWar
+-- (and the whole guild-vs-guild war flow) never got any server-side reaction ("declare war does nothing").
+-- War state is tracked per-expedition (each side sees its own war against `war_enemy_expedition_id`) so it
+-- survives independently of the other side's row on reload/disband.
+ALTER TABLE `expeditions` ADD COLUMN `war_enemy_expedition_id` INT UNSIGNED NOT NULL DEFAULT '0' AFTER `interest`;
+ALTER TABLE `expeditions` ADD COLUMN `war_declared_at` DATETIME NULL DEFAULT NULL AFTER `war_enemy_expedition_id`;
+ALTER TABLE `expeditions` ADD COLUMN `war_protected_until` DATETIME NULL DEFAULT NULL AFTER `war_declared_at`;
+ALTER TABLE `expeditions` ADD COLUMN `war_ends_at` DATETIME NULL DEFAULT NULL AFTER `war_protected_until`;
+ALTER TABLE `expeditions` ADD COLUMN `war_kill_score` INT UNSIGNED NOT NULL DEFAULT '0' AFTER `war_ends_at`;
+-- Was in-memory only (set at DeclareWar, never persisted), so a World restart during an active war lost
+-- which side had declared - both expeditions' WarIsDeclarer then defaulted to false, and EndWar's
+-- declarer/defender split (only the defender gets post-war protection) came out wrong for every war that
+-- happened to be running across a restart.
+ALTER TABLE `expeditions` ADD COLUMN `war_is_declarer` TINYINT(1) NOT NULL DEFAULT '0' AFTER `war_kill_score`;

--- a/SQL/updates/2026-09-02_aaemu_game_expedition_war.sql
+++ b/SQL/updates/2026-09-02_aaemu_game_expedition_war.sql
@@ -9,8 +9,3 @@ ALTER TABLE `expeditions` ADD COLUMN `war_declared_at` DATETIME NULL DEFAULT NUL
 ALTER TABLE `expeditions` ADD COLUMN `war_protected_until` DATETIME NULL DEFAULT NULL AFTER `war_declared_at`;
 ALTER TABLE `expeditions` ADD COLUMN `war_ends_at` DATETIME NULL DEFAULT NULL AFTER `war_protected_until`;
 ALTER TABLE `expeditions` ADD COLUMN `war_kill_score` INT UNSIGNED NOT NULL DEFAULT '0' AFTER `war_ends_at`;
--- Was in-memory only (set at DeclareWar, never persisted), so a World restart during an active war lost
--- which side had declared - both expeditions' WarIsDeclarer then defaulted to false, and EndWar's
--- declarer/defender split (only the defender gets post-war protection) came out wrong for every war that
--- happened to be running across a restart.
-ALTER TABLE `expeditions` ADD COLUMN `war_is_declarer` TINYINT(1) NOT NULL DEFAULT '0' AFTER `war_kill_score`;

--- a/SQL/updates/2026-09-04_aaemu_game_war_is_declarer.sql
+++ b/SQL/updates/2026-09-04_aaemu_game_war_is_declarer.sql
@@ -10,13 +10,33 @@ USE aaemu_game;
 -- which side had declared - both expeditions' WarIsDeclarer then defaulted to false, and EndWar's
 -- declarer/defender split (only the defender gets post-war protection) came out wrong for every war that
 -- happened to be running across a restart.
-ALTER TABLE `expeditions` ADD COLUMN `war_is_declarer` TINYINT(1) NOT NULL DEFAULT '0' AFTER `war_kill_score`;
+--
+-- Guarded (IF NOT EXISTS check, not a plain ALTER) because a server that ran the earlier revision of the
+-- 2026-09-02 file already has this column - an unconditional ADD COLUMN would hard-fail with a duplicate
+-- column error on those servers and abort startup. The cleanup UPDATE only runs inside that same
+-- not-yet-added branch: if the column already existed, any active wars on it already have real,
+-- server-produced declarer data (from having run the fixed code since), so there is nothing to clear.
+DROP PROCEDURE IF EXISTS `aaemu_migrate_war_is_declarer`;
 
--- There is no source of truth to reconstruct who declared a war that was already active before this
--- column existed (war_declared_at is set identically on both sides). Rather than leave such a war with
--- both sides defaulted to war_is_declarer=false - which would grant post-war protection to BOTH guilds
--- instead of just the defender - clear its in-flight war state so stale/unknown data can't be acted on.
--- Participants can simply redeclare.
-UPDATE `expeditions`
-SET `war_enemy_expedition_id` = 0, `war_declared_at` = NULL, `war_protected_until` = NULL, `war_ends_at` = NULL, `war_kill_score` = 0
-WHERE `war_enemy_expedition_id` != 0;
+CREATE PROCEDURE `aaemu_migrate_war_is_declarer`()
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM `INFORMATION_SCHEMA`.`COLUMNS`
+        WHERE `TABLE_SCHEMA` = DATABASE() AND `TABLE_NAME` = 'expeditions' AND `COLUMN_NAME` = 'war_is_declarer'
+    ) THEN
+        ALTER TABLE `expeditions` ADD COLUMN `war_is_declarer` TINYINT(1) NOT NULL DEFAULT '0' AFTER `war_kill_score`;
+
+        -- There is no source of truth to reconstruct who declared a war that was already active before
+        -- this column existed (war_declared_at is set identically on both sides). Rather than leave such
+        -- a war with both sides defaulted to war_is_declarer=false - which would grant post-war
+        -- protection to BOTH guilds instead of just the defender - clear its in-flight war state so
+        -- stale/unknown data can't be acted on. Participants can simply redeclare.
+        UPDATE `expeditions`
+        SET `war_enemy_expedition_id` = 0, `war_declared_at` = NULL, `war_protected_until` = NULL, `war_ends_at` = NULL, `war_kill_score` = 0
+        WHERE `war_enemy_expedition_id` != 0;
+    END IF;
+END;
+
+CALL `aaemu_migrate_war_is_declarer`();
+
+DROP PROCEDURE IF EXISTS `aaemu_migrate_war_is_declarer`;

--- a/SQL/updates/2026-09-04_aaemu_game_war_is_declarer.sql
+++ b/SQL/updates/2026-09-04_aaemu_game_war_is_declarer.sql
@@ -1,0 +1,22 @@
+USE aaemu_game;
+
+-- war_is_declarer was originally folded into 2026-09-02_aaemu_game_expedition_war.sql, but
+-- MySqlDatabaseUpdater tracks completed updates by filename only (not content), so any server that had
+-- already run an earlier revision of that file (before this column was added) would have it marked
+-- installed and silently never pick up war_is_declarer at all. Split into its own file so it always
+-- applies regardless of when a server first ran the original migration.
+--
+-- Was in-memory only (set at DeclareWar, never persisted), so a World restart during an active war lost
+-- which side had declared - both expeditions' WarIsDeclarer then defaulted to false, and EndWar's
+-- declarer/defender split (only the defender gets post-war protection) came out wrong for every war that
+-- happened to be running across a restart.
+ALTER TABLE `expeditions` ADD COLUMN `war_is_declarer` TINYINT(1) NOT NULL DEFAULT '0' AFTER `war_kill_score`;
+
+-- There is no source of truth to reconstruct who declared a war that was already active before this
+-- column existed (war_declared_at is set identically on both sides). Rather than leave such a war with
+-- both sides defaulted to war_is_declarer=false - which would grant post-war protection to BOTH guilds
+-- instead of just the defender - clear its in-flight war state so stale/unknown data can't be acted on.
+-- Participants can simply redeclare.
+UPDATE `expeditions`
+SET `war_enemy_expedition_id` = 0, `war_declared_at` = NULL, `war_protected_until` = NULL, `war_ends_at` = NULL, `war_kill_score` = 0
+WHERE `war_enemy_expedition_id` != 0;


### PR DESCRIPTION
Builds out the guild (Expedition) system on top of client_version/zone-10.0.2_r575: declare-war handshake, in-world PvP (enemy recolor + attackability + kill registration), a live kill scoreboard, per-guild win/lost banners plus a server-wide result announcement, post-war protection, guild residence (place/demolish/tax), guild prestige-shop buffs, and guild leveling/experience. Also fixes several previously-unregistered but fully-implemented C2G/G2C guild packets, corrects three real client opcodes (SCExpeditionWarStatePacket, SCExpeditionRejoinFailPacket, plus the new SCExpeditionWarDeclarationMoney), and closes a gap where the guild-invite flow never checked the inviter's and invitee's top-level faction (Nuia/Haranya/Pirate) matched.

- ExpeditionManager: DeclareWar/EndWar handshake, RegisterWarKill, kill-score tracking (Expedition.WarKillsByMember), post-war protection (defender-only, 1h), Invite's new same-faction check, TryChangeContributionPoints already reused by guild buffs/residence refunds.
- BaseUnit/Character/CharacterCombat: war enemies are mutually hostile and attackable everywhere (including normally-protected zones), a war-kill is registered on PvP death, and a war participant's client re-learns both the guild nameplate tag and the enemy war-state tag whenever a unit becomes visible (previously blank until the next membership/war-state change).
- New SC/CS packets for the declare-war money confirm step, the kill scoreboard, and the win/lose/draw result notification, plus corrected opcodes for SCExpeditionWarStatePacket/SCExpeditionRejoinFailPacket - see each packet's own doc comment.
- GameNetwork: registers CSExpeditionBuffPacket/CSExpeditionBuffGradePacket/ CSExpeditionExpAddPacket/CSExpeditionInterestUpatePacket/ CSRequestDeclarationMoneyPacket/CSExpeditionLevelUpPacket and a few other guild C2G packets that were fully implemented but never wired up.
- HousingManager/HousingGameData: Guild Residence placement (one per guild), tax-info push on placement and login, and an 80%-of-shop-price Contribution Point refund on demolish.
- Features.json: flips on the client feature bits gating the guild info panel, guild-war UI, guild summon, and item-based guild rename - all of which have working server support already but were never advertised.
- GuildExp/GuildPrestige/GuildResidence/GuildWarEnd/GuildWarTime/ EndGuildProtection: GM commands used to build and verify this feature.