### PR TITLE
feat(game): fishing loop, rod charge, and vocation downgrade

### DIFF
--- a/AAEmu.Game/Core/Managers/FishSchoolManager.cs
+++ b/AAEmu.Game/Core/Managers/FishSchoolManager.cs
@@ -1,7 +1,6 @@
 ﻿using AAEmu.Commons.Utils;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.World;
-using AAEmu.Game.Models.StaticValues;
 
 using NLog;
 
@@ -23,42 +22,73 @@ public class FishSchoolManager : Singleton<FishSchoolManager>, IFishSchoolManage
 
     public void Load(WorldInstance world)
     {
-        var fishSchool = new List<Doodad>();
         Logger.Info("Loading FishSchool...");
-        var doodads = world.GetAllDoodads();
+        var fishSchool = new List<Doodad>();
+        var doodads = world?.GetAllDoodads();
         if (doodads != null)
         {
             foreach (var d in doodads)
             {
-                // ID=6447, "Freshwater Fish School", ID=6448, "Saltwater Fish School"
-                if (d.TemplateId == DoodadConstants.FreshwaterFishSchool || d.TemplateId == DoodadConstants.SaltwaterFishSchool)
+                if (FishSchoolLookup.IsSchool(d))
                     fishSchool.Add(d);
             }
-
-            lock (FishSchools)
-            {
-                if (fishSchool.Count > 0)
-                {
-                    if (!FishSchools.TryGetValue(world.Id, out var worldFishList))
-                    {
-                        worldFishList = [];
-                        FishSchools.Add(world.Id, worldFishList);
-                    }
-
-                    worldFishList.AddRange(fishSchool);
-                }
-            }
         }
+
+        lock (FishSchools)
+        {
+            var worldId = world?.Id ?? 0;
+            FishSchools[worldId] = fishSchool;
+        }
+
         Logger.Info($"Loaded {fishSchool.Count} FishSchool for world {world} ...");
+    }
+
+    public void Track(Doodad doodad)
+    {
+        if (!FishSchoolLookup.IsSchool(doodad))
+            return;
+
+        var worldId = doodad.ParentWorld?.Id ?? 0;
+        lock (FishSchools)
+        {
+            if (!FishSchools.TryGetValue(worldId, out var worldFishList))
+            {
+                worldFishList = [];
+                FishSchools[worldId] = worldFishList;
+            }
+
+            if (!worldFishList.Contains(doodad))
+                worldFishList.Add(doodad);
+        }
+    }
+
+    public void Untrack(Doodad doodad)
+    {
+        if (doodad == null)
+            return;
+
+        lock (FishSchools)
+        {
+            foreach (var worldFishList in FishSchools.Values)
+                worldFishList.Remove(doodad);
+        }
     }
 
     public List<Doodad> GetAllFishSchools()
     {
         var res = new List<Doodad>();
-        foreach (var (world, doodads) in FishSchools)
+        lock (FishSchools)
         {
-            res.AddRange(doodads);
+            foreach (var doodads in FishSchools.Values)
+            {
+                foreach (var doodad in doodads)
+                {
+                    if (FishSchoolLookup.IsPresent(doodad))
+                        res.Add(doodad);
+                }
+            }
         }
+
         return res;
     }
 }

--- a/AAEmu.Game/Core/Managers/IFishSchoolManager.cs
+++ b/AAEmu.Game/Core/Managers/IFishSchoolManager.cs
@@ -6,5 +6,7 @@ namespace AAEmu.Game.Core.Managers;
 public interface IFishSchoolManager : IInitializable
 {
     void Load(WorldInstance world);
+    void Track(Doodad doodad);
+    void Untrack(Doodad doodad);
     List<Doodad> GetAllFishSchools();
 }

--- a/AAEmu.Game/Core/Managers/RadarManager.cs
+++ b/AAEmu.Game/Core/Managers/RadarManager.cs
@@ -1,5 +1,4 @@
 ﻿using AAEmu.Commons.Utils;
-using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game;
@@ -125,8 +124,6 @@ public class RadarManager : Singleton<RadarManager>, IRadarManager
 
             foreach (var (_, entry) in Registrations)
             {
-                // TODO: Make a proper GM flag
-                var gmRangeCheck = CharacterManager.Instance.GetEffectiveAccessLevel(entry.Player) >= 100 ? 100000f : 0f;
                 if (entry.Player == null)
                     continue;
 
@@ -143,7 +140,9 @@ public class RadarManager : Singleton<RadarManager>, IRadarManager
                         if (transfer.Transform.WorldId != entry.Player.Transform.WorldId || transfer.Transform.InstanceId != entry.Player.Transform.InstanceId)
                             continue;
 
-                        if (MathUtil.CalculateDistance(entry.Player, transfer, true) <= Math.Max(entry.ShowPublicTransportRange, gmRangeCheck))
+                        if (RadarRangeRules.IsInRange(
+                                MathUtil.CalculateDistance(entry.Player, transfer, true),
+                                entry.ShowPublicTransportRange))
                         {
                             inRangeTransfers.Add(transfer);
                         }
@@ -170,7 +169,9 @@ public class RadarManager : Singleton<RadarManager>, IRadarManager
                         if (fish.Transform.WorldId != entry.Player.Transform.WorldId || fish.Transform.InstanceId != entry.Player.Transform.InstanceId)
                             continue;
 
-                        if (MathUtil.CalculateDistance(entry.Player, fish, true) <= Math.Max(entry.ShowFishSchoolRange, gmRangeCheck))
+                        if (RadarRangeRules.IsInRange(
+                                MathUtil.CalculateDistance(entry.Player, fish, true),
+                                entry.ShowFishSchoolRange))
                         {
                             inRangeFish.Add(fish);
                         }
@@ -197,7 +198,9 @@ public class RadarManager : Singleton<RadarManager>, IRadarManager
                         if (ship.Transform.WorldId != entry.Player.Transform.WorldId || ship.Transform.InstanceId != entry.Player.Transform.InstanceId)
                             continue;
 
-                        if (MathUtil.CalculateDistance(entry.Player, ship, true) <= Math.Max(entry.ShowShipTelescopeRange, gmRangeCheck))
+                        if (RadarRangeRules.IsInRange(
+                                MathUtil.CalculateDistance(entry.Player, ship, true),
+                                entry.ShowShipTelescopeRange))
                         {
                             inRangeShips.Add(ship);
                         }

--- a/AAEmu.Game/Core/Managers/RadarRangeRules.cs
+++ b/AAEmu.Game/Core/Managers/RadarRangeRules.cs
@@ -1,0 +1,11 @@
+namespace AAEmu.Game.Core.Managers;
+
+/// <summary>
+/// Finder / telescope visibility uses the registered buff range only.
+/// Access level must not widen that circle.
+/// </summary>
+public static class RadarRangeRules
+{
+    public static bool IsInRange(float distance, float range) =>
+        range > 0f && distance <= range;
+}

--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -52,8 +52,16 @@ public class CharacterManager(
     private readonly Dictionary<uint, ActabilityTemplate> _actabilities = [];
     private readonly Dictionary<uint, ActabilityCategoriesTemplate> _actabilitiesCategories = [];
     private readonly Dictionary<int, ExpertLimit> _expertLimits = [];
+    private readonly Dictionary<int, ExpertLimit> _languageExpertLimits = [];
     private readonly Dictionary<int, ExpandExpertLimit> _expandExpertLimits = [];
+    private uint _downgradeIntensifiedExpertTicketItemId;
     private readonly object _characterDeletionLock = new();
+
+    /// <summary>
+    /// <c>content_configs.downgrade_intensified_expert_ticket</c> — spent when leaving a
+    /// <see cref="ExpertLimit.UseIntensified"/> rank.
+    /// </summary>
+    public uint DowngradeIntensifiedExpertTicketItemId => _downgradeIntensifiedExpertTicketItemId;
 
     public CharacterTemplate GetTemplate(Race race, Gender gender)
     {
@@ -101,6 +109,25 @@ public class CharacterManager(
         if (_expertLimits.TryGetValue(step, out var limit))
             return limit;
         return null;
+    }
+
+    public ExpertLimit GetLanguageExpertLimit(int step)
+    {
+        if (_languageExpertLimits.TryGetValue(step, out var limit))
+            return limit;
+        return null;
+    }
+
+    public ExpertLimit GetPointCapLimit(uint actabilityId, int step)
+    {
+        if (ExpertLimitRules.UsesLanguageLadder(actabilityId))
+        {
+            var language = GetLanguageExpertLimit(0);
+            if (language != null)
+                return language;
+        }
+
+        return GetExpertLimit(step);
     }
 
     public ExpandExpertLimit GetExpandExpertLimit(int step)
@@ -356,13 +383,12 @@ public class CharacterManager(
 
             using (var command = connection.CreateCommand())
             {
-                // Actability.Step is the zero-based native expert-limit sequence. IDs are the sequence;
-                // ordering by up_limit incorrectly inserts the language-only id 32 between ids 2 and 3.
-                command.CommandText = "SELECT * FROM expert_limits ORDER BY id ASC";
+                // Shown rows only, ordered by point cap. Language-flagged rows go to their own
+                // map so they cannot sit between production ranks.
+                command.CommandText = "SELECT * FROM expert_limits ORDER BY up_limit ASC, id ASC";
                 command.Prepare();
                 using (var reader = new SQLiteWrapperReader(command.ExecuteReader()))
                 {
-                    var step = 0;
                     while (reader.Read())
                     {
                         var template = new ExpertLimit
@@ -376,9 +402,11 @@ public class CharacterManager(
                             UpPrice = reader.GetInt32("up_price"),
                             DownCurrencyId = reader.GetUInt32("down_currency_id", 0),
                             DownPrice = reader.GetInt32("down_price"),
+                            Show = reader.GetBoolean("show"),
+                            UseLanguageType = reader.GetBoolean("use_language_type"),
                             UseIntensified = reader.GetBoolean("use_intensified")
                         };
-                        _expertLimits.Add(step++, template);
+                        ExpertLimitRules.IndexShownRow(template, _expertLimits, _languageExpertLimits);
                     }
                 }
             }
@@ -393,7 +421,8 @@ public class CharacterManager(
                 while (reader.Read())
                 {
                     var expertLimitId = reader.GetUInt32("expert_limit_id");
-                    var template = _expertLimits.Values.FirstOrDefault(limit => limit.Id == expertLimitId);
+                    var template = _expertLimits.Values.FirstOrDefault(limit => limit.Id == expertLimitId)
+                        ?? _languageExpertLimits.Values.FirstOrDefault(limit => limit.Id == expertLimitId);
                     if (template == null)
                         continue;
 
@@ -422,6 +451,23 @@ public class CharacterManager(
                         _expandExpertLimits.Add(step++, template);
                     }
                 }
+            }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText =
+                    "SELECT c.value FROM content_configs c " +
+                    "JOIN enum_content_configs e ON e.id = c.id " +
+                    "WHERE e.name = 'downgrade_intensified_expert_ticket'";
+                command.Prepare();
+                var value = command.ExecuteScalar();
+                if (value == null || value == DBNull.Value)
+                    throw new InvalidDataException("Missing required content config 'downgrade_intensified_expert_ticket'.");
+
+                var ticketItemId = Convert.ToUInt32(value);
+                if (ticketItemId == 0)
+                    throw new InvalidDataException("Invalid downgrade_intensified_expert_ticket value 0.");
+                _downgradeIntensifiedExpertTicketItemId = ticketItemId;
             }
         }
 

--- a/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
@@ -2675,14 +2675,7 @@ public class DoodadManager(INonUnitObjectIdManager objectIdManager, IDoodadIdMan
             }
 
             var funcTemplate = GetFuncTemplate(func.FuncId, func.FuncType);
-            // Special handler for fake use skill id
-            if (funcTemplate is DoodadFuncFakeUse { FakeSkillId: > 0 } fakeUseTemplate && fakeUseTemplate.FakeSkillId == skillId)
-            {
-                return func;
-            }
-
-            // Special handler for use (func) skill id
-            if (funcTemplate is DoodadFuncUse { SkillId: > 0 } useTemplate && useTemplate.SkillId == skillId)
+            if (DoodadFuncIncomingSkill.TemplateAccepts(funcTemplate, skillId))
             {
                 return func;
             }

--- a/AAEmu.Game/Core/Managers/UnitManagers/ICharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/ICharacterManager.cs
@@ -18,6 +18,8 @@ public interface ICharacterManager : ILoadable
     ActabilityTemplate GetActability(uint id);
     uint GetActabilityIdByCategoryId(uint id);
     ExpertLimit GetExpertLimit(int step);
+    ExpertLimit GetLanguageExpertLimit(int step);
+    ExpertLimit GetPointCapLimit(uint actabilityId, int step);
     ExpandExpertLimit GetExpandExpertLimit(int step);
     int GetEffectiveAccessLevel(Character character);
     void Create(GameConnection connection, string name, Race race, Gender gender, uint[] bodyItems, UnitCustomModelParams customModel, AbilityType ability1, AbilityType ability2, AbilityType ability3, byte level);

--- a/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/NpcManager.cs
@@ -1036,8 +1036,8 @@ public class NpcManager(
                         var id = reader.GetUInt32("id");
                         Goods[id] = new MerchantGoods(
                             id,
-                            (MerchantPackKind)reader.GetByte("kind_id"),
-                            reader.GetUInt32("item_point_id"));
+                            (MerchantPackKind)reader.GetByte("kind_id", 0),
+                            reader.GetUInt32("item_point_id", 0));
                     }
                 }
             }
@@ -1067,7 +1067,7 @@ public class NpcManager(
                         if (currency == (ShopCurrencyType)byte.MaxValue)
                             continue;
 
-                        var overrideCost = reader.GetInt32("cost");
+                        var overrideCost = reader.GetInt32("cost", 0);
                         int? price = pack.Kind == MerchantPackKind.CustomItemPoint
                             ? overrideCost
                             : overrideCost > 0
@@ -1088,8 +1088,8 @@ public class NpcManager(
                             Grade = grade,
                             Cost = price.Value,
                             Currency = currency,
-                            PurchaseType = (MerchantPurchaseType)reader.GetByte("purchase_type_id"),
-                            PurchaseLimit = reader.GetInt32("purchase_limit")
+                            PurchaseType = (MerchantPurchaseType)reader.GetByte("purchase_type_id", 0),
+                            PurchaseLimit = reader.GetInt32("purchase_limit", 0)
                         });
                     }
                 }

--- a/AAEmu.Game/Core/Managers/World/SpawnManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SpawnManager.cs
@@ -778,10 +778,8 @@ public class SpawnManager(WorldInstance parentWorld)
                 var count = 0;
                 foreach (var spawner in DoodadSpawners.Values)
                 {
-                    // Zone takes physics ownership of each doodad World authors.
-                    var doodad = spawner.Spawn(0);
-                    if (doodad != null)
-                        WorldIntegration.RelayCreateDoodadToZone?.Invoke(doodad);
+                    // Zone Create is sent from DoodadSpawner.DoSpawn (boot and management respawn).
+                    spawner.Spawn(0);
                     count++;
                     if (count % 5000 == 0)
                         Logger.Debug($"In world {World} Doodads spawned: {count}...");
@@ -945,6 +943,19 @@ public class SpawnManager(WorldInstance parentWorld)
         {
             Despawns.Add(obj);
         }
+    }
+
+    /// <summary>
+    /// Zone was already told to retire this mirror. Force-remove it if ZWRemoveNpc never comes.
+    /// </summary>
+    public void ScheduleZoneDespawnAck(Npc npc)
+    {
+        if (npc == null)
+            return;
+
+        npc.ZoneDespawnSignaled = true;
+        npc.Despawn = DateTime.UtcNow.AddSeconds(ZoneDespawnAckSeconds);
+        AddDespawn(npc);
     }
 
     /// <summary>

--- a/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
@@ -9,6 +9,7 @@ using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj.Static;
 using AAEmu.Game.Models.Game.Items.Templates;
 using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Skills.SkillControllers;
 using AAEmu.Game.Models.Game.Units;
@@ -327,6 +328,10 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
             // Clear the local cooldown after failures that should immediately unlock the slot.
             if (skillResult is SkillResult.TooFarRange or SkillResult.TooCloseRange or SkillResult.NoTarget
                 or SkillResult.InvalidSource or SkillResult.Failure)
+                character.ResetSkillCooldown(skillId, true);
+            else if (skillResult == SkillResult.CooldownTime &&
+                     SportFishCombat.IsFishingHoldSkill(
+                         template.TargetType, SkillManager.Instance.GetSkillTags(skillId)))
                 character.ResetSkillCooldown(skillId, true);
             Logger.Warn("ZoneAuthority Use failed skillId={0} result={1} caster={2}", skillId, skillResult, casterUnit.ObjId);
             return;

--- a/AAEmu.Game/Core/Packets/C2G/CSStopCastingPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStopCastingPacket.cs
@@ -1,6 +1,8 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Skills.Effects;
+using AAEmu.Game.Models.Game.Skills.Plots.Tree;
 using AAEmu.Game.Models.Tasks.Skills;
 using AAEmu.Game;
 
@@ -31,6 +33,21 @@ public class CSStopCastingPacket() : GamePacket(CSOffsets.CSStopCastingPacket, 1
         {
             if (Connection.ActiveChar.ActivePlotState.ActiveSkill.TlId == plotTlId)
             {
+                var active = Connection.ActiveChar.ActivePlotState.ActiveSkill;
+                var template = active.Template;
+                if (template != null &&
+                    SportFishCombat.ShouldIgnoreClientStopCasting(
+                        template.Plot?.Id ?? 0,
+                        template.CastingCancelable,
+                        template.ChannelingCancelable))
+                {
+                    Logger.Debug(
+                        "StopCasting ignored rod plot tl={0} skill={1} char={2}",
+                        plotTlId, active.Id, Connection.ActiveChar.Name);
+                    RefreshIgnoredRodPlot(Connection.ActiveChar.ActivePlotState);
+                    return;
+                }
+
                 Connection.ActiveChar.ActivePlotState.RequestCancellation();
             }
             else
@@ -70,5 +87,38 @@ public class CSStopCastingPacket() : GamePacket(CSOffsets.CSStopCastingPacket, 1
             skillTask.Skill.Stop(Connection.ActiveChar);
 
         Logger.Info("StopCasting cancelled tl={0} skill={1} char={2}", tlId, skillTask.Skill.Id, Connection.ActiveChar.Name);
+    }
+
+    private void RefreshIgnoredRodPlot(PlotState state)
+    {
+        if (state?.Caster == null)
+            return;
+
+        var last = state.LastClientEvent;
+        var now = DateTime.UtcNow;
+        if (!PlotChannelingRules.ShouldRefreshPlotAfterIgnoredStop(
+                last != null,
+                state.LastIgnoredStopRefreshUtc,
+                now))
+            return;
+
+        state.LastIgnoredStopRefreshUtc = now;
+        Logger.Debug(
+            "StopCasting refreshed rod plot tl={0} event={1} skill={2} char={3}",
+            last.Tl, last.EventId, last.SkillId, Connection.ActiveChar.Name);
+        state.Caster.BroadcastPacket(
+            new SCPlotEventPacket(
+                last.Tl,
+                last.EventId,
+                last.SkillId,
+                last.Caster,
+                last.Target,
+                last.UnkId,
+                last.CastWire,
+                last.Flag,
+                0,
+                last.TargetCount,
+                channelingTime: last.ChannelWire),
+            true);
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCExpertLimitModifiedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCExpertLimitModifiedPacket.cs
@@ -3,13 +3,15 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCExpertLimitModifiedPacket(bool isUpgrade, uint id, byte step)
+public class SCExpertLimitModifiedPacket(bool isUpgrade, uint id, int point, byte step)
     : GamePacket(SCOffsets.SCExpertLimitModifiedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
+        // isUpgrade then the same pisc(id, point)+step entry as SCActability / labor-changed.
+        // A bare u32 id + step leaves the client without point and shifts the step byte.
         stream.Write(isUpgrade);
-        stream.Write(id);
+        stream.WritePisc(id, (uint)Math.Max(0, point));
         stream.Write(step);
         return stream;
     }

--- a/AAEmu.Game/Core/Packets/G2C/SCPlotEventPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCPlotEventPacket.cs
@@ -19,7 +19,8 @@ public class SCPlotEventPacket(
     byte flag,
     ulong itemId = 0L,
     byte targetUnitCount = 1,
-    byte inputDirection = 0)
+    byte inputDirection = 0,
+    ushort channelingTime = 0)
     : GamePacket(SCOffsets.SCPlotEventPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
@@ -33,7 +34,7 @@ public class SCPlotEventPacket(
         stream.WriteBc(objId);
         stream.Write(castingTime);
         stream.WriteBc(0);
-        stream.Write((ushort)0); // channeling msec wire
+        stream.Write(channelingTime);
         stream.Write(targetUnitCount);
         if (targetUnitCount > 0)
         {

--- a/AAEmu.Game/GameData/FishDetailsGameData.cs
+++ b/AAEmu.Game/GameData/FishDetailsGameData.cs
@@ -68,29 +68,15 @@ public class FishDetailsGameData : Singleton<FishDetailsGameData>, IGameDataLoad
 
     public bool TryCalculateSalePrice(BigFish fish, out long price)
     {
-        const float percentScale = 0.01f;
-
         price = 0;
-        if (fish == null || fish.Template == null || fish.Weight < 0 || !float.IsFinite(fish.Weight) ||
-            !TryGetMaxWeight(fish.TemplateId, out var maxWeight))
+        if (fish?.Template == null || !TryGetMaxWeight(fish.TemplateId, out var maxWeight))
             return false;
 
         var grade = ItemManager.Instance.GetGradeTemplate(fish.Grade);
-        if (grade == null || grade.RefundMultiplier < 0 || fish.Template.Refund < 0)
+        if (grade == null)
             return false;
 
-        // then the weight ratio. Values are non-negative, so floor(x + 0.5) is the exact native rule.
-        var adjustedBaseValue = grade.RefundMultiplier * percentScale * fish.Template.Refund;
-        if (!float.IsFinite(adjustedBaseValue))
-            return false;
-        var adjustedBase = (long)MathF.Floor(adjustedBaseValue + 0.5f);
-
-        var weightedValue = (float)adjustedBase * fish.Weight / maxWeight;
-        if (!float.IsFinite(weightedValue) || weightedValue < 0)
-            return false;
-
-        price = (long)MathF.Floor(weightedValue + 0.5f);
-        return true;
+        return FishSalePrice.TryCalculate(fish.Template.Refund, grade.RefundMultiplier, fish.Weight, maxWeight, out price);
     }
 
     public BigFish CreateTrophy(uint outputItemId, BigFish sourceFish)

--- a/AAEmu.Game/Models/Game/Char/CharacterActability.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterActability.cs
@@ -41,12 +41,39 @@ public class CharacterActability(Character owner)
         if (!Actabilities.TryGetValue(id, out var actability))
             return 0;
         var previousPoints = actability.Point;
-        actability.Point += point;
-
-        var template = CharacterManager.Instance.GetExpertLimit(actability.Step);
-        if (actability.Point > template.UpLimit)
-            actability.Point = template.UpLimit;
+        var template = CharacterManager.Instance.GetPointCapLimit(id, actability.Step);
+        var cap = template?.UpLimit ?? int.MaxValue;
+        actability.Point = ExpertLimitRules.AddEarnedPoints(actability.Point, point, cap);
         return actability.Point - previousPoints;
+    }
+
+    /// <summary>
+    /// GM / test helper: set points (and optional expert step) and push <see cref="SCActabilityPacket"/>.
+    /// Points are clamped to the expert-limit cap for the resulting step.
+    /// </summary>
+    public bool TrySet(uint id, int point, int? step)
+    {
+        if (!Actabilities.TryGetValue(id, out var actability))
+            return false;
+
+        if (step.HasValue)
+        {
+            var stepLimit = ExpertLimitRules.UsesLanguageLadder(id)
+                ? CharacterManager.Instance.GetLanguageExpertLimit(step.Value)
+                    ?? CharacterManager.Instance.GetExpertLimit(step.Value)
+                : CharacterManager.Instance.GetExpertLimit(step.Value);
+            if (stepLimit == null)
+                return false;
+            actability.Step = (byte)step.Value;
+        }
+
+        var template = CharacterManager.Instance.GetPointCapLimit(id, actability.Step);
+        if (template == null)
+            return false;
+
+        actability.Point = ExpertLimitRules.ClampPoints(template, point);
+        Send();
+        return true;
     }
 
     /// <summary>
@@ -59,34 +86,26 @@ public class CharacterActability(Character owner)
             return false;
         }
 
+        // Rank buttons always walk the production ladder (same index the UI uses).
         var currentTemplate = CharacterManager.Instance.GetExpertLimit(actability.Step);
-        if (currentTemplate == null)
-        {
-            Owner.SendErrorMessage(isUpgrade
-                ? ErrorMessageType.ActabilityCanUpgradeAnyMore
-                : ErrorMessageType.ActabilityCanDowngradeAnyMore);
-            return false;
-        }
-
         if (isUpgrade)
         {
-            if (actability.Point < currentTemplate.UpLimit)
-            {
-                Owner.SendErrorMessage(ErrorMessageType.ActabilityNotEnoughPoint);
-                return false;
-            }
-
             var targetStep = actability.Step + 1;
             var targetTemplate = CharacterManager.Instance.GetExpertLimit(targetStep);
-            if (targetTemplate == null)
+            var hasSlot = ExpertLimitRules.HasSelectionSlot(
+                Actabilities.Values,
+                targetTemplate,
+                targetStep,
+                Owner.ExpandedExpert,
+                actability.Template.ViewGroupId);
+            var upgradeError = ExpertLimitRules.UpgradeError(
+                currentTemplate,
+                targetTemplate,
+                actability.Point,
+                hasSlot);
+            if (upgradeError != null)
             {
-                Owner.SendErrorMessage(ErrorMessageType.ActabilityCanUpgradeAnyMore);
-                return false;
-            }
-
-            if (!HasExpertSelectionSlot(actability, targetTemplate, targetStep))
-            {
-                Owner.SendErrorMessage(ErrorMessageType.ActabilityCanUpgradeSelectionCountLimit);
+                Owner.SendErrorMessage(upgradeError.Value);
                 return false;
             }
 
@@ -97,51 +116,51 @@ public class CharacterActability(Character owner)
         }
         else
         {
-            if (actability.Step == 0)
+            var targetTemplate = actability.Step == 0
+                ? null
+                : CharacterManager.Instance.GetExpertLimit(actability.Step - 1);
+            var downgradeError = ExpertLimitRules.DowngradeError(actability.Step, currentTemplate, targetTemplate);
+            if (downgradeError != null)
             {
-                Owner.SendErrorMessage(ErrorMessageType.ActabilityCanDowngradeAnyMore);
+                Owner.SendErrorMessage(downgradeError.Value);
                 return false;
             }
 
-            var targetTemplate = CharacterManager.Instance.GetExpertLimit(actability.Step - 1);
-            if (targetTemplate == null)
+            var ticketItemId = CharacterManager.Instance.DowngradeIntensifiedExpertTicketItemId;
+            var needsTicket = ExpertLimitRules.RequiresIntensifiedDowngradeTicket(currentTemplate);
+            var hasTicket = !needsTicket || Owner.Inventory.CheckItems(
+                SlotType.Inventory, ticketItemId, ExpertLimitRules.IntensifiedDowngradeTicketCount);
+            var ticketError = ExpertLimitRules.DowngradeTicketError(currentTemplate, ticketItemId, hasTicket);
+            if (ticketError != null)
             {
-                Owner.SendErrorMessage(ErrorMessageType.ActabilityCanDowngradeAnyMore);
+                Owner.SendErrorMessage(ticketError.Value);
                 return false;
             }
 
             if (!TryPay(currentTemplate.DownCurrencyId, currentTemplate.DownPrice, autoUseAaPoint))
                 return false;
 
+            if (needsTicket)
+            {
+                var consumed = Owner.Inventory.Bag.ConsumeItem(
+                    ItemTaskType.ChangeExpertLimit,
+                    ticketItemId,
+                    ExpertLimitRules.IntensifiedDowngradeTicketCount,
+                    null);
+                if (consumed != ExpertLimitRules.IntensifiedDowngradeTicketCount)
+                {
+                    Owner.SendErrorMessage(ErrorMessageType.NotEnoughItem);
+                    return false;
+                }
+            }
+
+            // Rank is only the selected slot. Earned points stay so the same total can
+            // walk back up as long as each rank still has a free slot.
             actability.Step--;
-            actability.Point = Math.Min(actability.Point, targetTemplate.UpLimit);
         }
 
-        Owner.SendPacket(new SCExpertLimitModifiedPacket(isUpgrade, id, actability.Step));
+        Owner.SendPacket(new SCExpertLimitModifiedPacket(isUpgrade, id, actability.Point, actability.Step));
         return true;
-    }
-
-    private bool HasExpertSelectionSlot(Actability actability, ExpertLimit targetTemplate, int targetStep)
-    {
-        if (targetTemplate.UseIntensified)
-        {
-            var viewGroupId = actability.Template.ViewGroupId;
-            if (!targetTemplate.IntensifiedViewGroupLimits.TryGetValue(viewGroupId, out var groupLimit))
-                return false;
-
-            var groupCount = Actabilities.Values.Count(entry =>
-                entry.Template.CountsTowardExpertLimit &&
-                entry.Template.ViewGroupId == viewGroupId &&
-                entry.Step >= targetStep);
-            return groupCount < groupLimit;
-        }
-
-        if (targetTemplate.ExpertLimitCount == 0)
-            return true;
-
-        var selectedCount = Actabilities.Values.Count(entry =>
-            entry.Template.CountsTowardExpertLimit && entry.Step >= targetStep);
-        return selectedCount < targetTemplate.ExpertLimitCount + Owner.ExpandedExpert;
     }
 
     private bool TryPay(uint currencyId, int price, bool autoUseAaPoint)
@@ -197,21 +216,14 @@ public class CharacterActability(Character owner)
     public bool ExpandExpert()
     {
         var expand = CharacterManager.Instance.GetExpandExpertLimit(Owner.ExpandedExpert);
-        if (expand == null)
+        var hasItems = expand == null
+            || expand.ItemId == 0
+            || expand.ItemCount == 0
+            || Owner.Inventory.CheckItems(Items.SlotType.Inventory, expand.ItemId, expand.ItemCount);
+        var expandError = ExpertLimitRules.ExpandError(expand, Owner.VocationPoint, hasItems);
+        if (expandError != null)
         {
-            Owner.SendErrorMessage(ErrorMessageType.ActabilityCanUpgradeSelectionCountLimit);
-            return false;
-        }
-
-        if (expand.LifePoint > Owner.VocationPoint)
-        {
-            Owner.SendErrorMessage(ErrorMessageType.NotEnoughExpandItemAndMoney);
-            return false;
-        }
-
-        if (expand.ItemId != 0 && expand.ItemCount != 0 && !Owner.Inventory.CheckItems(Items.SlotType.Inventory, expand.ItemId, expand.ItemCount))
-        {
-            Owner.SendErrorMessage(ErrorMessageType.NotEnoughExpandItem);
+            Owner.SendErrorMessage(expandError.Value);
             return false;
         }
 

--- a/AAEmu.Game/Models/Game/Char/ExpertLimit.cs
+++ b/AAEmu.Game/Models/Game/Char/ExpertLimit.cs
@@ -11,6 +11,8 @@ public class ExpertLimit
     public int UpPrice { get; set; }
     public uint DownCurrencyId { get; set; }
     public int DownPrice { get; set; }
+    public bool Show { get; set; }
+    public bool UseLanguageType { get; set; }
     public bool UseIntensified { get; set; }
     public Dictionary<uint, byte> IntensifiedViewGroupLimits { get; } = [];
 }

--- a/AAEmu.Game/Models/Game/Char/ExpertLimitRules.cs
+++ b/AAEmu.Game/Models/Game/Char/ExpertLimitRules.cs
@@ -1,0 +1,155 @@
+using AAEmu.Game.Models.Game;
+
+namespace AAEmu.Game.Models.Game.Char;
+
+/// <summary>
+/// Pure vocation rank rules. Production and language are separate ladders; hidden rows stay off both.
+/// </summary>
+public static class ExpertLimitRules
+{
+    public static bool UsesLanguageLadder(uint actabilityId) =>
+        actabilityId is >= (uint)ActabilityType.NuianLanguage
+            and <= (uint)ActabilityType.HaranyaContinentDialect;
+
+    public static bool CountsTowardProductionSlots(uint actabilityId, bool countsTowardExpertLimit) =>
+        countsTowardExpertLimit && !UsesLanguageLadder(actabilityId);
+
+    /// <summary>
+    /// Shown rows only. Language-flagged rows get their own 0-based index so they cannot sit
+    /// between production ranks when the source table is ordered by point cap.
+    /// </summary>
+    public static void IndexShownRow(
+        ExpertLimit row,
+        IDictionary<int, ExpertLimit> production,
+        IDictionary<int, ExpertLimit> language)
+    {
+        if (row == null || !row.Show)
+            return;
+
+        var map = row.UseLanguageType ? language : production;
+        map.Add(map.Count, row);
+    }
+
+    public static int ClampPoints(ExpertLimit limit, int point)
+    {
+        if (limit == null)
+            return Math.Max(0, point);
+        return Math.Clamp(point, 0, limit.UpLimit);
+    }
+
+    /// <summary>
+    /// Earning is capped by the selected rank. Already-earned points above that cap stay put
+    /// so a downgrade only frees a slot — the total can be spent again on the way back up.
+    /// </summary>
+    public static int AddEarnedPoints(int current, int delta, int cap)
+    {
+        if (delta == 0)
+            return Math.Max(0, current);
+        if (delta < 0)
+            return Math.Max(0, current + delta);
+        if (current >= cap)
+            return current;
+        return Math.Min(cap, current + delta);
+    }
+
+    public static ErrorMessageType? UpgradeError(ExpertLimit current, ExpertLimit next, int points, bool hasSlot)
+    {
+        if (current == null)
+            return ErrorMessageType.ActabilityCanUpgradeAnyMore;
+        if (points < current.UpLimit)
+            return ErrorMessageType.ActabilityNotEnoughPoint;
+        if (next == null)
+            return ErrorMessageType.ActabilityCanUpgradeAnyMore;
+        if (!hasSlot)
+            return ErrorMessageType.ActabilityCanUpgradeSelectionCountLimit;
+        return null;
+    }
+
+    public static ErrorMessageType? DowngradeError(byte step, ExpertLimit current, ExpertLimit next)
+    {
+        if (step == 0 || current == null || next == null)
+            return ErrorMessageType.ActabilityCanDowngradeAnyMore;
+        return null;
+    }
+
+    /// <summary>
+    /// Intensified ranks (대가 and the hidden rows above it) spend
+    /// <c>downgrade_intensified_expert_ticket</c> (item 49001) to drop one step. Famed and below do not.
+    /// </summary>
+    public const int IntensifiedDowngradeTicketCount = 1;
+
+    public static bool RequiresIntensifiedDowngradeTicket(ExpertLimit current) =>
+        current is { UseIntensified: true };
+
+    public static ErrorMessageType? DowngradeTicketError(ExpertLimit current, uint ticketItemId, bool hasTicket)
+    {
+        if (!RequiresIntensifiedDowngradeTicket(current))
+            return null;
+        if (ticketItemId == 0)
+            return ErrorMessageType.Invalid;
+        if (!hasTicket)
+            return ErrorMessageType.NotEnoughItem;
+        return null;
+    }
+
+    public static ErrorMessageType? ExpandError(ExpandExpertLimit next, int vocationPoint, bool hasRequiredItems)
+    {
+        if (next == null)
+            return ErrorMessageType.ActabilityCanUpgradeAnyMore;
+        if (next.LifePoint > vocationPoint)
+            return ErrorMessageType.NotEnoughLivingPoint;
+        if (!hasRequiredItems)
+            return ErrorMessageType.NotEnoughItem;
+        return null;
+    }
+
+    /// <summary>
+    /// Slot check against the <em>next</em> rank. A zero <see cref="ExpertLimit.ExpertLimitCount"/>
+    /// is unlimited. Expanded slots add to that count except on intensified ranks, which use the
+    /// per-view-group cap only.
+    /// </summary>
+    public static bool HasSelectionSlot(
+        IEnumerable<Actability> actabilities,
+        ExpertLimit target,
+        int targetStep,
+        byte expandedExpert,
+        uint viewGroupId)
+    {
+        if (target == null)
+            return false;
+
+        if (target.UseIntensified)
+        {
+            if (!target.IntensifiedViewGroupLimits.TryGetValue(viewGroupId, out var groupLimit))
+                return false;
+
+            var groupCount = CountAtOrAbove(actabilities, targetStep, viewGroupId);
+            return groupCount < groupLimit;
+        }
+
+        if (target.ExpertLimitCount == 0)
+            return true;
+
+        var selectedCount = CountAtOrAbove(actabilities, targetStep, viewGroupId: null);
+        return selectedCount < target.ExpertLimitCount + expandedExpert;
+    }
+
+    private static int CountAtOrAbove(IEnumerable<Actability> actabilities, int targetStep, uint? viewGroupId)
+    {
+        var count = 0;
+        foreach (var entry in actabilities)
+        {
+            if (entry?.Template == null)
+                continue;
+            if (!CountsTowardProductionSlots(entry.Template.Id, entry.Template.CountsTowardExpertLimit))
+                continue;
+            if (entry.Step < targetStep)
+                continue;
+            if (viewGroupId.HasValue && entry.Template.ViewGroupId != viewGroupId.Value)
+                continue;
+            count++;
+        }
+
+        return count;
+    }
+}

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -340,6 +340,7 @@ public class Doodad : BaseUnit
     public DateTime OverridePhaseTime { get; set; } = DateTime.MinValue;
 
     private bool _deleted;
+    public bool IsDeleted => _deleted;
 
     /// <summary>
     /// Re-entrancy cap for <see cref="DoPhaseFuncs"/>. Phase graphs must settle; without this,
@@ -960,12 +961,11 @@ public class Doodad : BaseUnit
         var funcs = DoodadManager.Instance.GetFuncsForGroup(FuncGroupId);
         if (funcs == null) { return; }
 
-        // ReSharper disable once UnusedVariable
-        foreach (var func in funcs.Where(func => func.FuncType == "DoodadFuncSkillHit"))
-        {
-            // func.Use(caster, this, skillId);
+        // One Use: GetFunc picks the SkillHit whose template skill matches. Calling Use once per
+        // SkillHit row re-entered the new phase (or the first unmatched row) and skipped later
+        // chum skills in the same idle group.
+        if (funcs.Exists(func => func.FuncType == "DoodadFuncSkillHit"))
             Use(caster, skillId);
-        }
     }
 
     /// <summary>
@@ -1064,6 +1064,12 @@ public class Doodad : BaseUnit
     public override void BroadcastPacket(GamePacket packet, bool self)
     {
         base.BroadcastPacket(packet, false);
+    }
+
+    public override void Spawn()
+    {
+        base.Spawn();
+        FishSchoolManager.Instance.Track(this);
     }
 
     /// <summary>
@@ -1187,6 +1193,19 @@ public class Doodad : BaseUnit
 
         // Mark as deleted early to avoid re-entry/races (e.g. concurrent packet handlers).
         _deleted = true;
+        FishSchoolManager.Instance.Untrack(this);
+
+        // Tell Zone while Transform.ZoneId is still valid. ForUnit after RemoveObject misses
+        // doodads (they are not in the unit table), which left the Zone mesh in the water
+        // after the 30-minute school timer and never put a replacement back.
+        var zoneId = Transform?.ZoneId ?? 0;
+        if (WorldIntegration.ZoneAuthority)
+        {
+            if (zoneId != 0)
+                WorldIntegration.RelayRemoveDoodadToZoneId?.Invoke(zoneId, ObjId);
+            else
+                WorldIntegration.RelayRemoveDoodadToZone?.Invoke(ObjId);
+        }
 
         base.Delete();
         var triggersToRemove = new List<AreaTrigger>(AttachAreaTriggers);
@@ -1196,9 +1215,6 @@ public class Doodad : BaseUnit
         }
 
         AttachAreaTriggers.Clear();
-
-        if (WorldIntegration.ZoneAuthority)
-            WorldIntegration.RelayRemoveDoodadToZone?.Invoke(ObjId);
 
         // Delete associated item if expired
         if (ItemId > 0)

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadFuncIncomingSkill.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadFuncIncomingSkill.cs
@@ -1,0 +1,32 @@
+using AAEmu.Game.Models.Game.DoodadObj.Funcs;
+using AAEmu.Game.Models.Game.DoodadObj.Templates;
+
+namespace AAEmu.Game.Models.Game.DoodadObj;
+
+/// <summary>
+/// Matches an incoming skill to a doodad func when <see cref="DoodadFunc.SkillId"/> is empty
+/// and the real skill lives on the func template.
+/// </summary>
+/// <remarks>
+/// <c>doodad_funcs.func_skill_id</c> is unset on every <see cref="DoodadFuncSkillHit"/> row
+/// in 10.0.2.13 (chum, harvest hits, school count). The skill is only on
+/// <c>doodad_func_skill_hits.skill_id</c>. Without this match, <c>GetFunc</c> falls through to
+/// the first skill-less func in the phase, so only the first chum skill of a school ever
+/// advanced — squid / horse mackerel / saury / sardine never did.
+/// </remarks>
+public static class DoodadFuncIncomingSkill
+{
+    public static bool TemplateAccepts(DoodadFuncTemplate template, uint skillId)
+    {
+        if (template == null || skillId == 0)
+            return false;
+
+        return template switch
+        {
+            DoodadFuncFakeUse { FakeSkillId: > 0 } fakeUse => fakeUse.FakeSkillId == skillId,
+            DoodadFuncUse { SkillId: > 0 } use => use.SkillId == skillId,
+            DoodadFuncSkillHit { SkillId: > 0 } skillHit => skillHit.SkillId == skillId,
+            _ => false
+        };
+    }
+}

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadSpawner.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadSpawner.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 
+using AAEmu.Game;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.UnitManagers;
@@ -448,6 +449,10 @@ public class DoodadSpawner : Spawner<Doodad>
         #endregion Schedule
 
         Last.Spawn(); // initialize Doodad with the initial phase and display it on the terrain
+        // Boot used to relay Create only from SpawnAll. Management respawn (6447/6448 after
+        // DoodadFuncFinal) also comes through here and must Create on Zone or the school
+        // stays gone after the 30-minute timer.
+        WorldIntegration.RelayCreateDoodadToZone?.Invoke(Last);
 
         if (Last.Transform.WorldId != WorldManager.DefaultWorldTemplateId)
         {

--- a/AAEmu.Game/Models/Game/DoodadObj/FishSchoolLookup.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/FishSchoolLookup.cs
@@ -1,0 +1,106 @@
+using AAEmu.Game.Models.Game.DoodadObj.Funcs;
+using AAEmu.Game.Models.Game.DoodadObj.Static;
+using AAEmu.Game.Models.Game.DoodadObj.Templates;
+using AAEmu.Game.Models.Game.NPChar;
+
+namespace AAEmu.Game.Models.Game.DoodadObj;
+
+/// <summary>
+/// School-of-fish doodads are <see cref="DoodadGroupId.SportFishing"/> (group 65).
+/// Only the chummed phase carries <see cref="DoodadFuncFishSchool"/>; idle yields no spawner.
+/// </summary>
+public static class FishSchoolLookup
+{
+    public static uint SchoolGroupId => (uint)DoodadGroupId.SportFishing;
+
+    public static bool IsSchool(Doodad doodad) =>
+        doodad?.Template != null && doodad.Template.GroupId == SchoolGroupId;
+
+    /// <summary>
+    /// Radar must only list a school that is still in its world. The boot snapshot kept
+    /// deleted placements, which is why the finder showed pins over empty water.
+    /// </summary>
+    public static bool IsPresent(Doodad doodad)
+    {
+        if (!IsSchool(doodad) || doodad.IsDeleted || !doodad.IsVisible)
+            return false;
+
+        var world = doodad.ParentWorld;
+        return world != null && world.GetDoodad(doodad.ObjId) == doodad;
+    }
+
+    public static uint ReadActiveSpawnerId(
+        Doodad doodad,
+        Func<uint, string, DoodadPhaseFuncTemplate> getPhaseTemplate)
+    {
+        if (!IsSchool(doodad) || getPhaseTemplate == null || doodad.CurrentPhaseFuncs == null)
+            return 0;
+
+        foreach (var func in doodad.CurrentPhaseFuncs)
+        {
+            if (func == null)
+                continue;
+            if (getPhaseTemplate(func.FuncId, func.FuncType) is DoodadFuncFishSchool school)
+                return school.NpcSpawnerId;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Nearest chummed school to the bobber (or other origin), inside <paramref name="rangeMeters"/>.
+    /// Entries with <c>SpawnerId == 0</c> are idle and skipped.
+    /// </summary>
+    public static uint ResolveNearestSpawnerId(
+        IEnumerable<(float X, float Y, uint SpawnerId)> schools,
+        float originX,
+        float originY,
+        float rangeMeters)
+    {
+        if (schools == null || rangeMeters < 0f)
+            return 0;
+
+        uint best = 0;
+        var bestD2 = rangeMeters * rangeMeters;
+        foreach (var (x, y, spawnerId) in schools)
+        {
+            if (spawnerId == 0)
+                continue;
+            var dx = x - originX;
+            var dy = y - originY;
+            var d2 = dx * dx + dy * dy;
+            if (d2 <= bestD2)
+            {
+                bestD2 = d2;
+                best = spawnerId;
+            }
+        }
+
+        return best;
+    }
+
+    public static NpcSpawnerNpc SelectWeighted(IReadOnlyList<NpcSpawnerNpc> npcs, double rollUnitInterval)
+    {
+        if (npcs == null || npcs.Count == 0)
+            return null;
+        if (npcs.Count == 1)
+            return npcs[0];
+
+        var totalWeight = 0f;
+        foreach (var entry in npcs)
+            totalWeight += entry.Weight;
+        if (totalWeight <= 0f)
+            return npcs[0];
+
+        var roll = Math.Clamp(rollUnitInterval, 0d, 1d) * totalWeight;
+        var current = 0d;
+        foreach (var entry in npcs)
+        {
+            current += entry.Weight;
+            if (roll < current)
+                return entry;
+        }
+
+        return npcs[0];
+    }
+}

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncBuyFish.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncBuyFish.cs
@@ -1,6 +1,5 @@
-using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.GameData;
+using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj.Templates;
 using AAEmu.Game.Models.Game.Items;
@@ -22,7 +21,7 @@ public class DoodadFuncBuyFish : DoodadFuncTemplate
 
         var backpack = character.Inventory.GetEquippedBySlot(EquipmentItemSlot.Backpack);
         if (backpack is not BigFish fish || !AllowedItemIds.Contains(backpack.TemplateId) ||
-            !FishDetailsGameData.Instance.TryCalculateSalePrice(fish, out var total))
+            !FishDetailsGameData.Instance.TryCalculateSalePrice(fish, out var total) || total <= 0)
         {
             Fail(character, owner);
             return;
@@ -34,10 +33,9 @@ public class DoodadFuncBuyFish : DoodadFuncTemplate
             return;
         }
 
-        long updatedMoney;
         try
         {
-            updatedMoney = checked(character.Money + total);
+            _ = checked(character.Money + total);
         }
         catch (OverflowException)
         {
@@ -46,19 +44,24 @@ public class DoodadFuncBuyFish : DoodadFuncTemplate
             return;
         }
 
-        var removeTask = new ItemRemoveSlot(backpack);
-        if (!character.Equipment.RemoveItem(ItemTaskType.Invalid, backpack, true))
+        // Remove first (own packet). Gold is a separate money task — putting Seize and
+        // MoneyChange in the same list leaves the client wallet unchanged after the pack is gone.
+        if (!character.Equipment.RemoveItem(ItemTaskType.Fishing, backpack, true))
         {
             owner.ToNextPhase = false;
             return;
         }
 
         owner.ItemTemplateId = backpack.TemplateId;
-        character.Money = updatedMoney;
-        character.SendPacket(new SCItemTaskSuccessPacket(
-            ItemTaskType.Fishing,
-            [removeTask, new MoneyChange(total)],
-            [backpack.Id]));
+        if (!character.AddMoney(SlotType.Inventory, total, ItemTaskType.Fishing))
+        {
+            owner.ToNextPhase = false;
+            Logger.Error($"Fish sale paid {total} but the wallet update failed for {character.Name}");
+            return;
+        }
+
+        Logger.Info(
+            $"Fish stand sale {character.Name} item={backpack.TemplateId} grade={backpack.Grade} weight={fish.Weight} price={total}");
     }
 
     private static void Fail(Character character, Doodad owner)

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncSkillHit.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncSkillHit.cs
@@ -1,50 +1,20 @@
-﻿using AAEmu.Game.Core.Managers;
-using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.DoodadObj.Templates;
-using AAEmu.Game.Models.Game.Items.Actions;
-using AAEmu.Game.Models.Game.Skills;
-using AAEmu.Game.Models.Game.Skills.Effects;
+﻿using AAEmu.Game.Models.Game.DoodadObj.Templates;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.DoodadObj.Funcs;
 
 public class DoodadFuncSkillHit : DoodadFuncTemplate
 {
-    // doodad_funcs
     public uint SkillId { get; set; }
 
     public override void Use(BaseUnit caster, Doodad owner, uint skillId, int nextPhase = 0)
     {
-        if (caster is Character character)
-        {
-            if (SkillId > 0)
-            {
-                var skillCaster = SkillCaster.GetByType(SkillCasterType.Item);
-                // An item caster uses the wielding unit's identifier, not a non-unit object id.
-                skillCaster.ObjId = character.ObjId;
-
-                var target = SkillCastTarget.GetByType(SkillCastTargetType.Doodad);
-                target.ObjId = owner.ObjId;
-
-                var skill = new Skill(SkillManager.Instance.GetSkillTemplate(SkillId));
-
-                if (skillCaster is SkillItem sc)
-                {
-                    foreach (var skillEffect in skill.Template.Effects)
-                    {
-                        var template = SkillManager.Instance.GetEffectTemplate(skillEffect.EffectId);
-                        if (template is SpecialEffect specialEffect)
-                        {
-                            var itemId = (uint)specialEffect.Value1;
-                            sc.ItemTemplateId = itemId;
-                            var item = ItemManager.Instance.Create(itemId, 1, 0);
-                            var res = character.Inventory.Bag.AcquireDefaultItem(ItemTaskType.Loot, item.TemplateId, item.Count, item.Grade);
-                            skill.Use(caster, skillCaster, target, null, false, out _);
-                        }
-                    }
-                }
-            }
-        }
-        owner.ToNextPhase = SkillId == skillId;
+        // SkillHit is a phase gate: the incoming skill either matches this row or it does not.
+        // Recasting the skill / creating items from SpecialEffect.Value1 was leftover harvest
+        // loot logic and re-entered OnSkillHit (chum never needed it).
+        owner.ToNextPhase = AdvancesPhase(SkillId, skillId);
     }
+
+    public static bool AdvancesPhase(uint hitSkillId, uint incomingSkillId) =>
+        hitSkillId != 0 && hitSkillId == incomingSkillId;
 }

--- a/AAEmu.Game/Models/Game/FishSchools/FishSalePrice.cs
+++ b/AAEmu.Game/Models/Game/FishSchools/FishSalePrice.cs
@@ -1,0 +1,30 @@
+namespace AAEmu.Game.Models.Game.FishSchools;
+
+/// <summary>
+/// Stand payout for a caught-fish backpack: grade-adjust the catalog refund, then scale by
+/// measured weight over the species max. Both steps use floor(x + 0.5). A zero or unknown
+/// weight must not produce a successful sale.
+/// </summary>
+public static class FishSalePrice
+{
+    public static bool TryCalculate(int refund, int refundMultiplier, float weight, int maxWeight, out long price)
+    {
+        const float percentScale = 0.01f;
+
+        price = 0;
+        if (refund < 0 || refundMultiplier < 0 || weight <= 0 || !float.IsFinite(weight) || maxWeight <= 0)
+            return false;
+
+        var adjustedBaseValue = refundMultiplier * percentScale * refund;
+        if (!float.IsFinite(adjustedBaseValue))
+            return false;
+        var adjustedBase = (long)MathF.Floor(adjustedBaseValue + 0.5f);
+
+        var weightedValue = (float)adjustedBase * weight / maxWeight;
+        if (!float.IsFinite(weightedValue) || weightedValue <= 0)
+            return false;
+
+        price = (long)MathF.Floor(weightedValue + 0.5f);
+        return price > 0;
+    }
+}

--- a/AAEmu.Game/Models/Game/Items/ItemChargeRules.cs
+++ b/AAEmu.Game/Models/Game/Items/ItemChargeRules.cs
@@ -1,0 +1,38 @@
+using AAEmu.Game.Models.Game.Items.Templates;
+
+namespace AAEmu.Game.Models.Game.Items;
+
+/// <summary>
+/// Charge-lifetime gear (fishing rods, event weapons) names its reagent on
+/// <see cref="EquipItemTemplate.RechargeRestrictItemId"/> and writes the new window onto the
+/// piece. The client must hear that write as a detail packet, not an <c>UpdateDetail</c> task.
+/// </summary>
+public static class ItemChargeRules
+{
+    public enum RechargeApply
+    {
+        Applied,
+        Rejected,
+        Equipped
+    }
+
+    /// <summary>
+    /// Starts a new charge window when the source item is the piece's named reagent and the
+    /// piece is not sitting in an equipment slot.
+    /// </summary>
+    public static RechargeApply TryApply(EquipItem equipItem, Item sourceItem, DateTime time)
+    {
+        if (equipItem?.Template is not EquipItemTemplate template ||
+            template.RechargeRestrictItemId == 0 ||
+            sourceItem == null ||
+            template.RechargeRestrictItemId != sourceItem.TemplateId)
+            return RechargeApply.Rejected;
+
+        if (equipItem.SlotType == SlotType.Equipment)
+            return RechargeApply.Equipped;
+
+        equipItem.ChargeStartTime = time;
+        equipItem.ChargeCount = template.ChargeCount;
+        return RechargeApply.Applied;
+    }
+}

--- a/AAEmu.Game/Models/Game/NPChar/Npc.cs
+++ b/AAEmu.Game/Models/Game/NPChar/Npc.cs
@@ -52,6 +52,11 @@ public partial class Npc : Unit
     public bool ZoneDespawnSignaled { get; set; }
 
     /// <summary>
+    /// Sport fish whose line is gone (timeout, 20 tension, or flee 21616). Skills must miss it.
+    /// </summary>
+    public bool SportFishLineDropped { get; set; }
+
+    /// <summary>
     /// This is the "Idle Animation Id" that is used in UnitModelChangePosture, it can change depending on the time of the day
     /// </summary>
     public uint AnimActionId

--- a/AAEmu.Game/Models/Game/NPChar/NpcEvents.cs
+++ b/AAEmu.Game/Models/Game/NPChar/NpcEvents.cs
@@ -1,8 +1,11 @@
 ﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Units;
+
+using WorldIntegration = AAEmu.Game.WorldIntegration;
 
 namespace AAEmu.Game.Models.Game.NPChar;
 
@@ -153,12 +156,19 @@ public partial class Npc
                 ? npc.CurrentTarget.ObjId
                 : npc.ObjId;
 
+            if (!SportFishCombat.ShouldWorldApplyInCombatSkill(
+                    WorldIntegration.ZoneAuthority, npc.IsZoneMirror, skill.Id))
+                continue;
+
             if (npc.Cooldowns.CheckCooldown(skill.Id)) { continue; }
 
             if (skill.Template.CooldownTime == 0)
             {
                 npc.Cooldowns.AddCooldown(skill.Id, uint.MaxValue); // Run once / выполняем один раз
             }
+
+            if (WorldIntegration.ZoneAuthority && npc.IsZoneMirror)
+                skill.SuppressZoneSkillRelay = true;
 
             Logger.Trace($"Npc={npc.ObjId}:{npc.TemplateId} using skill={skill.Id}");
             skill.Use(npc, skillCaster, skillTarget, null, false, out _);

--- a/AAEmu.Game/Models/Game/Skills/Buff.cs
+++ b/AAEmu.Game/Models/Game/Skills/Buff.cs
@@ -109,7 +109,7 @@ public class Buff
                 _count = -1;
             EffectTaskManager.Instance.AddDispelTask(this, Tick);
         }
-        else
+        else if (BuffStackRules.ShouldScheduleDispel(Duration, Tick))
             EffectTaskManager.Instance.AddDispelTask(this, GetTimeLeft());
     }
 
@@ -142,7 +142,7 @@ public class Buff
                             _count = -1;
                         EffectTaskManager.Instance.AddDispelTask(this, Tick);
                     }
-                    else
+                    else if (BuffStackRules.ShouldScheduleDispel(Duration, Tick))
                         EffectTaskManager.Instance.AddDispelTask(this, GetTimeLeft());
 
                     if (Template.FactionId > 0 && Owner is Unit owner)
@@ -244,20 +244,25 @@ public class Buff
                 Duration = newBuff.Duration;
             }
 
-            // Recalculate EndTime based on the new StartTime and Duration.
-            EndTime = StartTime.AddMilliseconds(Duration);
-
-            // Remove any tasks associated with this buff using a predicate.
-            TaskManager.Instance.RemoveTasks(task =>
+            if (!BuffStackRules.ShouldScheduleDispel(Duration, Template.Tick))
             {
-                if (task is DispelTask dt && dt.Effect.Target is Buff buff)
+                // Permanent refresh: keep Acting. SetInUse(update) would queue a
+                // -1 ms dispel and the instance would finish on the next tick.
+                EndTime = DateTime.MinValue;
+                InUse = true;
+                State = EffectState.Acting;
+            }
+            else
+            {
+                EndTime = StartTime.AddMilliseconds(Duration);
+                TaskManager.Instance.RemoveTasks(task =>
                 {
-                    // Remove tasks if they are for this buff.
-                    return buff == this;
-                }
-                return false;
-            });
-            SetInUse(true, true);
+                    if (task is DispelTask dt && dt.Effect.Target is Buff existing)
+                        return existing == this;
+                    return false;
+                });
+                SetInUse(true, true);
+            }
         }
 
         NotifyUpdated(reason: 1); // refresh/overwrite

--- a/AAEmu.Game/Models/Game/Skills/BuffStackRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/BuffStackRules.cs
@@ -20,6 +20,13 @@ public static class BuffStackRules
         maxStack > 1 && currentStack < maxStack;
 
     /// <summary>
+    /// A family with <paramref name="transformBuffId"/> replaces itself once the live count
+    /// reaches the ceiling (tension 5793 → line-broken 5794 at 20).
+    /// </summary>
+    public static bool ShouldTransform(int stack, int maxStack, uint transformBuffId) =>
+        transformBuffId != 0 && maxStack > 1 && stack >= maxStack;
+
+    /// <summary>
     /// Flat or linear-level modifier after the instance's stack is applied.
     /// </summary>
     /// <remarks>
@@ -32,4 +39,21 @@ public static class BuffStackRules
         var n = Math.Max(1, stack);
         return (long)Math.Round((value + linearLevelBonus * (abLevel / 100f)) * n);
     }
+
+    /// <summary>
+    /// A duration-0 family has no expire timer. Refresh must not replace the live
+    /// instance: <c>OverwriteWith</c> used to schedule a dispel from
+    /// <c>GetTimeLeft() == -1</c>, which is "already due", so the buff vanished
+    /// on the second apply. Fishing 4053 (pose / anim action) is that family —
+    /// auto-reuse re-applies it and the throw then starts from default idle.
+    /// </summary>
+    public static bool ShouldOverwriteOnRefresh(int incomingDurationMs, int existingDurationMs) =>
+        incomingDurationMs > 0 || existingDurationMs > 0;
+
+    /// <summary>
+    /// Only timed or ticking buffs get a dispel task. Permanent (duration 0, no
+    /// tick) must not be queued at -1 ms or they finish on the next tick.
+    /// </summary>
+    public static bool ShouldScheduleDispel(int durationMs, double tickMs) =>
+        durationMs > 0 || tickMs > 0;
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpawnFishEffect.cs
@@ -5,7 +5,6 @@ using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
-using AAEmu.Game.Models.Game.DoodadObj.Funcs;
 using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.Game.Units;
@@ -25,7 +24,13 @@ public class SpawnFishEffect : EffectTemplate
     {
         if (caster is not Character player) return;
 
-        var fishSpawnerId = GetFishSpawnerId(player);
+        if (SportFishCombat.HasActiveHook(player.Id))
+        {
+            Logger.Info("Skipped SpawnFish for {0}: a hooked fish is still on the line", player.Name);
+            return;
+        }
+
+        var fishSpawnerId = GetFishSpawnerId(player, target);
         if (fishSpawnerId == 0)
         {
             Logger.Debug($"Fish Spawner ID not found for player {player.Name}.");
@@ -39,10 +44,7 @@ public class SpawnFishEffect : EffectTemplate
             return;
         }
 
-        // Weighted random fish selection
-        NpcSpawnerNpc npcTemplateEntry = template.Npcs.Count == 1
-            ? template.Npcs[0]
-            : SelectWeightedRandom(template.Npcs);
+        var npcTemplateEntry = FishSchoolLookup.SelectWeighted(template.Npcs, Random.Shared.NextDouble());
 
         if (npcTemplateEntry == null)
         {
@@ -82,6 +84,7 @@ public class SpawnFishEffect : EffectTemplate
             // Register so that Despawn() -> RemoveNpcFromSpawnedList doesn't log a false warning
             tempSpawner.SpawnedNpcs.TryAdd(fishSpawnerId, spawnedList);
             var fish = spawnedList.First();
+            SportFishCombat.RegisterHook(player.Id, fish.ObjId);
             // Aggro & targeting
             fish.CurrentTarget = player;
             fish.AddUnitAggro(AggroKind.Damage, player, 10000);
@@ -123,7 +126,11 @@ public class SpawnFishEffect : EffectTemplate
             fish.OwnerId = player.Id;
             fish.Transform = target.Transform.CloneDetached(fish);
             fish.IsZoneMirror = true;
+            // NpcManager.Create does not register np_skills. The non-ZA path goes through
+            // NpcSpawnerNpc.Spawn, which does — bite / OnDeath school-count need the same hook.
+            fish.RegisterNpcEvents();
             fish.Spawn();
+            SportFishCombat.RegisterHook(player.Id, fish.ObjId);
 
             void CompleteCombatHandoff()
             {
@@ -148,9 +155,12 @@ public class SpawnFishEffect : EffectTemplate
                     fish.CurrentTarget = player;
                     WorldIntegration.RelayTargetChangedToZone?.Invoke(fish.ObjId, player.ObjId, true);
                     player.CurrentTarget = fish;
+                    player.SendPacket(new SCTargetChangedPacket(player.ObjId, fish.ObjId));
                     WorldIntegration.RelayTargetChangedToZone?.Invoke(player.ObjId, fish.ObjId, true);
                     WorldIntegration.PublishAggro(fish, player, 10000, castAction);
-                    fish.IsInBattle = true;
+                    // Must run before IsInBattle is set: OnCombatStarted no-ops when already in battle.
+                    // Under ZoneAuthority this only applies bite 21608 (plot 821 / tag 1090).
+                    fish.Events.OnCombatStarted(fish, new OnCombatStartedArgs { Owner = fish, Target = player });
                     player.IsInBattle = true;
                     Logger.Debug(
                         $"Successfully handed fish {npcTemplateEntry.MemberId} (owner {player.Id}) to Zone at the bobber.");
@@ -199,45 +209,33 @@ public class SpawnFishEffect : EffectTemplate
             Logger.Error(ex, $"Error handing fish template {npcTemplateEntry.MemberId} to Zone.");
         }
     }
-    private NpcSpawnerNpc SelectWeightedRandom(List<NpcSpawnerNpc> npcs)
-    {
-        var totalWeight = npcs.Sum(x => x.Weight);
-        if (totalWeight <= 0) return npcs[0];
-
-        var roll = Random.Shared.NextDouble() * totalWeight;
-        var current = 0.0;
-
-        foreach (var entry in npcs)
-        {
-            current += entry.Weight;
-            if (roll < current)
-                return entry;
-        }
-        return npcs[0];
-    }
 
     /// <summary>
     /// Finds the school the bobber landed in and returns the npc_spawners id its current phase feeds
     /// from. Only the chummed phase carries a <see cref="DoodadFuncFishSchool"/> — freshwater 6447
     /// holds it on 26363 and not on the idle 26362 — so an un-chummed school correctly yields 0.
     /// </summary>
-    private uint GetFishSpawnerId(Character player)
+    private uint GetFishSpawnerId(Character player, BaseUnit origin)
     {
         // spawn_fish_effects.range is millimetres, as in ScopedFEffect: 50000 -> 50m for the school
         // effects plot 821 and 809 use, 25000 -> 25m for effect 1.
-        var doodads = WorldManager.GetAround<Doodad>(player, Range / 1000f);
+        var searchOrigin = origin ?? player;
+        if (searchOrigin == null)
+            return 0;
+
+        var rangeMeters = Range / 1000f;
+        var doodads = WorldManager.GetAround<Doodad>(searchOrigin, rangeMeters);
+        var schools = new List<(float X, float Y, uint SpawnerId)>(doodads.Count);
         foreach (var doodad in doodads)
         {
-            if (doodad.Template.GroupId == 65)
-            {
-                foreach (var func in doodad.CurrentPhaseFuncs)
-                {
-                    var funcTemplate = DoodadManager.Instance.GetPhaseFuncTemplate(func.FuncId, func.FuncType);
-                    if (funcTemplate is DoodadFuncFishSchool schoolFunc)
-                        return schoolFunc.NpcSpawnerId;
-                }
-            }
+            var spawnerId = FishSchoolLookup.ReadActiveSpawnerId(
+                doodad,
+                DoodadManager.Instance.GetPhaseFuncTemplate);
+            var pos = doodad.Transform.World.Position;
+            schools.Add((pos.X, pos.Y, spawnerId));
         }
-        return 0;
+
+        var originPos = searchOrigin.Transform.World.Position;
+        return FishSchoolLookup.ResolveNearestSpawnerId(schools, originPos.X, originPos.Y, rangeMeters);
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/NpcDespawn.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/NpcDespawn.cs
@@ -1,5 +1,6 @@
 ﻿using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
@@ -25,6 +26,8 @@ public class NpcDespawn : SpecialEffectAction
         // zero in all seven value fields. The selected source is therefore the only operand.
         if (caster is not Npc npc)
             return;
+
+        SportFishCombat.OnLineDropped(npc);
 
         if (WorldIntegration.ZoneAuthority)
         {

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/RechargeItemBuff.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/RechargeItemBuff.cs
@@ -2,7 +2,6 @@ using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
-using AAEmu.Game.Models.Game.Items.Templates;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
@@ -32,33 +31,25 @@ public class RechargeItemBuff : SpecialEffectAction
         // inventory so client-supplied template ids cannot choose either side of the operation.
         var sourceItem = owner.Inventory.GetItemById(sourceCaster.ItemId);
         var equipItem = owner.Inventory.GetItemById(itemTarget.Id) as EquipItem;
-        if (sourceItem == null ||
-            equipItem?.Template is not EquipItemTemplate equipTemplate ||
-            equipTemplate.RechargeRestrictItemId == 0 ||
-            equipTemplate.RechargeRestrictItemId != sourceItem.TemplateId)
+        switch (ItemChargeRules.TryApply(equipItem, sourceItem, time))
         {
-            Logger.Warn(
-                "RechargeItemBuff rejected owner={0} source={1} target={2}",
-                owner.Id,
-                sourceCaster.ItemId,
-                itemTarget.Id);
-            return;
+            case ItemChargeRules.RechargeApply.Rejected:
+                Logger.Warn(
+                    "RechargeItemBuff rejected owner={0} source={1} target={2}",
+                    owner.Id,
+                    sourceCaster.ItemId,
+                    itemTarget.Id);
+                return;
+            case ItemChargeRules.RechargeApply.Equipped:
+                owner.SendErrorMessage(ErrorMessageType.CannotRechargeWhenEquipped);
+                return;
         }
 
-        // Native validation rejects recharge while the target occupies an equipment slot. The
-        // bag detail is charged first; its normal equip path applies RechargeBuffId afterwards.
-        if (equipItem.SlotType == SlotType.Equipment)
-        {
-            owner.SendErrorMessage(ErrorMessageType.CannotRechargeWhenEquipped);
-            return;
-        }
-
-        equipItem.ChargeStartTime = time;
-        equipItem.ChargeCount = equipTemplate.ChargeCount;
-
-        owner.SendPacket(new SCItemTaskSuccessPacket(
-            ItemTaskType.RechargeBuff,
-            [new ItemUpdate(equipItem)],
-            []));
+        // Same publish as temper / synthesis: the detail packet is what the client redraws from.
+        // An UpdateDetail item task is a length-prefixed array the client does not treat as a
+        // detail, which is why a successful lure apply left the rod as an invalid item with no
+        // mesh in hand.
+        owner.SendPacket(new SCItemDetailUpdatedPacket(equipItem));
+        owner.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.RechargeBuff, [], []));
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SportFishCombat.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SportFishCombat.cs
@@ -1,0 +1,172 @@
+using System.Collections.Concurrent;
+
+using AAEmu.Game;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.StaticValues;
+
+namespace AAEmu.Game.Models.Game.Skills.Effects;
+
+/// <summary>
+/// Sport-fish combat split under ZoneAuthority, plus hook / line-break rules.
+/// </summary>
+/// <remarks>
+/// Plot 821 waits on tag 1090, applied by bite skill 21608 (입질). Zone owns the rest of the
+/// InCombat kit (move / flee / basic attack). World still applies the bite so the running
+/// plot sees the tag; movement skills must not run on World or the fish is simulated twice.
+/// Tension (buff 5793) transforms to line-broken (5794) at 20 stacks; that pulse and the
+/// fish-lifetime / struggle timeouts all SkillUse 21616, whose only effect is NpcDespawn.
+/// </remarks>
+public static class SportFishCombat
+{
+    public const uint BiteSkillId = 21608;
+    public const uint FleeSkillId = 21616;
+    public const uint TensionBuffId = 5793;
+    public const uint LineBrokenBuffId = 5794;
+    public const uint FishingSkillTagId = (uint)TagsEnum.FishingSkill;
+    public const uint BaitFishingPlotId = 809;
+    public const uint SportFishingPlotId = 821;
+
+    private static readonly ConcurrentDictionary<uint, uint> HooksByPlayerId = new();
+
+    public static bool ShouldWorldApplyInCombatSkill(bool zoneAuthority, bool isZoneMirror, uint skillId)
+    {
+        if (!zoneAuthority || !isZoneMirror)
+            return true;
+        return skillId == BiteSkillId;
+    }
+
+    public static bool HasFishingSkillTag(IReadOnlyList<uint> skillTags)
+    {
+        if (skillTags == null)
+            return false;
+        for (var i = 0; i < skillTags.Count; i++)
+        {
+            if (skillTags[i] == FishingSkillTagId)
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Hold / reel / slack. Rod casts (21571 / 21578) are Pos-targeted and are not holds.
+    /// </summary>
+    public static bool IsFishingHoldSkill(SkillTargetType targetType, IReadOnlyList<uint> skillTags) =>
+        targetType == SkillTargetType.Hostile && HasFishingSkillTag(skillTags);
+
+    /// <summary>
+    /// Stand-firm left → right (and the rest of the kit) must start on the first click. The
+    /// shared GCD and the 150 ms anti-spam belong to the rod cast, not to swapping holds.
+    /// </summary>
+    public static bool ShouldBypassSharedGcd(
+        int castingTime,
+        SkillTargetType targetType,
+        IReadOnlyList<uint> skillTags) =>
+        castingTime <= 0 && IsFishingHoldSkill(targetType, skillTags);
+
+    public static bool IsRodPlot(uint plotId) =>
+        plotId == BaitFishingPlotId || plotId == SportFishingPlotId;
+
+    /// <summary>
+    /// Rod casts 21571 / 21578 are not cancelable on the skill row. The client still
+    /// sends CSStopCasting when the hull (or the attached player) reports movement,
+    /// which tore the plot down during the 1.5 s cast and left the last throw pose.
+    /// </summary>
+    public static bool ShouldIgnoreClientStopCasting(
+        uint plotId,
+        bool castingCancelable,
+        bool channelingCancelable) =>
+        IsRodPlot(plotId) && !castingCancelable && !channelingCancelable;
+
+    /// <summary>
+    /// A new hold replaces the previous hold immediately. A hold must not cancel the rod
+    /// channel (plots 809 / 821). Any other busy cast/channel is still replaced.
+    /// </summary>
+    public static bool ShouldCancelPreviousPlot(bool previousWasBusy, bool previousWasHold, bool incomingIsHold)
+    {
+        if (previousWasHold && incomingIsHold)
+            return true;
+        if (incomingIsHold)
+            return false;
+        return previousWasBusy;
+    }
+
+    /// <summary>
+    /// Hold skills such as 21194 ship a plot but are not flagged plot_only. Running Cast()
+    /// afterwards EndSkill's the TlId while the plot is still on the bar.
+    /// </summary>
+    public static bool ShouldRunPlotGraphOnly(
+        bool casterIsCharacter,
+        bool hasPlot,
+        bool plotOnly,
+        IReadOnlyList<uint> skillTags)
+    {
+        if (plotOnly)
+            return true;
+        if (!casterIsCharacter || !hasPlot)
+            return false;
+        return HasFishingSkillTag(skillTags);
+    }
+
+    public static void RegisterHook(uint playerId, uint fishObjId)
+    {
+        if (playerId == 0 || fishObjId == 0)
+            return;
+        HooksByPlayerId[playerId] = fishObjId;
+    }
+
+    public static bool HasActiveHook(uint playerId)
+    {
+        if (playerId == 0 || !HooksByPlayerId.TryGetValue(playerId, out var fishObjId))
+            return false;
+
+        if (WorldIntegration.FindUnitAcrossWorlds(fishObjId) is Npc { SportFishLineDropped: false })
+            return true;
+
+        HooksByPlayerId.TryRemove(playerId, out _);
+        return false;
+    }
+
+    public static bool IsUnusableTarget(BaseUnit target) =>
+        target is Npc { SportFishLineDropped: true };
+
+    public static void OnLineDropped(Npc fish)
+    {
+        if (fish == null || fish.SportFishLineDropped)
+            return;
+
+        fish.SportFishLineDropped = true;
+        if (fish.OwnerId != 0)
+            HooksByPlayerId.TryRemove(fish.OwnerId, out _);
+
+        fish.ClearAllAggro();
+        fish.IsInBattle = false;
+        fish.CurrentTarget = null;
+        WorldIntegration.RelayAggroResetToZone?.Invoke(fish.ObjId, 0, 0, 0, 0);
+        WorldIntegration.RelayTargetChangedToZone?.Invoke(fish.ObjId, 0, true);
+
+        var owner = fish.OwnerId == 0 ? null : WorldManager.Instance.GetCharacterById(fish.OwnerId);
+        if (owner == null)
+            return;
+
+        if (owner.CurrentTarget?.ObjId == fish.ObjId)
+        {
+            owner.CurrentTarget = null;
+            owner.SendPacket(new SCTargetChangedPacket(owner.ObjId, 0));
+            WorldIntegration.RelayTargetChangedToZone?.Invoke(owner.ObjId, 0, true);
+        }
+
+        var plotSkill = owner.ActivePlotState?.ActiveSkill;
+        if (plotSkill?.Template == null)
+            return;
+
+        var tags = SkillManager.Instance.GetSkillTags(plotSkill.Id);
+        if (ShouldRunPlotGraphOnly(true, plotSkill.Template.Plot != null, plotSkill.Template.PlotOnly, tags))
+            owner.ActivePlotState.RequestCancellation();
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/Plots/Plot.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Plot.cs
@@ -1,6 +1,8 @@
-﻿using AAEmu.Game.Core.Packets.G2C;
+﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Skills.Plots.Tree;
 using AAEmu.Game.Models.Game.Units;
 
@@ -21,13 +23,23 @@ public class Plot
         if (caster is not Unit casterUnit)
             return;
 
-        // New cast-time plot while still casting: cancel the previous cast bar/plot so anims don't stack.
-        // In-flight (post-cast) plots keep running for projectile/damage; only casting ones are interrupted.
+        // New cast-time or channel plot while the previous one is still on the bar: cancel so
+        // anims / projectiles do not stack. Sport-fish holds replace each other immediately but
+        // must not tear down the rod channel (plots 809 / 821).
         var prev = casterUnit.ActivePlotState;
-        if (prev != null && !ReferenceEquals(prev.ActiveSkill, skill) && prev.IsCasting &&
-            skill.Template.CastingTime > 0)
+        if (prev != null && !ReferenceEquals(prev.ActiveSkill, skill))
         {
-            prev.RequestCancellation();
+            var incomingTags = SkillManager.Instance.GetSkillTags(skill.Id);
+            var prevSkill = prev.ActiveSkill;
+            var prevTags = prevSkill != null ? SkillManager.Instance.GetSkillTags(prevSkill.Id) : null;
+            var incomingHold = SportFishCombat.IsFishingHoldSkill(skill.Template.TargetType, incomingTags);
+            var prevHold = prevSkill?.Template != null &&
+                           SportFishCombat.IsFishingHoldSkill(prevSkill.Template.TargetType, prevTags);
+            if (SportFishCombat.ShouldCancelPreviousPlot(
+                    prev.IsCasting || prev.IsChanneling,
+                    prevHold,
+                    incomingHold))
+                prev.RequestCancellation();
         }
 
         var state = new PlotState(caster, casterCaster, target, targetCaster, skillObject, skill);

--- a/AAEmu.Game/Models/Game/Skills/Plots/PlotNextEvent.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/PlotNextEvent.cs
@@ -25,9 +25,9 @@ public class PlotNextEvent
     public bool UseExeTime { get; set; }
     public bool Fail { get; set; }
 
-    private int GetAnimDelay(IEnumerable<PlotEventEffect> effects)
+    public static int AnimCsTimeMs(IEnumerable<PlotEventEffect> effects)
     {
-        if (!AddAnimCsTime)
+        if (effects == null)
             return 0;
 
         foreach (var effect in effects)
@@ -40,10 +40,19 @@ public class PlotNextEvent
                 continue;
 
             var anim = AnimationManager.Instance.GetAnimation((uint)specialEffect.Value1);
+            if (anim == null)
+                continue;
             return anim.CombatSyncTime;
         }
 
         return 0;
+    }
+
+    private int GetAnimDelay(IEnumerable<PlotEventEffect> effects)
+    {
+        if (!AddAnimCsTime)
+            return 0;
+        return AnimCsTimeMs(effects);
     }
 
     private int GetProjectileDelay(BaseUnit caster, BaseUnit target)

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotChannelingRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotChannelingRules.cs
@@ -1,0 +1,77 @@
+namespace AAEmu.Game.Models.Game.Skills.Plots.Tree;
+
+/// <summary>
+/// Cast-bar vs channel wait on a plot node, and which queued event a bite/cancel must resume.
+/// </summary>
+public static class PlotChannelingRules
+{
+    public static (int CastingMs, int ChannelingMs) NextEdgeDurations(
+        IEnumerable<(bool Casting, bool Channeling, int DelayMs)> edges)
+    {
+        var castingMs = 0;
+        var channelingMs = 0;
+        foreach (var (casting, channeling, delayMs) in edges)
+        {
+            if (casting)
+                castingMs = Math.Max(castingMs, delayMs);
+            if (channeling)
+                channelingMs = Math.Max(channelingMs, delayMs);
+        }
+
+        return (castingMs, channelingMs);
+    }
+
+    /// <summary>
+    /// SC plot times are milliseconds / 10, same as skill cast-time wire.
+    /// </summary>
+    public static ushort ToPlotWireTime(int delayMs) =>
+        (ushort)Math.Clamp(delayMs / 10, 0, ushort.MaxValue);
+
+    /// <summary>
+    /// The client holds the plot cast/channel for the packet time only. It does not
+    /// add <c>add_anim_cs_time</c> itself, so the wire must include that wait or the
+    /// throw pose drops when the delay elapses and the next event is still queued.
+    /// </summary>
+    public static int IncludeAnimCsTime(int delayMs, bool addAnimCsTime, int animCsTimeMs)
+    {
+        if (!addAnimCsTime || animCsTimeMs <= 0)
+            return delayMs;
+        if (delayMs <= 0)
+            return animCsTimeMs;
+        return delayMs + animCsTimeMs;
+    }
+
+    public const int IgnoredStopRefreshMinMs = 400;
+
+    /// <summary>
+    /// Re-send the last plot event after an ignored CSStopCasting, but not on every
+    /// retry the client fires while the local pose is already idle.
+    /// </summary>
+    public static bool ShouldRefreshPlotAfterIgnoredStop(
+        bool hasLastEvent,
+        DateTime lastRefreshUtc,
+        DateTime nowUtc)
+    {
+        if (!hasLastEvent)
+            return false;
+        if (lastRefreshUtc != default &&
+            (nowUtc - lastRefreshUtc).TotalMilliseconds < IgnoredStopRefreshMinMs)
+            return false;
+        return true;
+    }
+
+    /// <summary>
+    /// The channel wait is the child entered by a channeling edge. A bite-roll loop
+    /// queued from the same parent is not that wait — resuming it would swallow the hook.
+    /// </summary>
+    public static int IndexOfChannelWait<T>(IReadOnlyList<T> items, Func<T, bool> enteredByChannelingEdge)
+    {
+        for (var i = 0; i < items.Count; i++)
+        {
+            if (enteredByChannelingEdge(items[i]))
+                return i;
+        }
+
+        return -1;
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotNode.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotNode.cs
@@ -2,6 +2,7 @@
 using AAEmu.Game;
 using AAEmu.Game.Core.Packets;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Skills.Plots;
 using AAEmu.Game.Models.Game.Skills.Static;
 
 using NLog;
@@ -65,11 +66,28 @@ public class PlotNode
             }
         }
 
-        double castTime = Event.NextEvents
-             .Where(nextEvent => nextEvent.Casting || nextEvent.Channeling)
-             .Max(nextEvent => nextEvent.Delay / 10 as int?) ?? 0;
-        castTime = state.Caster.ApplySkillModifiers(state.ActiveSkill, SkillAttribute.CastTime, castTime) * state.Caster.CastTimeMul;
+        var (castingMs, channelingMs) = PlotChannelingRules.NextEdgeDurations(
+            Event.NextEvents.Select(nextEvent => (nextEvent.Casting, nextEvent.Channeling, nextEvent.Delay)));
+        var animCs = PlotNextEvent.AnimCsTimeMs(Event.Effects);
+        var addAnimToCast = false;
+        var addAnimToChannel = false;
+        foreach (var nextEvent in Event.NextEvents)
+        {
+            if (!nextEvent.AddAnimCsTime)
+                continue;
+            if (nextEvent.Casting)
+                addAnimToCast = true;
+            if (nextEvent.Channeling)
+                addAnimToChannel = true;
+        }
+
+        var castTime = state.Caster.ApplySkillModifiers(state.ActiveSkill, SkillAttribute.CastTime, castingMs) *
+                       state.Caster.CastTimeMul;
         castTime = Math.Max(castTime, 0);
+        castTime = PlotChannelingRules.IncludeAnimCsTime((int)castTime, addAnimToCast, animCs);
+        channelingMs = PlotChannelingRules.IncludeAnimCsTime(channelingMs, addAnimToChannel, animCs);
+        var castWire = PlotChannelingRules.ToPlotWireTime((int)castTime);
+        var channelWire = PlotChannelingRules.ToPlotWireTime(channelingMs);
 
         if (castTime > 0)
             state.IsCasting = true;
@@ -86,7 +104,7 @@ public class PlotNode
         else
             state.IsChanneling = true;
 
-        if (Event.HasSpecialEffects() || castTime > 0 || Event.Conditions.Count > 0)
+        if (Event.HasSpecialEffects() || castTime > 0 || channelingMs > 0 || Event.Conditions.Count > 0)
         {
             var skill = state.ActiveSkill;
             var unkId = (ParentNextEvent?.Casting ?? false) || (ParentNextEvent?.Channeling ?? false) ? state.Caster.ObjId : 0;
@@ -106,7 +124,20 @@ public class PlotNode
             var targetCount = (byte)targetInfo.EffectedTargets.Count;
 
             var packet = new SCPlotEventPacket(skill.TlId, Event.Id, skill.Template.Id, casterPlotObj,
-                targetPlotObj, unkId, (ushort)castTime, flag, 0, targetCount);
+                targetPlotObj, unkId, castWire, flag, 0, targetCount, channelingTime: channelWire);
+            state.LastClientEvent = new PlotClientEvent
+            {
+                Tl = skill.TlId,
+                EventId = Event.Id,
+                SkillId = skill.Template.Id,
+                Caster = casterPlotObj,
+                Target = targetPlotObj,
+                UnkId = unkId,
+                CastWire = castWire,
+                Flag = flag,
+                TargetCount = targetCount,
+                ChannelWire = channelWire
+            };
 
             if (packets != null)
                 packets.AddPacket(packet);
@@ -114,7 +145,7 @@ public class PlotNode
             {
                 state.Caster.BroadcastPacket(packet, true);
                 RelayPlotEventToZoneIfNeeded(skill.TlId, Event.Id, skill.Template.Id, casterPlotObj, targetPlotObj,
-                    0ul, unkId, (ushort)castTime, flag, targetCount, targetInfo);
+                    0ul, unkId, (uint)castTime, (uint)channelingMs, flag, targetCount, targetInfo);
             }
 
             Logger.Trace($"Execute Took {stopwatch.ElapsedMilliseconds} to finish.");
@@ -144,7 +175,8 @@ public class PlotNode
         PlotObject targetPlotObj,
         ulong itemId,
         uint objId,
-        ushort castingTime,
+        uint castTimeMs,
+        uint channelingTimeMs,
         byte flag,
         byte targetUnitCount,
         PlotTargetInfo targetInfo)
@@ -177,8 +209,8 @@ public class PlotNode
             targetPlotObj,
             itemId,
             objId,
-            castingTime,
-            0u,
+            castTimeMs,
+            channelingTimeMs,
             true,
             false,
             targetIds.ToArray());

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotState.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotState.cs
@@ -1,7 +1,22 @@
 ﻿using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
+using AAEmu.Game.Models.Game.Skills.Plots;
 
 namespace AAEmu.Game.Models.Game.Skills.Plots.Tree;
+
+public sealed class PlotClientEvent
+{
+    public ushort Tl { get; init; }
+    public uint EventId { get; init; }
+    public uint SkillId { get; init; }
+    public PlotObject Caster { get; init; }
+    public PlotObject Target { get; init; }
+    public uint UnkId { get; init; }
+    public ushort CastWire { get; init; }
+    public byte Flag { get; init; }
+    public byte TargetCount { get; init; }
+    public ushort ChannelWire { get; init; }
+}
 
 public class PlotState(
     BaseUnit caster,
@@ -23,6 +38,8 @@ public class PlotState(
     public byte CombatDiceRoll { get; set; }
     public bool IsCasting { get; set; }
     public bool IsChanneling { get; set; }
+    public PlotClientEvent LastClientEvent { get; set; }
+    public DateTime LastIgnoredStopRefreshUtc { get; set; }
 
     public Skill ActiveSkill { get; set; } = skill;
     public Unit Caster { get; set; } = caster as Unit;

--- a/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTree.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Tree/PlotTree.cs
@@ -41,21 +41,26 @@ public class PlotTree(uint plotId)
                 var node = item.node;
                 if (state.IsChanneling && state.ChannelingFinishRequested())
                 {
-                    HandleChannelingFinish(node, state, queue, item);
+                    ResumeChannelEnd(state, queue, item);
                     lastEvent = 0;
                     continue;
                 }
                 if (state.CancellationRequested())
                 {
-                    if (state.IsCasting)
+                    var stoppedChannel = ResumeChannelEnd(state, queue, item);
+                    if (state.IsCasting || stoppedChannel)
                     {
+                        if (state.IsCasting)
+                        {
+                            state.Caster.BroadcastPacket(
+                                new SCPlotCastingStoppedPacket(state.ActiveSkill.TlId, 0, lastEvent),
+                                true
+                            );
+                        }
+
                         state.Caster.BroadcastPacket(
-                            new SCPlotCastingStoppedPacket(state.ActiveSkill.TlId, 0, lastEvent),
+                            new SCPlotChannelingStoppedPacket(state.ActiveSkill.TlId, 0, 1),
                             true
-                        );
-                        state.Caster.BroadcastPacket(
-                        new SCPlotChannelingStoppedPacket(state.ActiveSkill.TlId, 0, 1),
-                        true
                         );
                     }
 
@@ -164,75 +169,77 @@ public class PlotTree(uint plotId)
         DoPlotEnd(state);
         Logger.Trace($"Tree with ID {PlotId} has finished executing took {treeWatch.ElapsedMilliseconds}ms");
     }
-    private void HandleChannelingFinish(PlotNode node, PlotState state, Queue<(PlotNode node, DateTime timestamp, PlotTargetInfo targetInfo)> queue, (PlotNode node, DateTime timestamp, PlotTargetInfo targetInfo) item)
+    /// <summary>
+    /// Bite and cancel both cut the channel wait. The wait is the child entered by a
+    /// channeling edge — not the bite-roll loop queued next to it. Ending that wait runs
+    /// hook/fail (ClearProjectile) so the cast line is torn down.
+    /// </summary>
+    private bool ResumeChannelEnd(
+        PlotState state,
+        Queue<(PlotNode node, DateTime timestamp, PlotTargetInfo targetInfo)> queue,
+        (PlotNode node, DateTime timestamp, PlotTargetInfo targetInfo) current)
     {
-        if (node == null || state == null || queue == null || item.targetInfo == null)
+        if (state == null || queue == null)
+            return false;
+
+        var waiting = new List<(PlotNode node, DateTime timestamp, PlotTargetInfo targetInfo)>(queue.Count + 1);
+        waiting.Add(current);
+        while (queue.Count > 0)
+            waiting.Add(queue.Dequeue());
+
+        var index = PlotChannelingRules.IndexOfChannelWait(
+            waiting,
+            item => item.node?.ParentNextEvent?.Channeling == true);
+        if (index < 0)
         {
-            Logger.Error($"Plot {PlotId}: Invalid arguments passed to HandleChannelingFinish.");
-            return;
+            foreach (var item in waiting)
+                queue.Enqueue(item);
+            return false;
         }
 
-        // Stop all active channeling or casting nodes
         EndPlotChannel(state);
+        state.PermitChanneling();
 
-        // Check if ParentNextEvent is null
-        if (node.ParentNextEvent == null)
+        var channelItem = waiting[index];
+        var channelNode = channelItem.node;
+        channelNode.Execute(state, channelItem.targetInfo);
+        FollowChannelEnd(
+            state,
+            channelNode,
+            channelItem.targetInfo,
+            queue,
+            enqueueDelayed: !state.CancellationRequested());
+
+        return true;
+    }
+
+    private static void FollowChannelEnd(
+        PlotState state,
+        PlotNode parent,
+        PlotTargetInfo targetInfo,
+        Queue<(PlotNode node, DateTime timestamp, PlotTargetInfo targetInfo)> queue,
+        bool enqueueDelayed)
+    {
+        foreach (var child in parent.Children ?? [])
         {
-            return;
-        }
+            if (child?.Event == null || child.ParentNextEvent == null)
+                continue;
 
-        // Determine the correct node to trigger
-        if (node.ParentNextEvent.Channeling)
-        {
+            var condition = child.CheckConditions(state, targetInfo);
+            if (condition == child.ParentNextEvent.Fail)
+                continue;
 
-            // Reset channeling state
-            state.PermitChanneling();
-
-            // Execute the correct node fully before moving to children
-            node.Execute(state, item.targetInfo);
-
-            // Use a HashSet to track unique node IDs already in the queue
-            var queuedNodeIds = new HashSet<uint>(queue.Select(q => q.node.Event.Id));
-
-            // Only enqueue children after the current node is executed
-            foreach (var child in node.Children ?? Enumerable.Empty<PlotNode>())
+            var childInfo = new PlotTargetInfo(targetInfo.Source, targetInfo.Target);
+            var delay = child.ComputeDelayMs(state, childInfo);
+            if (delay > 0)
             {
-                if (child == null || child.Event == null)
-                {
-                    Logger.Warn($"Plot {PlotId}: Skipping null child or child with null Event.");
-                    continue;
-                }
-
-                // Check if the child node's Event.Id is already in the queue
-                if (!queuedNodeIds.Contains(child.Event.Id))
-                {
-                    if (child.ParentNextEvent?.PerTarget ?? false)
-                    {
-                        foreach (var target in item.targetInfo.EffectedTargets)
-                        {
-
-                            var targetInfo = new PlotTargetInfo(item.targetInfo.Source, target);
-                            queue.Enqueue((child, DateTime.UtcNow, targetInfo));
-                            queuedNodeIds.Add(child.Event.Id); // Mark this node as queued
-                        }
-                    }
-                    else
-                    {
-                        var targetInfo = new PlotTargetInfo(item.targetInfo.Source, item.targetInfo.Target);
-                        queue.Enqueue((child, DateTime.UtcNow, targetInfo));
-                        queuedNodeIds.Add(child.Event.Id); // Mark this node as queued
-                    }
-
-                }
-                else
-                {
-                    //Logger.Debug($"Plot {PlotId}: Child node {child.Event.Id} is already in the queue. Skipping.");
-                }
+                if (enqueueDelayed)
+                    queue.Enqueue((child, DateTime.UtcNow.AddMilliseconds(delay), childInfo));
+                continue;
             }
-        }
-        else
-        {
-            //Logger.Debug($"Plot {PlotId}: No channeling node to transition to.");
+
+            child.Execute(state, childInfo);
+            FollowChannelEnd(state, child, childInfo, queue, enqueueDelayed);
         }
     }
     private static void FlushExecutionQueue(Queue<(PlotNode node, PlotTargetInfo targetInfo)> executeQueue, PlotState state)

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -179,6 +179,9 @@ public class Skill
         _zoneSkillFiredRelayed = false;
         _zoneSkillEndedRelayed = false;
         _zoneSkillCaster = null;
+        var skillTags = SkillManager.Instance.GetSkillTags(Template.Id);
+        var fishingHold = character != null &&
+                          SportFishCombat.ShouldBypassSharedGcd(Template.CastingTime, Template.TargetType, skillTags);
         if (!_bypassGcd)
         {
             lock (unit.GcdLock)
@@ -191,7 +194,7 @@ public class Skill
                 if (Id == 2 || Id == 3 || Id == 4)
                     delay = character != null ? 100 : 1500;
 
-                if (unit.SkillLastUsed.AddMilliseconds(delay) > DateTime.UtcNow)
+                if (!fishingHold && unit.SkillLastUsed.AddMilliseconds(delay) > DateTime.UtcNow)
                 {
                     Logger.Trace($"Skill: CooldownTime [{delay}]!");
                     return SkillResult.CooldownTime;
@@ -199,7 +202,8 @@ public class Skill
 
                 // Instant combo hits (e.g. Fireball 24894/24895 custom_gcd=10) must not be blocked by
                 // the parent's cast GCD — they fire at the same moment as plot cast-end.
-                var comboBypassGcd = Template.CastingTime <= 0 && Template.CustomGcd > 0 && Template.CustomGcd <= 50;
+                var comboBypassGcd = fishingHold ||
+                    (Template.CastingTime <= 0 && Template.CustomGcd > 0 && Template.CustomGcd <= 50);
                 if (unit.GlobalCooldown >= DateTime.UtcNow && !Template.IgnoreGlobalCooldown && !comboBypassGcd)
                 {
                     Logger.Trace($"Skill: GlobalCooldown active for {Template.Id}");
@@ -230,6 +234,12 @@ public class Skill
             return SkillResult.NoTarget; // We should try to make sure this doesn't happen, but can happen with NPC skills
         }
 
+        if (SportFishCombat.IsUnusableTarget(target))
+        {
+            Logger.Trace($"Skill: SkillResult.InvalidTarget! - Skill {Template.Id} vs dropped-line fish {target.ObjId}");
+            return SkillResult.InvalidTarget;
+        }
+
         // Unmount character if skill asks for it
         if (character is { IsRiding: true } && Template.Unmount)
         {
@@ -250,6 +260,21 @@ public class Skill
         TlId = SkillTlIdManager.GetNextId(caster);
         // if (caster is Character)
         Logger.Debug($"Created SkillTlId {TlId} for Skill {Template.Id}, Caster {caster.Name} ({caster.TemplateId}:{caster.ObjId}) with target {target.Name} ({target.TemplateId}:{target.ObjId})");
+
+        // Hold / reel kit ships a plot but is not flagged plot_only. Cast() after the plot
+        // starts EndSkill's the TlId while the graph is still on the bar.
+        if (Template.Plot != null
+            && !Template.PlotOnly
+            && !ForcePlotGraphOnly
+            && character != null
+            && SportFishCombat.ShouldRunPlotGraphOnly(
+                true,
+                true,
+                false,
+                skillTags))
+        {
+            ForcePlotGraphOnly = true;
+        }
 
         // If skill uses Plots, then start the plot
         if (Template.Plot != null)
@@ -1796,7 +1821,9 @@ AlwaysHit:
     /// </summary>
     public void ApplyPlotOnlyFireCosts(Unit unit)
     {
-        if (unit == null || !Template.PlotOnly || _bypassGcd)
+        if (unit == null || _bypassGcd)
+            return;
+        if (!Template.PlotOnly && !ForcePlotGraphOnly)
             return;
         ApplyGlobalCooldown(unit);
         // Skill cooldown is also applied in DoPlotEnd; applying early matches Cast() and blocks re-cast spam.

--- a/AAEmu.Game/Models/Game/Skills/ZoneAuthorityCombat.cs
+++ b/AAEmu.Game/Models/Game/Skills/ZoneAuthorityCombat.cs
@@ -223,6 +223,16 @@ public static class ZoneAuthorityCombat
             return false;
         }
 
+        if (npc.ZoneDespawnSignaled || npc.SportFishLineDropped)
+        {
+            npc.SetBattleStateFromZone(false);
+            npc.ClearAllAggro();
+            Logger.Info(
+                "ZWClearCombat npc={0} — skip leash heal (line dropped / despawn signaled)",
+                objId);
+            return false;
+        }
+
         var beforeHp = npc.Hp;
         var beforeMp = npc.Mp;
         npc.Hp = npc.MaxHp;

--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -5,6 +5,7 @@ using AAEmu.Game.Models.Game.DoodadObj.Static;
 using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Buffs;
+using AAEmu.Game.Models.Game.Skills.Effects;
 using AAEmu.Game.Models.Game.Skills.Static;
 using AAEmu.Game.Models.Game.Skills.Templates;
 using AAEmu.Game.Models.StaticValues;
@@ -299,6 +300,8 @@ public class Buffs : IBuffs
     public void AddBuff(Buff buff, uint index = 0, int forcedDuration = 0)
     {
         var finalToleranceBuffId = 0u;
+        Buff transformFrom = null;
+        var transformBuffId = 0u;
         lock (_lock)
         {
             var owner = GetOwner();
@@ -382,10 +385,13 @@ public class Buffs : IBuffs
                 case BuffStackRule.Refresh:
                     foreach (var e in new List<Buff>(_effects))
                         if (e is { InUse: true } && e.Template.BuffId == buff.Template.BuffId)
+                        {
+                            if (!BuffStackRules.ShouldOverwriteOnRefresh(buff.Duration, e.Duration))
+                                return;
                             if (buff.GetTimeLeft() < e.GetTimeLeft())
                                 return;
-                            else
-                                last = e;
+                            last = e;
+                        }
                     break;
                 case BuffStackRule.ChargeRefresh:
                     foreach (var e in new List<Buff>(_effects))
@@ -405,7 +411,16 @@ public class Buffs : IBuffs
                     var live = FindLiveInstance(buff.Template.BuffId);
                     if (live != null)
                     {
-                        if (live.TryGrowStack(buff.Template.MaxStack))
+                        var grew = live.TryGrowStack(buff.Template.MaxStack);
+                        if (BuffStackRules.ShouldTransform(
+                                live.Stack, live.Template.MaxStack, live.Template.TransformBuffId))
+                        {
+                            transformFrom = live;
+                            transformBuffId = live.Template.TransformBuffId;
+                            break;
+                        }
+
+                        if (grew)
                             return;
 
                         // At the ceiling. A permanent family has no timer to refresh, so the extra
@@ -425,7 +440,7 @@ public class Buffs : IBuffs
 
                     break;
             }
-            if (last != null)
+            if (transformBuffId == 0 && last != null)
             {
                 // Announce the instance that survives, not the one being discarded. An index is
                 // allocated for every arrival before the stack rule decides its fate, so a displacement
@@ -436,7 +451,7 @@ public class Buffs : IBuffs
                 buff.Index = last.Index;
                 last.OverwriteWith(buff);
             }
-            else
+            else if (transformBuffId == 0)
             {
                 _effects.Add(buff);
                 buff.Triggers.SubscribeEvents();
@@ -485,10 +500,29 @@ public class Buffs : IBuffs
                 }
             }
         }
+        if (transformBuffId > 0 && transformFrom != null)
+        {
+            RemoveBuff(transformFrom.Template.BuffId);
+            var nextTemplate = SkillManager.Instance.GetBuffTemplate(transformBuffId);
+            if (nextTemplate != null)
+            {
+                AddBuff(new Buff(
+                    transformFrom.Owner,
+                    transformFrom.Caster,
+                    transformFrom.SkillCaster,
+                    nextTemplate,
+                    transformFrom.Skill,
+                    DateTime.UtcNow));
+            }
+        }
+
         if (finalToleranceBuffId > 0)
         {
             AddBuff(new Buff(buff.Owner, buff.Caster, buff.SkillCaster, SkillManager.Instance.GetBuffTemplate(finalToleranceBuffId), buff.Skill, DateTime.UtcNow));
         }
+
+        if (buff.Template.BuffId == SportFishCombat.LineBrokenBuffId && GetOwner() is Npc lineFish)
+            SportFishCombat.OnLineDropped(lineFish);
     }
 
     private uint AllocateIndex()

--- a/AAEmu.Game/Models/StaticValues/TagsEnum.cs
+++ b/AAEmu.Game/Models/StaticValues/TagsEnum.cs
@@ -9,7 +9,9 @@ public enum TagsEnum : uint
     Left = 1021, //Sports fishing move left
     Descend = 1022, //Sports fishing move down
     Back = 1023, //Sports fishing run away
+    FishingSkill = 1024, // sport-rod hold / reel / bite kit
     Fish = 1025, // Sports Fishing fish
+    SportFishStart = 1090, // applied by bite 21608; plot 821 waits on this
     PlaySong = 1155,
 
 }

--- a/AAEmu.Game/Scripts/Commands/ActabilityCmd.cs
+++ b/AAEmu.Game/Scripts/Commands/ActabilityCmd.cs
@@ -1,0 +1,99 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Utils.Scripts;
+
+namespace AAEmu.Game.Scripts.Commands;
+
+public class ActabilityCmd : ICommand
+{
+    public string[] CommandNames { get; set; } = ["actability", "vocation"];
+
+    public void OnLoad()
+    {
+        CommandManager.Instance.Register(CommandNames, this);
+    }
+
+    public string GetCommandLineHelp()
+    {
+        return "(target) <id|name> <points> [step]";
+    }
+
+    public string GetCommandHelpText()
+    {
+        return
+            "Set a vocation (actability) to <points>, optionally moving its expert step first.\n" +
+            "Fishing is 7. Step 0 is Amateur (cap 10000). Rank buttons keep the point total;\n" +
+            "this command still clamps to the selected step's cap.\n" +
+            "Example: /actability 7 10000   or   /actability fishing 50000 4";
+    }
+
+    public void Execute(Character character, string[] args, IMessageOutput messageOutput)
+    {
+        if (args.Length == 0)
+        {
+            CommandManager.SendDefaultHelpText(this, messageOutput);
+            return;
+        }
+
+        var targetPlayer = WorldManager.Instance.GetTargetOrSelf(character, args[0], out var firstArg);
+        if (args.Length <= firstArg + 1)
+        {
+            CommandManager.SendDefaultHelpText(this, messageOutput);
+            return;
+        }
+
+        if (!TryResolveActabilityId(args[firstArg], out var actabilityId))
+        {
+            CommandManager.SendErrorText(this, messageOutput, $"Unknown actability '{args[firstArg]}'");
+            return;
+        }
+
+        if (!int.TryParse(args[firstArg + 1], out var points))
+        {
+            CommandManager.SendErrorText(this, messageOutput, "points must be an integer");
+            return;
+        }
+
+        int? step = null;
+        if (args.Length > firstArg + 2)
+        {
+            if (!int.TryParse(args[firstArg + 2], out var parsedStep) || parsedStep < 0)
+            {
+                CommandManager.SendErrorText(this, messageOutput, "step must be a non-negative integer");
+                return;
+            }
+
+            step = parsedStep;
+        }
+
+        if (!targetPlayer.Actability.TrySet(actabilityId, points, step))
+        {
+            CommandManager.SendErrorText(this, messageOutput,
+                $"Could not set actability {actabilityId} (missing group or expert step)");
+            return;
+        }
+
+        var updated = targetPlayer.Actability.Actabilities[actabilityId];
+        CommandManager.SendNormalText(this, messageOutput,
+            $"{targetPlayer.Name} actability {actabilityId} = {updated.Point} (step {updated.Step})");
+        if (character.Id != targetPlayer.Id)
+            targetPlayer.SendMessage($"[GM] {character.Name} set your actability {actabilityId} to {updated.Point}");
+    }
+
+    private static bool TryResolveActabilityId(string raw, out uint id)
+    {
+        if (uint.TryParse(raw, out id))
+            return id > 0;
+
+        if (Enum.TryParse<ActabilityType>(raw, ignoreCase: true, out var named) && named != ActabilityType.None)
+        {
+            id = (uint)named;
+            return true;
+        }
+
+        id = 0;
+        return false;
+    }
+}

--- a/AAEmu.Game/Scripts/Commands/FishSchoolCountCmd.cs
+++ b/AAEmu.Game/Scripts/Commands/FishSchoolCountCmd.cs
@@ -1,0 +1,51 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.StaticValues;
+using AAEmu.Game.Utils.Scripts;
+using NLog;
+
+namespace AAEmu.Game.Scripts.Commands;
+
+public class FishSchoolCountCmd : ICommand
+{
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
+    public string[] CommandNames { get; set; } = ["fishschools"];
+
+    public void OnLoad()
+    {
+        CommandManager.Instance.Register(CommandNames, this);
+    }
+
+    public string GetCommandLineHelp()
+    {
+        return "";
+    }
+
+    public string GetCommandHelpText()
+    {
+        return "Count fish-school doodads that are still present.";
+    }
+
+    public void Execute(Character character, string[] args, IMessageOutput messageOutput)
+    {
+        var all = FishSchoolManager.Instance.GetAllFishSchools();
+        var fresh = 0;
+        var salt = 0;
+        var other = 0;
+        foreach (var doodad in all)
+        {
+            if (doodad.TemplateId == DoodadConstants.FreshwaterFishSchool)
+                fresh++;
+            else if (doodad.TemplateId == DoodadConstants.SaltwaterFishSchool)
+                salt++;
+            else
+                other++;
+        }
+
+        var msg = $"present={all.Count} fresh={fresh} salt={salt} other={other}";
+        Logger.Info("FishSchoolCount {0}", msg);
+        CommandManager.SendNormalText(this, messageOutput, msg);
+    }
+}

--- a/AAEmu.Game/Scripts/SubCommands/Doodads/DoodadSaveSubCommand.cs
+++ b/AAEmu.Game/Scripts/SubCommands/Doodads/DoodadSaveSubCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Drawing;
+using System.Threading.Tasks;
 using AAEmu.Commons.IO;
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers;

--- a/AAEmu.Game/WorldIntegration.cs
+++ b/AAEmu.Game/WorldIntegration.cs
@@ -980,6 +980,7 @@ public static class WorldIntegration
             // Keep the mirror and its id reserved until ZWRemoveNpc confirms the authority has
             // retired the unit. Releasing earlier could recycle the bc while Zone still owns it.
             PublishNpcDespawn(npc);
+            npc.ParentWorld?.SpawnManager?.ScheduleZoneDespawnAck(npc);
             return;
         }
 

--- a/AAEmu.UnitTests/Game/Core/Managers/FishSchoolManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/FishSchoolManagerTests.cs
@@ -1,0 +1,142 @@
+using System.Reflection;
+
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.DoodadObj.Static;
+using AAEmu.Game.Models.Game.DoodadObj.Templates;
+using AAEmu.Game.Models.Game.World;
+using AAEmu.Game.Models.Game.World.Xml;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+[NotInParallel]
+public class FishSchoolManagerTests
+{
+    [Test]
+    public async Task GetAllFishSchools_SkipsDeletedAndForeignTemplates()
+    {
+        FishSchoolManager.Instance.Initialize();
+        try
+        {
+            var world = NewWorld(11);
+            var live = School(1, visible: true);
+            var hidden = School(2, visible: false);
+            var tree = new Doodad
+            {
+                ObjId = 3,
+                Template = new DoodadTemplate { GroupId = (uint)DoodadGroupId.Deforestation },
+                IsVisible = true
+            };
+            Attach(live, world);
+            Attach(hidden, world);
+            Attach(tree, world);
+            world.AddObject(live);
+            world.AddObject(hidden);
+            world.AddObject(tree);
+
+            FishSchoolManager.Instance.Track(live);
+            FishSchoolManager.Instance.Track(hidden);
+            FishSchoolManager.Instance.Track(tree);
+
+            var listed = FishSchoolManager.Instance.GetAllFishSchools();
+            await Assert.That(listed).Contains(live);
+            await Assert.That(listed).DoesNotContain(hidden);
+            await Assert.That(listed).DoesNotContain(tree);
+
+            world.RemoveObject(live);
+            listed = FishSchoolManager.Instance.GetAllFishSchools();
+            await Assert.That(listed).DoesNotContain(live);
+
+            world.Dispose();
+        }
+        finally
+        {
+            FishSchoolManager.Instance.Initialize();
+        }
+    }
+
+    [Test]
+    public async Task Untrack_DropsASchoolFromRadar()
+    {
+        FishSchoolManager.Instance.Initialize();
+        try
+        {
+            var world = NewWorld(12);
+            var school = School(4, visible: true);
+            Attach(school, world);
+            world.AddObject(school);
+            FishSchoolManager.Instance.Track(school);
+
+            await Assert.That(FishSchoolManager.Instance.GetAllFishSchools()).Contains(school);
+
+            FishSchoolManager.Instance.Untrack(school);
+            await Assert.That(FishSchoolManager.Instance.GetAllFishSchools()).DoesNotContain(school);
+
+            world.Dispose();
+        }
+        finally
+        {
+            FishSchoolManager.Instance.Initialize();
+        }
+    }
+
+    [Test]
+    public async Task Load_ReplacesLeftoverPinsForThatWorld()
+    {
+        FishSchoolManager.Instance.Initialize();
+        try
+        {
+            var world = NewWorld(13);
+            var leftover = School(5, visible: true);
+            var live = School(6, visible: true);
+            Attach(leftover, world);
+            Attach(live, world);
+            world.AddObject(live);
+            FishSchoolManager.Instance.Track(leftover);
+
+            FishSchoolManager.Instance.Load(world);
+
+            var listed = FishSchoolManager.Instance.GetAllFishSchools();
+            await Assert.That(listed).Contains(live);
+            await Assert.That(listed).DoesNotContain(leftover);
+
+            world.Dispose();
+        }
+        finally
+        {
+            FishSchoolManager.Instance.Initialize();
+        }
+    }
+
+    private static Doodad School(uint objId, bool visible) =>
+        new()
+        {
+            ObjId = objId,
+            Template = new DoodadTemplate { GroupId = (uint)DoodadGroupId.SportFishing },
+            IsVisible = visible
+        };
+
+    private static void Attach(Doodad doodad, WorldInstance world)
+    {
+        typeof(GameObject)
+            .GetField("_parentWorld", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(doodad, world);
+    }
+
+    private static WorldInstance NewWorld(uint id) =>
+        new(new WorldTemplate
+        {
+            CellX = 1,
+            CellY = 1,
+            Cells = new WorldCell[0, 0],
+            HousingZones = [],
+            Id = 0,
+            Name = "test_world",
+            OceanLevel = 100f,
+            SubZones = [],
+            XmlWorld = new XmlWorld { Zones = [] },
+            XmlWorldZones = [],
+            ZoneKeyByRegions = new uint[1, 1],
+            ZoneKeys = [0]
+        }, 0, true, id);
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/RadarRangeRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/RadarRangeRulesTests.cs
@@ -1,0 +1,32 @@
+using AAEmu.Game.Core.Managers;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class RadarRangeRulesTests
+{
+    [Test]
+    public async Task BuffRange_KeepsNearbySchool()
+    {
+        await Assert.That(RadarRangeRules.IsInRange(800f, 1000f)).IsTrue();
+    }
+
+    [Test]
+    public async Task BuffRange_HidesSchoolPastTheFinder()
+    {
+        await Assert.That(RadarRangeRules.IsInRange(12000f, 1000f)).IsFalse();
+    }
+
+    [Test]
+    public async Task DisabledFinder_ShowsNothing()
+    {
+        await Assert.That(RadarRangeRules.IsInRange(10f, 0f)).IsFalse();
+    }
+
+    [Test]
+    public async Task AccessLevelMustNotWidenTheCircle()
+    {
+        const float buffRange = 850f;
+        const float acrossTheMap = 40000f;
+        await Assert.That(RadarRangeRules.IsInRange(acrossTheMap, buffRange)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/UnitManagers/CharacterManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/UnitManagers/CharacterManagerTests.cs
@@ -541,6 +541,35 @@ public class CharacterManagerTests
     }
 
     [Test]
+    public async Task GetLanguageExpertLimit_StepExists_ReturnsLimit()
+    {
+        var manager = CreateCharacterManager();
+        var limit = new ExpertLimit { Id = 32, UpLimit = 20000, UseLanguageType = true };
+        SetPrivateField(manager, "_languageExpertLimits", new Dictionary<int, ExpertLimit> { { 0, limit } });
+
+        var result = manager.GetLanguageExpertLimit(0);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result.UpLimit).IsEqualTo(20000);
+    }
+
+    [Test]
+    public async Task GetPointCapLimit_LanguageUsesLanguageCap()
+    {
+        var manager = CreateCharacterManager();
+        var production = new ExpertLimit { Id = 1, UpLimit = 10000 };
+        var language = new ExpertLimit { Id = 32, UpLimit = 20000, UseLanguageType = true };
+        SetPrivateField(manager, "_expertLimits", new Dictionary<int, ExpertLimit> { { 0, production } });
+        SetPrivateField(manager, "_languageExpertLimits", new Dictionary<int, ExpertLimit> { { 0, language } });
+
+        var fishing = manager.GetPointCapLimit((uint)ActabilityType.Fishing, 0);
+        var nuian = manager.GetPointCapLimit((uint)ActabilityType.NuianLanguage, 0);
+
+        await Assert.That(fishing.UpLimit).IsEqualTo(10000);
+        await Assert.That(nuian.UpLimit).IsEqualTo(20000);
+    }
+
+    [Test]
     public async Task GetExpandExpertLimit_NegativeStep_ReturnsNull()
     {
         // Arrange

--- a/AAEmu.UnitTests/Game/Core/Packets/G2C/SCExpertLimitModifiedPacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/G2C/SCExpertLimitModifiedPacketTests.cs
@@ -1,0 +1,37 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Packets.G2C;
+
+namespace AAEmu.UnitTests.Game.Core.Packets.G2C;
+
+public class SCExpertLimitModifiedPacketTests
+{
+    [Test]
+    public async Task Body_IsUpgradeThenPiscIdPointAndStep()
+    {
+        var body = new SCExpertLimitModifiedPacket(true, 7, 10000, 1)
+            .Write(new PacketStream())
+            .GetBytes();
+
+        var expected = new PacketStream();
+        expected.Write(true);
+        expected.WritePisc(7u, 10000u);
+        expected.Write((byte)1);
+
+        await Assert.That(body).IsEquivalentTo(expected.GetBytes());
+    }
+
+    [Test]
+    public async Task Body_IsNotAFixedWidthIdAndStep()
+    {
+        var body = new SCExpertLimitModifiedPacket(true, 7, 10000, 1)
+            .Write(new PacketStream())
+            .GetBytes();
+
+        // bool + u32 id + step. Same length as the live entry for these values, wrong bytes.
+        byte[] fixedWidth = [1, 7, 0, 0, 0, 1];
+
+        await Assert.That(body).IsNotEquivalentTo(fixedWidth);
+        await Assert.That(body[0]).IsEqualTo((byte)1);
+        await Assert.That(body[^1]).IsEqualTo((byte)1);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Char/ExpertLimitRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Char/ExpertLimitRulesTests.cs
@@ -1,0 +1,216 @@
+using AAEmu.Game.Models.Game;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Char.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Char;
+
+public class ExpertLimitRulesTests
+{
+    [Test]
+    public async Task IndexShownRow_SplitsLanguageAndSkipsHidden()
+    {
+        var production = new Dictionary<int, ExpertLimit>();
+        var language = new Dictionary<int, ExpertLimit>();
+
+        ExpertLimitRules.IndexShownRow(Row(1, 10000, show: true), production, language);
+        ExpertLimitRules.IndexShownRow(Row(2, 20000, show: true, slots: 7), production, language);
+        ExpertLimitRules.IndexShownRow(Row(32, 20000, show: true, language: true), production, language);
+        ExpertLimitRules.IndexShownRow(Row(3, 30000, show: true, slots: 6), production, language);
+        ExpertLimitRules.IndexShownRow(Row(13, 260000, show: false), production, language);
+        ExpertLimitRules.IndexShownRow(Row(12, 230000, show: true, intensified: true), production, language);
+
+        await Assert.That(production.Count).IsEqualTo(4);
+        await Assert.That(language.Count).IsEqualTo(1);
+        await Assert.That(production[0].Id).IsEqualTo(1u);
+        await Assert.That(production[1].Id).IsEqualTo(2u);
+        await Assert.That(production[2].Id).IsEqualTo(3u);
+        await Assert.That(production[3].Id).IsEqualTo(12u);
+        await Assert.That(production[3].UpLimit).IsEqualTo(230000);
+        await Assert.That(language[0].Id).IsEqualTo(32u);
+        await Assert.That(language[0].UpLimit).IsEqualTo(20000);
+    }
+
+    [Test]
+    public async Task UpgradeError_NeedsCurrentCapBeforeRankUp()
+    {
+        var current = Row(1, 10000, show: true);
+        var next = Row(2, 20000, show: true, slots: 7);
+
+        await Assert.That(ExpertLimitRules.UpgradeError(current, next, 9999, true))
+            .IsEqualTo(ErrorMessageType.ActabilityNotEnoughPoint);
+        await Assert.That(ExpertLimitRules.UpgradeError(current, next, 10000, true)).IsNull();
+    }
+
+    [Test]
+    public async Task UpgradeError_LastShownRankHasNoNext()
+    {
+        var current = Row(12, 230000, show: true, intensified: true);
+
+        await Assert.That(ExpertLimitRules.UpgradeError(current, null, 230000, true))
+            .IsEqualTo(ErrorMessageType.ActabilityCanUpgradeAnyMore);
+    }
+
+    [Test]
+    public async Task UpgradeError_FullSlotsBlock()
+    {
+        var current = Row(1, 10000, show: true);
+        var next = Row(2, 20000, show: true, slots: 7);
+
+        await Assert.That(ExpertLimitRules.UpgradeError(current, next, 10000, false))
+            .IsEqualTo(ErrorMessageType.ActabilityCanUpgradeSelectionCountLimit);
+    }
+
+    [Test]
+    public async Task DowngradeTicketError_FamedIsFree_AuthorityNeedsCertificate()
+    {
+        var famed = Row(11, 180000, show: true);
+        var authority = Row(12, 230000, show: true, intensified: true);
+
+        await Assert.That(ExpertLimitRules.RequiresIntensifiedDowngradeTicket(famed)).IsFalse();
+        await Assert.That(ExpertLimitRules.DowngradeTicketError(famed, 49001, false)).IsNull();
+
+        await Assert.That(ExpertLimitRules.RequiresIntensifiedDowngradeTicket(authority)).IsTrue();
+        await Assert.That(ExpertLimitRules.DowngradeTicketError(authority, 49001, false))
+            .IsEqualTo(ErrorMessageType.NotEnoughItem);
+        await Assert.That(ExpertLimitRules.DowngradeTicketError(authority, 49001, true)).IsNull();
+        await Assert.That(ExpertLimitRules.DowngradeTicketError(authority, 0, true))
+            .IsEqualTo(ErrorMessageType.Invalid);
+    }
+
+    [Test]
+    public async Task DowngradeError_StepZeroIsTheFloor()
+    {
+        var current = Row(1, 10000, show: true);
+        await Assert.That(ExpertLimitRules.DowngradeError(0, current, null))
+            .IsEqualTo(ErrorMessageType.ActabilityCanDowngradeAnyMore);
+        await Assert.That(ExpertLimitRules.DowngradeError(1, current, Row(1, 10000, show: true))).IsNull();
+    }
+
+    [Test]
+    public async Task ExpandError_MatchesMissingRowLivingPointAndItem()
+    {
+        await Assert.That(ExpertLimitRules.ExpandError(null, 0, true))
+            .IsEqualTo(ErrorMessageType.ActabilityCanUpgradeAnyMore);
+
+        var next = new ExpandExpertLimit { ExpandCount = 1, LifePoint = 50, ItemId = 29656, ItemCount = 1 };
+        await Assert.That(ExpertLimitRules.ExpandError(next, 10, true))
+            .IsEqualTo(ErrorMessageType.NotEnoughLivingPoint);
+        await Assert.That(ExpertLimitRules.ExpandError(next, 50, false))
+            .IsEqualTo(ErrorMessageType.NotEnoughItem);
+        await Assert.That(ExpertLimitRules.ExpandError(next, 50, true)).IsNull();
+    }
+
+    [Test]
+    public async Task HasSelectionSlot_ApprenticeCapIsSevenPlusExpanded()
+    {
+        var apprentice = Row(2, 20000, show: true, slots: 7);
+        var seven = Occupied(7, step: 1);
+
+        await Assert.That(ExpertLimitRules.HasSelectionSlot(seven, apprentice, 1, 0, 1)).IsFalse();
+        await Assert.That(ExpertLimitRules.HasSelectionSlot(seven, apprentice, 1, 1, 1)).IsTrue();
+        await Assert.That(ExpertLimitRules.HasSelectionSlot(Occupied(6, step: 1), apprentice, 1, 0, 1)).IsTrue();
+    }
+
+    [Test]
+    public async Task HasSelectionSlot_LanguageDoesNotConsumeProductionSlots()
+    {
+        var apprentice = Row(2, 20000, show: true, slots: 7);
+        var filled = Occupied(7, step: 1);
+        filled.Add(Make((uint)ActabilityType.NuianLanguage, 1, viewGroup: 4));
+
+        await Assert.That(ExpertLimitRules.HasSelectionSlot(filled, apprentice, 1, 0, 1)).IsFalse();
+        await Assert.That(ExpertLimitRules.UsesLanguageLadder((uint)ActabilityType.NuianLanguage)).IsTrue();
+        await Assert.That(ExpertLimitRules.CountsTowardProductionSlots((uint)ActabilityType.Fishing, true)).IsTrue();
+        await Assert.That(ExpertLimitRules.CountsTowardProductionSlots((uint)ActabilityType.NuianLanguage, true))
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task HasSelectionSlot_ZeroExpertLimitIsUnlimited()
+    {
+        var novice = Row(1, 10000, show: true, slots: 0);
+        await Assert.That(ExpertLimitRules.HasSelectionSlot(Occupied(20, step: 0), novice, 0, 0, 1)).IsTrue();
+    }
+
+    [Test]
+    public async Task HasSelectionSlot_IntensifiedUsesViewGroupCapWithoutExpand()
+    {
+        var master = Row(12, 230000, show: true, intensified: true);
+        master.IntensifiedViewGroupLimits[1] = 2;
+        var one = new List<Actability> { Make((uint)ActabilityType.Fishing, 11, viewGroup: 1) };
+
+        await Assert.That(ExpertLimitRules.HasSelectionSlot(one, master, 11, 14, 1)).IsTrue();
+        one.Add(Make((uint)ActabilityType.Farming, 11, viewGroup: 1));
+        await Assert.That(ExpertLimitRules.HasSelectionSlot(one, master, 11, 14, 1)).IsFalse();
+        await Assert.That(ExpertLimitRules.HasSelectionSlot(one, master, 11, 0, 2)).IsFalse();
+    }
+
+    [Test]
+    public async Task ClampPoints_UsesTheRankCap()
+    {
+        var expert = Row(5, 50000, show: true, slots: 4);
+        await Assert.That(ExpertLimitRules.ClampPoints(expert, 60000)).IsEqualTo(50000);
+        await Assert.That(ExpertLimitRules.ClampPoints(expert, -1)).IsEqualTo(0);
+        await Assert.That(ExpertLimitRules.ClampPoints(null, 10)).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task AddEarnedPoints_DoesNotWipeBankedTotal()
+    {
+        await Assert.That(ExpertLimitRules.AddEarnedPoints(50000, 100, 10000)).IsEqualTo(50000);
+        await Assert.That(ExpertLimitRules.AddEarnedPoints(9000, 2000, 10000)).IsEqualTo(10000);
+        await Assert.That(ExpertLimitRules.AddEarnedPoints(5000, 100, 10000)).IsEqualTo(5100);
+        await Assert.That(ExpertLimitRules.AddEarnedPoints(50000, -100, 10000)).IsEqualTo(49900);
+    }
+
+    [Test]
+    public async Task UpgradeError_BankedPointsCanClimbFromAmateur()
+    {
+        var amateur = Row(1, 10000, show: true);
+        var novice = Row(2, 20000, show: true, slots: 7);
+        var veteran = Row(3, 30000, show: true, slots: 6);
+
+        await Assert.That(ExpertLimitRules.UpgradeError(amateur, novice, 10000, true)).IsNull();
+        await Assert.That(ExpertLimitRules.UpgradeError(amateur, novice, 50000, true)).IsNull();
+        await Assert.That(ExpertLimitRules.UpgradeError(novice, veteran, 50000, true)).IsNull();
+        await Assert.That(ExpertLimitRules.UpgradeError(veteran, Row(4, 40000, show: true, slots: 5), 19999, true))
+            .IsEqualTo(ErrorMessageType.ActabilityNotEnoughPoint);
+    }
+
+    private static ExpertLimit Row(
+        uint id,
+        int upLimit,
+        bool show,
+        byte slots = 0,
+        bool language = false,
+        bool intensified = false) =>
+        new()
+        {
+            Id = id,
+            UpLimit = upLimit,
+            ExpertLimitCount = slots,
+            Show = show,
+            UseLanguageType = language,
+            UseIntensified = intensified
+        };
+
+    private static List<Actability> Occupied(int count, byte step)
+    {
+        var list = new List<Actability>(count);
+        for (var i = 0; i < count; i++)
+            list.Add(Make((uint)(i + 1), step, viewGroup: 1));
+        return list;
+    }
+
+    private static Actability Make(uint id, byte step, uint viewGroup) =>
+        new(new ActabilityTemplate
+        {
+            Id = id,
+            ViewGroupId = viewGroup,
+            CountsTowardExpertLimit = true
+        })
+        {
+            Point = 0,
+            Step = step
+        };
+}

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadFuncIncomingSkillTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadFuncIncomingSkillTests.cs
@@ -1,0 +1,39 @@
+using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.DoodadObj.Funcs;
+
+namespace AAEmu.UnitTests.Game.Models.Game.DoodadObj;
+
+public class DoodadFuncIncomingSkillTests
+{
+    [Test]
+    public async Task SkillHit_MatchesTemplateSkillWhenFuncSkillIdIsEmpty()
+    {
+        // Every SkillHit row in 10.0.2.13 has doodad_funcs.func_skill_id unset.
+        var hit = new DoodadFuncSkillHit { SkillId = 21744 };
+        await Assert.That(DoodadFuncIncomingSkill.TemplateAccepts(hit, 21744)).IsTrue();
+        await Assert.That(DoodadFuncIncomingSkill.TemplateAccepts(hit, 21693)).IsFalse();
+    }
+
+    [Test]
+    public async Task FakeUse_MatchesFakeSkillId()
+    {
+        var fake = new DoodadFuncFakeUse { FakeSkillId = 100 };
+        await Assert.That(DoodadFuncIncomingSkill.TemplateAccepts(fake, 100)).IsTrue();
+        await Assert.That(DoodadFuncIncomingSkill.TemplateAccepts(fake, 99)).IsFalse();
+    }
+
+    [Test]
+    public async Task Use_MatchesSkillId()
+    {
+        var use = new DoodadFuncUse { SkillId = 50 };
+        await Assert.That(DoodadFuncIncomingSkill.TemplateAccepts(use, 50)).IsTrue();
+        await Assert.That(DoodadFuncIncomingSkill.TemplateAccepts(use, 0)).IsFalse();
+    }
+
+    [Test]
+    public async Task NullOrZeroSkill_NeverMatches()
+    {
+        await Assert.That(DoodadFuncIncomingSkill.TemplateAccepts(null, 21693)).IsFalse();
+        await Assert.That(DoodadFuncIncomingSkill.TemplateAccepts(new DoodadFuncSkillHit { SkillId = 21693 }, 0)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/FishSchoolLookupTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/FishSchoolLookupTests.cs
@@ -1,0 +1,159 @@
+using System.Reflection;
+
+using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.DoodadObj.Funcs;
+using AAEmu.Game.Models.Game.DoodadObj.Static;
+using AAEmu.Game.Models.Game.DoodadObj.Templates;
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.World;
+using AAEmu.Game.Models.Game.World.Xml;
+
+namespace AAEmu.UnitTests.Game.Models.Game.DoodadObj;
+
+public class FishSchoolLookupTests
+{
+    [Test]
+    public async Task IsSchool_Group65_IsTrue()
+    {
+        var school = new Doodad { Template = new DoodadTemplate { GroupId = (uint)DoodadGroupId.SportFishing } };
+        var tree = new Doodad { Template = new DoodadTemplate { GroupId = (uint)DoodadGroupId.Deforestation } };
+        await Assert.That(FishSchoolLookup.IsSchool(school)).IsTrue();
+        await Assert.That(FishSchoolLookup.IsSchool(tree)).IsFalse();
+        await Assert.That(FishSchoolLookup.IsSchool(null)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsPresent_RequiresALiveSchoolInItsWorld()
+    {
+        var school = new Doodad
+        {
+            Template = new DoodadTemplate { GroupId = (uint)DoodadGroupId.SportFishing },
+            IsVisible = true
+        };
+        var tree = new Doodad
+        {
+            Template = new DoodadTemplate { GroupId = (uint)DoodadGroupId.Deforestation },
+            IsVisible = true
+        };
+
+        await Assert.That(FishSchoolLookup.IsPresent(school)).IsFalse();
+        await Assert.That(FishSchoolLookup.IsPresent(tree)).IsFalse();
+        await Assert.That(FishSchoolLookup.IsPresent(null)).IsFalse();
+
+        school.IsVisible = false;
+        await Assert.That(FishSchoolLookup.IsPresent(school)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsPresent_TrueOnlyWhileTheWorldStillOwnsTheDoodad()
+    {
+        var world = new WorldInstance(new WorldTemplate
+        {
+            CellX = 1,
+            CellY = 1,
+            Cells = new WorldCell[0, 0],
+            HousingZones = [],
+            Id = 0,
+            Name = "test_world",
+            OceanLevel = 100f,
+            SubZones = [],
+            XmlWorld = new XmlWorld { Zones = [] },
+            XmlWorldZones = [],
+            ZoneKeyByRegions = new uint[1, 1],
+            ZoneKeys = [0]
+        }, 0, true, 14);
+
+        var school = new Doodad
+        {
+            ObjId = 7,
+            Template = new DoodadTemplate { GroupId = (uint)DoodadGroupId.SportFishing },
+            IsVisible = true
+        };
+        typeof(GameObject)
+            .GetField("_parentWorld", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(school, world);
+
+        await Assert.That(FishSchoolLookup.IsPresent(school)).IsFalse();
+
+        world.AddObject(school);
+        await Assert.That(FishSchoolLookup.IsPresent(school)).IsTrue();
+
+        world.RemoveObject(school);
+        await Assert.That(FishSchoolLookup.IsPresent(school)).IsFalse();
+
+        world.Dispose();
+    }
+
+    [Test]
+    public async Task ReadActiveSpawnerId_IdlePhase_IsZero()
+    {
+        var doodad = new Doodad
+        {
+            Template = new DoodadTemplate { GroupId = (uint)DoodadGroupId.SportFishing }
+        };
+        doodad.CurrentPhaseFuncs.Add(new DoodadPhaseFunc { FuncId = 1, FuncType = "DoodadFuncTimer" });
+
+        var id = FishSchoolLookup.ReadActiveSpawnerId(doodad, (_, type) =>
+            type == "DoodadFuncFishSchool" ? new DoodadFuncFishSchool { NpcSpawnerId = 17535 } : null);
+
+        await Assert.That(id).IsEqualTo(0u);
+    }
+
+    [Test]
+    public async Task ReadActiveSpawnerId_ChummedPhase_ReturnsSpawner()
+    {
+        var doodad = new Doodad
+        {
+            Template = new DoodadTemplate { GroupId = (uint)DoodadGroupId.SportFishing }
+        };
+        doodad.CurrentPhaseFuncs.Add(new DoodadPhaseFunc { FuncId = 29, FuncType = "DoodadFuncFishSchool" });
+
+        var id = FishSchoolLookup.ReadActiveSpawnerId(doodad, (_, type) =>
+            type == "DoodadFuncFishSchool" ? new DoodadFuncFishSchool { NpcSpawnerId = 17535 } : null);
+
+        await Assert.That(id).IsEqualTo(17535u);
+    }
+
+    [Test]
+    public async Task ResolveNearestSpawnerId_PicksClosestChummedSchool()
+    {
+        var schools = new (float X, float Y, uint SpawnerId)[]
+        {
+            (0f, 0f, 0),       // idle, ignored
+            (40f, 0f, 17534),  // farther chummed
+            (10f, 0f, 17535),  // nearer chummed
+        };
+
+        var id = FishSchoolLookup.ResolveNearestSpawnerId(schools, originX: 0f, originY: 0f, rangeMeters: 50f);
+        await Assert.That(id).IsEqualTo(17535u);
+    }
+
+    [Test]
+    public async Task ResolveNearestSpawnerId_OutOfRange_IsZero()
+    {
+        var schools = new (float X, float Y, uint SpawnerId)[] { (100f, 0f, 17535) };
+        var id = FishSchoolLookup.ResolveNearestSpawnerId(schools, 0f, 0f, 50f);
+        await Assert.That(id).IsEqualTo(0u);
+    }
+
+    [Test]
+    public async Task SelectWeighted_RespectsWeights()
+    {
+        var npcs = new List<NpcSpawnerNpc>
+        {
+            new() { MemberId = 1, Weight = 1f },
+            new() { MemberId = 2, Weight = 3f },
+        };
+
+        await Assert.That(FishSchoolLookup.SelectWeighted(npcs, 0.0)?.MemberId).IsEqualTo(1u);
+        await Assert.That(FishSchoolLookup.SelectWeighted(npcs, 0.24)?.MemberId).IsEqualTo(1u);
+        await Assert.That(FishSchoolLookup.SelectWeighted(npcs, 0.25)?.MemberId).IsEqualTo(2u);
+        await Assert.That(FishSchoolLookup.SelectWeighted(npcs, 0.99)?.MemberId).IsEqualTo(2u);
+    }
+
+    [Test]
+    public async Task SelectWeighted_Empty_IsNull()
+    {
+        await Assert.That(FishSchoolLookup.SelectWeighted([], 0.5)).IsNull();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/Funcs/DoodadFuncSkillHitTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/Funcs/DoodadFuncSkillHitTests.cs
@@ -1,0 +1,44 @@
+using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.DoodadObj.Funcs;
+
+namespace AAEmu.UnitTests.Game.Models.Game.DoodadObj.Funcs;
+
+public class DoodadFuncSkillHitTests
+{
+    [Test]
+    public async Task AdvancesPhase_MatchingSkill_IsTrue()
+    {
+        await Assert.That(DoodadFuncSkillHit.AdvancesPhase(21693, 21693)).IsTrue();
+    }
+
+    [Test]
+    public async Task AdvancesPhase_OtherChumSkill_IsFalse()
+    {
+        // Idle freshwater 26362 lists 21693 then 21744. The wrong row must not advance.
+        await Assert.That(DoodadFuncSkillHit.AdvancesPhase(21693, 21744)).IsFalse();
+    }
+
+    [Test]
+    public async Task AdvancesPhase_UnsetHitSkill_IsFalse()
+    {
+        await Assert.That(DoodadFuncSkillHit.AdvancesPhase(0, 21693)).IsFalse();
+    }
+
+    [Test]
+    public async Task Use_MatchingSkill_SetsToNextPhaseWithoutRecast()
+    {
+        var owner = new Doodad();
+        var hit = new DoodadFuncSkillHit { SkillId = 21693 };
+        hit.Use(null, owner, 21693);
+        await Assert.That(owner.ToNextPhase).IsTrue();
+    }
+
+    [Test]
+    public async Task Use_Mismatch_DoesNotAdvance()
+    {
+        var owner = new Doodad();
+        var hit = new DoodadFuncSkillHit { SkillId = 21693 };
+        hit.Use(null, owner, 21744);
+        await Assert.That(owner.ToNextPhase).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/FishSchools/FishSalePriceTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/FishSchools/FishSalePriceTests.cs
@@ -1,0 +1,45 @@
+using AAEmu.Game.Models.Game.FishSchools;
+
+namespace AAEmu.UnitTests.Game.Models.Game.FishSchools;
+
+public class FishSalePriceTests
+{
+    // Small tuna pack 27501 (소형 참다랑어 꾸러미). Catalog: item_prices.refund 91000,
+    // fish_details 284–356, item_grades 0→100 / 2→150. The two live stand sales on 2026-09-04
+    // were this template: a caught pack (grade 0) and `/item add self 27501 1 2`.
+    private const int SmallTunaRefund = 91000;
+    private const int SmallTunaMaxWeight = 356;
+    private const int CaughtWeight = 320;
+    private const int Grade0Multiplier = 100;
+    private const int Grade2Multiplier = 150;
+
+    [Test]
+    public async Task CaughtSmallTunaPack_Grade0_PaysWeightShareOfRefund()
+    {
+        var ok = FishSalePrice.TryCalculate(
+            SmallTunaRefund, Grade0Multiplier, CaughtWeight, SmallTunaMaxWeight, out var price);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(price).IsEqualTo(81798);
+    }
+
+    [Test]
+    public async Task GmSmallTunaPack_Grade2_PaysGradeAdjustedRefund()
+    {
+        var ok = FishSalePrice.TryCalculate(
+            SmallTunaRefund, Grade2Multiplier, CaughtWeight, SmallTunaMaxWeight, out var price);
+
+        await Assert.That(ok).IsTrue();
+        await Assert.That(price).IsEqualTo(122697);
+    }
+
+    [Test]
+    public async Task ZeroWeight_DoesNotPriceASale()
+    {
+        var ok = FishSalePrice.TryCalculate(
+            SmallTunaRefund, Grade0Multiplier, 0f, SmallTunaMaxWeight, out var price);
+
+        await Assert.That(ok).IsFalse();
+        await Assert.That(price).IsEqualTo(0);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Items/ItemChargeRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Items/ItemChargeRulesTests.cs
@@ -1,0 +1,75 @@
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Items;
+
+public class ItemChargeRulesTests
+{
+    // Bamboo fishing rod 27308 names golden crafted lure 45600 as its recharge reagent.
+    private const uint BambooRodRestrictLure = 45600;
+
+    [Test]
+    public async Task TryApply_NamedLure_StartsANewChargeWindow()
+    {
+        var rod = Rod(SlotType.Inventory);
+        var lure = new Item { TemplateId = BambooRodRestrictLure };
+        var at = new DateTime(2026, 9, 4, 12, 20, 45, DateTimeKind.Utc);
+
+        var result = ItemChargeRules.TryApply(rod, lure, at);
+
+        await Assert.That(result).IsEqualTo(ItemChargeRules.RechargeApply.Applied);
+        await Assert.That(rod.ChargeStartTime).IsEqualTo(at);
+        await Assert.That(rod.ChargeCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task TryApply_WrongReagent_IsRejected()
+    {
+        var rod = Rod(SlotType.Inventory);
+        var other = new Item { TemplateId = 27319 };
+
+        var result = ItemChargeRules.TryApply(rod, other, DateTime.UtcNow);
+
+        await Assert.That(result).IsEqualTo(ItemChargeRules.RechargeApply.Rejected);
+        await Assert.That(rod.ChargeStartTime).IsEqualTo(DateTime.MinValue);
+    }
+
+    [Test]
+    public async Task TryApply_EquippedRod_IsRefused()
+    {
+        var rod = Rod(SlotType.Equipment);
+        var lure = new Item { TemplateId = BambooRodRestrictLure };
+
+        var result = ItemChargeRules.TryApply(rod, lure, DateTime.UtcNow);
+
+        await Assert.That(result).IsEqualTo(ItemChargeRules.RechargeApply.Equipped);
+        await Assert.That(rod.ChargeStartTime).IsEqualTo(DateTime.MinValue);
+    }
+
+    [Test]
+    public async Task TryApply_MissingRestrict_IsRejected()
+    {
+        var rod = new EquipItem
+        {
+            Template = new EquipItemTemplate { RechargeRestrictItemId = 0, ChargeCount = 0 },
+            SlotType = SlotType.Inventory
+        };
+        var lure = new Item { TemplateId = BambooRodRestrictLure };
+
+        await Assert.That(ItemChargeRules.TryApply(rod, lure, DateTime.UtcNow))
+            .IsEqualTo(ItemChargeRules.RechargeApply.Rejected);
+    }
+
+    private static EquipItem Rod(SlotType slot) =>
+        new()
+        {
+            Template = new EquipItemTemplate
+            {
+                RechargeRestrictItemId = BambooRodRestrictLure,
+                ChargeCount = 0,
+                ChargeLifetime = 120,
+                RechargeBuffId = 22921
+            },
+            SlotType = slot
+        };
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/BuffStackRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/BuffStackRulesTests.cs
@@ -37,6 +37,16 @@ public class BuffStackRulesTests
     }
 
     [Test]
+    public async Task ShouldTransform_FiresAtTheCeilingWhenATransformIsNamed()
+    {
+        // Tension 5793 → line-broken 5794 at 20. Sail trim has no transform and must stay put.
+        await Assert.That(BuffStackRules.ShouldTransform(20, 20, 5794)).IsTrue();
+        await Assert.That(BuffStackRules.ShouldTransform(19, 20, 5794)).IsFalse();
+        await Assert.That(BuffStackRules.ShouldTransform(20, 20, 0)).IsFalse();
+        await Assert.That(BuffStackRules.ShouldTransform(1, 1, 5794)).IsFalse();
+    }
+
+    [Test]
     public async Task ScaledModifier_GrowsSailTrimBySixPerStack()
     {
         // Sail trim is +6 move_speed_mul per application, ceiling 60. The first tick is +6;
@@ -45,5 +55,23 @@ public class BuffStackRulesTests
         await Assert.That(BuffStackRules.ScaledModifier(6, 0, 1, 2)).IsEqualTo(12);
         await Assert.That(BuffStackRules.ScaledModifier(6, 0, 1, 60)).IsEqualTo(360);
         await Assert.That(BuffStackRules.ScaledModifier(6, 0, 1, 0)).IsEqualTo(6);
+    }
+
+    [Test]
+    public async Task Refresh_KeepsAPermanentInstance()
+    {
+        // Fishing 4053 is duration 0 / Refresh. A second apply must not overwrite.
+        await Assert.That(BuffStackRules.ShouldOverwriteOnRefresh(0, 0)).IsFalse();
+        await Assert.That(BuffStackRules.ShouldOverwriteOnRefresh(1500, 0)).IsTrue();
+        await Assert.That(BuffStackRules.ShouldOverwriteOnRefresh(0, 1500)).IsTrue();
+        await Assert.That(BuffStackRules.ShouldOverwriteOnRefresh(1500, 800)).IsTrue();
+    }
+
+    [Test]
+    public async Task DispelTask_OnlyForTimedOrTicking()
+    {
+        await Assert.That(BuffStackRules.ShouldScheduleDispel(0, 0)).IsFalse();
+        await Assert.That(BuffStackRules.ShouldScheduleDispel(1500, 0)).IsTrue();
+        await Assert.That(BuffStackRules.ShouldScheduleDispel(0, 800)).IsTrue();
     }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/BuffTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/BuffTests.cs
@@ -452,6 +452,28 @@ public class BuffTests
         await Assert.That(bonuses[0].Value).IsEqualTo(100);
     }
 
+    [Test]
+    public async Task OverwriteWith_PermanentRefresh_StaysActing()
+    {
+        var owner = new Unit();
+        var caster = new Unit();
+        var template = new BuffTemplate { Duration = 0, Tick = 0 };
+        var live = CreateBonusBuff(owner, caster, template, index: 19u);
+        live.InUse = true;
+        live.State = EffectState.Acting;
+        live.Duration = 0;
+        var incoming = CreateBonusBuff(owner, caster, template, index: 99u);
+        incoming.Duration = 0;
+
+        live.OverwriteWith(incoming);
+
+        await Assert.That(live.IsEnded()).IsFalse();
+        await Assert.That(live.State).IsEqualTo(EffectState.Acting);
+        await Assert.That(live.InUse).IsTrue();
+        await Assert.That(live.Duration).IsEqualTo(0);
+        await Assert.That(live.EndTime).IsEqualTo(DateTime.MinValue);
+    }
+
     #endregion
 
     #region Zone relay

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/Effects/SportFishCombatTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/Effects/SportFishCombatTests.cs
@@ -1,0 +1,122 @@
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Effects;
+using AAEmu.Game.Models.StaticValues;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills.Effects;
+
+public class SportFishCombatTests
+{
+    [Test]
+    public async Task WithoutZoneAuthority_AllInCombatSkillsRunOnWorld()
+    {
+        await Assert.That(SportFishCombat.ShouldWorldApplyInCombatSkill(false, false, 21096)).IsTrue();
+        await Assert.That(SportFishCombat.ShouldWorldApplyInCombatSkill(false, true, 21096)).IsTrue();
+        await Assert.That(SportFishCombat.ShouldWorldApplyInCombatSkill(false, false, SportFishCombat.BiteSkillId)).IsTrue();
+    }
+
+    [Test]
+    public async Task ZoneMirror_OnlyBiteRunsOnWorld()
+    {
+        await Assert.That(SportFishCombat.ShouldWorldApplyInCombatSkill(true, true, SportFishCombat.BiteSkillId)).IsTrue();
+        await Assert.That(SportFishCombat.ShouldWorldApplyInCombatSkill(true, true, 21096)).IsFalse();
+        await Assert.That(SportFishCombat.ShouldWorldApplyInCombatSkill(true, true, 21208)).IsFalse();
+    }
+
+    [Test]
+    public async Task ZoneAuthorityNonMirror_KeepsFullWorldKit()
+    {
+        await Assert.That(SportFishCombat.ShouldWorldApplyInCombatSkill(true, false, 21096)).IsTrue();
+    }
+
+    [Test]
+    public async Task HoldKit_RunsPlotGraphOnly()
+    {
+        uint[] fishing = [(uint)TagsEnum.FishingSkill];
+        await Assert.That(SportFishCombat.ShouldRunPlotGraphOnly(true, true, false, fishing)).IsTrue();
+        await Assert.That(SportFishCombat.ShouldRunPlotGraphOnly(true, true, true, [])).IsTrue();
+        await Assert.That(SportFishCombat.ShouldRunPlotGraphOnly(true, true, false, [(uint)TagsEnum.Fish])).IsFalse();
+        await Assert.That(SportFishCombat.ShouldRunPlotGraphOnly(false, true, false, fishing)).IsFalse();
+        await Assert.That(SportFishCombat.ShouldRunPlotGraphOnly(true, false, false, fishing)).IsFalse();
+    }
+
+    [Test]
+    public async Task HoldKit_IsHostileFishingTag()
+    {
+        uint[] fishing = [(uint)TagsEnum.FishingSkill];
+        await Assert.That(SportFishCombat.IsFishingHoldSkill(SkillTargetType.Hostile, fishing)).IsTrue();
+        await Assert.That(SportFishCombat.IsFishingHoldSkill(SkillTargetType.Pos, fishing)).IsFalse();
+        await Assert.That(SportFishCombat.IsFishingHoldSkill(SkillTargetType.Hostile, [(uint)TagsEnum.Fish])).IsFalse();
+    }
+
+    [Test]
+    public async Task HoldKit_BypassesSharedGcd()
+    {
+        uint[] fishing = [(uint)TagsEnum.FishingSkill];
+        await Assert.That(SportFishCombat.ShouldBypassSharedGcd(0, SkillTargetType.Hostile, fishing)).IsTrue();
+        await Assert.That(SportFishCombat.ShouldBypassSharedGcd(1500, SkillTargetType.Hostile, fishing)).IsFalse();
+        await Assert.That(SportFishCombat.ShouldBypassSharedGcd(0, SkillTargetType.Pos, fishing)).IsFalse();
+    }
+
+    [Test]
+    public async Task RodPlot_IgnoresClientStopCastingWhenSkillIsNotCancelable()
+    {
+        await Assert.That(SportFishCombat.IsRodPlot(SportFishCombat.BaitFishingPlotId)).IsTrue();
+        await Assert.That(SportFishCombat.IsRodPlot(SportFishCombat.SportFishingPlotId)).IsTrue();
+        await Assert.That(SportFishCombat.IsRodPlot(1)).IsFalse();
+        await Assert.That(
+            SportFishCombat.ShouldIgnoreClientStopCasting(
+                SportFishCombat.BaitFishingPlotId,
+                castingCancelable: false,
+                channelingCancelable: false)).IsTrue();
+        await Assert.That(
+            SportFishCombat.ShouldIgnoreClientStopCasting(
+                SportFishCombat.SportFishingPlotId,
+                castingCancelable: false,
+                channelingCancelable: false)).IsTrue();
+        await Assert.That(
+            SportFishCombat.ShouldIgnoreClientStopCasting(
+                SportFishCombat.BaitFishingPlotId,
+                castingCancelable: true,
+                channelingCancelable: false)).IsFalse();
+        await Assert.That(
+            SportFishCombat.ShouldIgnoreClientStopCasting(
+                1,
+                castingCancelable: false,
+                channelingCancelable: false)).IsFalse();
+    }
+
+    [Test]
+    public async Task HoldSwitch_CancelsPreviousHold_KeepsRodChannel()
+    {
+        await Assert.That(SportFishCombat.ShouldCancelPreviousPlot(true, previousWasHold: true, incomingIsHold: true))
+            .IsTrue();
+        await Assert.That(SportFishCombat.ShouldCancelPreviousPlot(false, previousWasHold: true, incomingIsHold: true))
+            .IsTrue();
+        await Assert.That(SportFishCombat.ShouldCancelPreviousPlot(true, previousWasHold: false, incomingIsHold: true))
+            .IsFalse();
+        await Assert.That(SportFishCombat.ShouldCancelPreviousPlot(true, previousWasHold: false, incomingIsHold: false))
+            .IsTrue();
+        await Assert.That(SportFishCombat.ShouldCancelPreviousPlot(false, previousWasHold: false, incomingIsHold: false))
+            .IsFalse();
+    }
+
+    [Test]
+    public async Task DroppedLine_IsUnusableTarget()
+    {
+        await Assert.That(SportFishCombat.IsUnusableTarget(null)).IsFalse();
+        await Assert.That(SportFishCombat.IsUnusableTarget(new Npc())).IsFalse();
+        await Assert.That(SportFishCombat.IsUnusableTarget(new Npc { SportFishLineDropped = true })).IsTrue();
+    }
+
+    [Test]
+    public async Task OnLineDropped_IsIdempotentAndClearsAggro()
+    {
+        var fish = new Npc { OwnerId = 0 };
+        SportFishCombat.OnLineDropped(fish);
+        await Assert.That(fish.SportFishLineDropped).IsTrue();
+        await Assert.That(fish.IsInBattle).IsFalse();
+        SportFishCombat.OnLineDropped(fish);
+        await Assert.That(fish.SportFishLineDropped).IsTrue();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/Plots/Tree/PlotChannelingRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/Plots/Tree/PlotChannelingRulesTests.cs
@@ -1,0 +1,89 @@
+using AAEmu.Game.Models.Game.Skills.Plots.Tree;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills.Plots.Tree;
+
+public class PlotChannelingRulesTests
+{
+    [Test]
+    public async Task SportFishChannelStart_SplitsCastFromChannel()
+    {
+        // Plot 821 event 6859: 1500 ms was the previous (cast) edge; this node starts
+        // a 220 s channel plus a 19.5 s bite-roll. Those must not share one field.
+        var (castingMs, channelingMs) = PlotChannelingRules.NextEdgeDurations(
+        [
+            (Casting: false, Channeling: true, DelayMs: 220_000),
+            (Casting: false, Channeling: false, DelayMs: 19_500)
+        ]);
+
+        await Assert.That(castingMs).IsEqualTo(0);
+        await Assert.That(channelingMs).IsEqualTo(220_000);
+        await Assert.That(PlotChannelingRules.ToPlotWireTime(channelingMs)).IsEqualTo((ushort)22_000);
+    }
+
+    [Test]
+    public async Task CastEdge_DoesNotCountAsChannel()
+    {
+        var (castingMs, channelingMs) = PlotChannelingRules.NextEdgeDurations(
+        [
+            (Casting: true, Channeling: false, DelayMs: 1500)
+        ]);
+
+        await Assert.That(castingMs).IsEqualTo(1500);
+        await Assert.That(channelingMs).IsEqualTo(0);
+        await Assert.That(PlotChannelingRules.ToPlotWireTime(castingMs)).IsEqualTo((ushort)150);
+    }
+
+    [Test]
+    public async Task BiteOrCancel_ResumesTheChannelWait_NotTheRollLoop()
+    {
+        var queued = new[] { "roll-loop", "channel-end", "roll-loop-again" };
+        var index = PlotChannelingRules.IndexOfChannelWait(
+            queued,
+            id => id == "channel-end");
+
+        await Assert.That(index).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task NoChannelWait_ReturnsMissing()
+    {
+        var queued = new[] { "roll-loop" };
+        var index = PlotChannelingRules.IndexOfChannelWait(queued, _ => false);
+        await Assert.That(index).IsEqualTo(-1);
+    }
+
+    [Test]
+    public async Task BaitCastEdge_WireIncludesAnimCsTime()
+    {
+        // Plot 809 6752→6753: delay 1500, add_anim_cs_time, fist_fishing_casting sync.
+        var scheduled = PlotChannelingRules.IncludeAnimCsTime(1500, addAnimCsTime: true, animCsTimeMs: 1500);
+        await Assert.That(scheduled).IsEqualTo(3000);
+        await Assert.That(PlotChannelingRules.ToPlotWireTime(scheduled)).IsEqualTo((ushort)300);
+        await Assert.That(PlotChannelingRules.IncludeAnimCsTime(1500, addAnimCsTime: false, animCsTimeMs: 1500))
+            .IsEqualTo(1500);
+        await Assert.That(PlotChannelingRules.IncludeAnimCsTime(1500, addAnimCsTime: true, animCsTimeMs: 0))
+            .IsEqualTo(1500);
+    }
+
+    [Test]
+    public async Task IgnoredStop_RefreshesOncePerInterval()
+    {
+        var t0 = new DateTime(2026, 9, 4, 23, 6, 31, DateTimeKind.Utc);
+        await Assert.That(PlotChannelingRules.ShouldRefreshPlotAfterIgnoredStop(false, default, t0))
+            .IsFalse();
+        await Assert.That(PlotChannelingRules.ShouldRefreshPlotAfterIgnoredStop(true, default, t0))
+            .IsTrue();
+        await Assert.That(
+                PlotChannelingRules.ShouldRefreshPlotAfterIgnoredStop(
+                    true,
+                    t0,
+                    t0.AddMilliseconds(PlotChannelingRules.IgnoredStopRefreshMinMs - 1)))
+            .IsFalse();
+        await Assert.That(
+                PlotChannelingRules.ShouldRefreshPlotAfterIgnoredStop(
+                    true,
+                    t0,
+                    t0.AddMilliseconds(PlotChannelingRules.IgnoredStopRefreshMinMs)))
+            .IsTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- Stacked on #1547 (`feat/ship-zone-seams`). Unique commit is fishing, rod lure charge, fish-stand payout, and intensified vocation downgrade.
- School finder tracks the live doodad set (untrack on `DoodadFuncFinal`, Create on management respawn). Chum `SkillHit` matches the incoming skill when `doodad_funcs.func_skill_id` is empty.
- Bait auto-fish (21571 / plot 809) keeps the rod pose across reuse: ignore non-cancelable `CSStopCasting`, include anim-sync on the cast edge, and do not expire duration-0 Refresh buffs (4053) on the second apply.
- Fish stand pays gold on its own money packet. Rod lure charge publishes `SCItemDetailUpdated` instead of `UpdateDetail`. Intensified ranks (대가+) spend item 49001 on downgrade; Famed and below stay free.
- Sport 21578 is wired under ZoneAuthority (bite on World, hold kit, line-break). Live chum → kill is still unsmoked.

## Test plan
- [x] Auto bait fishing (Tester, Two Crowns): consecutive throws stay in pose and pay loot
- [x] Fish stand sale pays gold (`DoodadFuncBuyFish`)
- [x] Lure on an unequipped timed rod does not invalidate the item
- [x] Intensified vocation downgrade consumes the certificate
- [ ] Chum a school (27313–27318) and confirm the finder model / clout 5767
- [ ] Sport 21578: SpawnFish at the bobber, bite 21608, hold kit, kill → BigFish backpack
- [ ] Unit tests: `FishSchool*`, `FishSalePrice`, `ItemChargeRules`, `ExpertLimitRules`, `SportFishCombat`, `PlotChannelingRules`, `BuffStackRules` (duration-0 refresh)

Made with [Cursor](https://cursor.com)