### PR TITLE
fix(game): 10.0.2 player-mail wire layout (send/sent/returned/attach)

### DIFF
--- a/AAEmu.Game/Core/Managers/MailManager.cs
+++ b/AAEmu.Game/Core/Managers/MailManager.cs
@@ -153,7 +153,12 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
 
         var originalReceiver = worldManager.GetCharacterById(originalReceiverId);
         if (originalReceiver is { IsOnline: true })
-            originalReceiver.SendPacket(new SCMailReturnedPacket(mail.Id, mail.Header));
+        {
+            // The client's SCMailReturned reader (FUN_39a9f110) expects a CountUnreadMail after the
+            // header; refresh so the toast carries current counters.
+            originalReceiver.Mails.RefreshAllMailCounts();
+            originalReceiver.SendPacket(new SCMailReturnedPacket(mail.Id, mail.Header, originalReceiver.Mails.UnreadMailCount));
+        }
 
         NotifyNewMailByNameIfOnline(mail, destinationName);
         return true;

--- a/AAEmu.Game/Core/Packets/C2G/CSSendMailPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSendMailPacket.cs
@@ -19,16 +19,29 @@ public class CSSendMailPacket() : GamePacket(CSOffsets.CSSendMailPacket, 1)
 
         Logger.Debug($"SendMail by {character.Name}");
 
+        // Wire layout from the 10.0.2 client: the sender builds CSSendMailPacket (opcode 0xDB,
+        // part_26025.c) from the struct read by FUN_39bdeb70 with the group-mail tail appended by
+        // FUN_39a965d0 and the whole packet read back by FUN_39ac17e0 (part_38658.c):
+        //   u8 type, str receiverCharName (cap 128), u64 receiverRefId, str title (cap 0x4b0),
+        //   str text (cap 0x640), u8 attachments, u64 money x3, u32 money3, u64 extra,
+        //   bool groupMail, 10 x (u8 slotType, u8 slot), u32 doodadId (Bc),
+        //   u64 groupMoney, u32 userCount, u64 userList[userCount, max 100].
+        //
+        // The money widths matter: the three main amounts are u64 on the wire (same helpers as
+        // the S2C mail-body money fields), followed by a fourth u32 amount. Reading them as i32
+        // shifted every later field and made the mailbox doodad check fail for every send.
         var type = (MailType)stream.ReadByte();
         var receiverCharName = stream.ReadString();
-        var unkId = stream.ReadUInt32(); //could be status
+        var receiverRefId = stream.ReadUInt64();
         var title = stream.ReadString();
-        var text = stream.ReadString(); // TODO max length 1600
+        var text = stream.ReadString();
         var attachments = stream.ReadByte();
-        var money0 = stream.ReadInt32();
-        var money1 = stream.ReadInt32();
-        var money2 = stream.ReadInt32();
+        var money0 = stream.ReadUInt64();
+        var money1 = stream.ReadUInt64();
+        var money2 = stream.ReadUInt64();
+        var money3 = stream.ReadUInt32();
         var extra = stream.ReadInt64();
+        var groupMail = stream.ReadBoolean();
         var itemSlots = new List<(SlotType slotType, byte slot)>();
         for (var i = 0; i < 10; i++)
         {
@@ -41,6 +54,14 @@ public class CSSendMailPacket() : GamePacket(CSOffsets.CSSendMailPacket, 1)
         }
 
         var doodadObjId = stream.ReadBc();
+        var groupMoney = stream.ReadUInt64();
+        var userCount = stream.ReadUInt32();
+        var userList = new List<ulong>();
+        for (var i = 0; i < userCount && i < 100; i++)
+            userList.Add(stream.ReadUInt64());
+
+        Logger.Debug($"SendMail by {character.Name} to {receiverCharName} (ref {receiverRefId}), group={groupMail}, extraUsers={userList.Count}, groupMoney={groupMoney}");
+
         if (character.Level + character.HeirLevel < AppConfiguration.Instance.LevelRestrictions.MailLevel)
         {
             character.SendErrorMessage(ErrorMessageType.MailCannotSendSinceLevelLow);
@@ -72,7 +93,7 @@ public class CSSendMailPacket() : GamePacket(CSOffsets.CSSendMailPacket, 1)
 
         if (mailCheckOK)
         {
-            var mailResult = character.Mails.SendMailToPlayer(type, receiverCharName, title, text, attachments, money0, money1, money2, extra, itemSlots);
+            var mailResult = character.Mails.SendMailToPlayer(type, receiverCharName, title, text, attachments, money0, money1, money2, money3, extra, itemSlots, groupMail, userList);
             if (mailResult == MailResult.Success)
             {
                 character.SendErrorMessage(ErrorMessageType.MailSuccess);

--- a/AAEmu.Game/Core/Packets/C2G/CSTakeAttachmentSequentially.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSTakeAttachmentSequentially.cs
@@ -12,6 +12,12 @@ public class CSTakeAttachmentSequentially() : GamePacket(CSOffsets.CSTakeAttachm
         var mailId = stream.ReadInt64();
         Logger.Debug("TakeAttachmentSequentially, mailId: {0}", mailId);
         var mail = MailManager.Instance.GetMailById(mailId);
+        if (mail == null)
+        {
+            Logger.Debug("TakeAttachmentSequentially for unknown mailId: {0}", mailId);
+            Connection.ActiveChar.SendErrorMessage(ErrorMessageType.MailInvalid);
+            return;
+        }
         if (mail.Header.ReceiverId != Connection.ActiveChar.Id) // just a check for hackers trying to steal mails
         {
             Connection.ActiveChar.SendErrorMessage(ErrorMessageType.MailInvalid);

--- a/AAEmu.Game/Core/Packets/G2C/SCMailReturnedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCMailReturnedPacket.cs
@@ -4,12 +4,15 @@ using AAEmu.Game.Models.Game.Mails;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCMailReturnedPacket(long mailId, MailHeader mail) : GamePacket(SCOffsets.SCMailReturnedPacket, 1)
+public class SCMailReturnedPacket(long mailId, MailHeader mail, CountUnreadMail count) : GamePacket(SCOffsets.SCMailReturnedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
+        // Client reader FUN_39a9f110: u64 mailId, MailHeader, CountUnreadMail.
+        // Omitting the counters leaves the client reading past the end of the packet.
         stream.Write(mailId);
         stream.Write(mail);
+        stream.Write(count);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCMailSentPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCMailSentPacket.cs
@@ -5,16 +5,29 @@ using AAEmu.Game.Models.Game.Mails;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCMailSentPacket(MailHeader mail, (SlotType slotType, byte slot)[] items)
+public class SCMailSentPacket(bool groupSending, MailHeader mail, CountUnreadMail count, (SlotType slotType, byte slot)[] items)
     : GamePacket(SCOffsets.SCMailSentPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
+        // Client reader FUN_39a9ecf0: bool groupSending, MailHeader, CountUnreadMail,
+        // then always 10 x (u8 slotType, u8 slot). The header alone desyncs the client,
+        // so the leading flag and the counters are load-bearing, not decorative.
+        stream.Write(groupSending);
         stream.Write(mail);
-        foreach (var (slotType, slot) in items) // TODO 10 items
+        stream.Write(count);
+        for (var i = 0; i < MailBody.MaxMailAttachments; i++)
         {
-            stream.Write((byte)slotType);
-            stream.Write(slot);
+            if (i < items.Length)
+            {
+                stream.Write((byte)items[i].slotType);
+                stream.Write(items[i].slot);
+            }
+            else
+            {
+                stream.Write((byte)0);
+                stream.Write((byte)0);
+            }
         }
 
         return stream;

--- a/AAEmu.Game/Models/Game/Char/CharacterMails.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterMails.cs
@@ -536,19 +536,15 @@ public class CharacterMails
             return;
         }
 
-        var wasUnread = thisMail.Header.Status != MailStatus.Read;
-        var mailType = thisMail.MailType;
-
         if (!thisMail.ReturnToSenderFor(Self.Id))
         {
             Self.SendPacket(new SCMailFailedPacket(MailResult.ReturnsNotAllowed, [], false));
             return;
         }
 
-        // It is the sender's mail now, so it leaves this inbox and its counters.
-        UnreadMailCount.AddTotal(mailType, -1);
-        if (wasUnread)
-            UnreadMailCount.UpdateReceived(mailType, -1);
+        // TryReturnToSenderCore already refreshed the counters authoritatively (the letter is no
+        // longer addressed to this inbox, so it is excluded) for the SCMailReturnedPacket above.
+        // Adjusting again here would double-count the return; just publish the refreshed totals.
         SendUnreadMailCount();
     }
 }

--- a/AAEmu.Game/Models/Game/Char/CharacterMails.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterMails.cs
@@ -301,8 +301,9 @@ public class CharacterMails
         }
 
         // With attachments in place, we can calculate the send fee.
-        // Widened to long so the sum cannot wrap past the balance check (money0 is range-checked
-        // to int above, so the cast back down is safe).
+        // Everything stays long end to end: money0 is range-checked to int above (AttachMoney and
+        // MailBody store ints), but fee + money0 can still exceed int.MaxValue, and narrowing it back
+        // for the charge would wrap negative and send the mail for free.
         var mailFee = mail.GetMailFee();
         var totalCost = (long)mailFee + (long)money0;
         if (totalCost > Self.Money)
@@ -325,8 +326,8 @@ public class CharacterMails
             // counters after the header; refresh so they are current.
             RefreshAllMailCounts();
             Self.SendPacket(new SCMailSentPacket(false, mail.Header, UnreadMailCount, itemSlots.ToArray()));
-            // Take the fee. totalCost is bounded by the balance check above, so the cast is safe.
-            Self.SubtractMoney(SlotType.Inventory, (int)totalCost);
+            // Take the fee + attached copper. SubtractMoney takes long, so no narrowing.
+            Self.SubtractMoney(SlotType.Inventory, totalCost);
             return MailResult.Success;
         }
         else

--- a/AAEmu.Game/Models/Game/Char/CharacterMails.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterMails.cs
@@ -15,9 +15,14 @@ public class CharacterMails
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    /// <summary>Capacity of the mails.title / mails.text columns, which are MySQL text.</summary>
-    private const int MaxMailTitleBytes = 65535;
-    private const int MaxMailTextBytes = 65535;
+    /// <summary>Retail mail caps, recovered from the 10.0.2 client: the send gate (FUN_39bdf190)
+    /// requires XlStringLen(title) &lt; 300 and XlStringLen(text) &lt; 400, and the wire structs cap
+    /// title at 0x4b0 (1200) bytes and text at 0x640 (1600) bytes. Both columns are MySQL text, so
+    /// the byte caps also keep the mails-row INSERT safe.</summary>
+    private const int MaxMailTitleChars = 300;
+    private const int MaxMailTitleBytes = 1200;
+    private const int MaxMailTextChars = 400;
+    private const int MaxMailTextBytes = 1600;
 
     private Character Self { get; set; }
     public CountUnreadMail UnreadMailCount { get; set; }
@@ -212,7 +217,7 @@ public class CharacterMails
         RefreshAllMailCounts();
     }
 
-    public MailResult SendMailToPlayer(MailType mailType, string receiverName, string title, string text, byte attachments, int money0, int money1, int money2, long extra, List<(SlotType, byte)> itemSlots)
+    public MailResult SendMailToPlayer(MailType mailType, string receiverName, string title, string text, byte attachments, ulong money0, ulong money1, ulong money2, uint money3, long extra, List<(SlotType, byte)> itemSlots, bool groupMail = false, List<ulong> userList = null)
     {
 
         if (string.IsNullOrWhiteSpace(receiverName) || NameManager.Instance.GetCharacterId(receiverName) == 0)
@@ -220,33 +225,53 @@ public class CharacterMails
             return MailResult.UnableToFindRecipient;
         }
 
-        // The three money fields come off the wire as signed ints and were used unchecked.
+        // The server has no group-mail (bulk) support: the client appends a groupMoney u64, a
+        // userCount u32 and a u64 recipient list (FUN_39a965d0) when groupMail is set. Refuse cleanly
+        // rather than delivering only to the single named receiver.
+        if (groupMail || (userList != null && userList.Count > 0))
+        {
+            Logger.Warn($"{Self.Name} ({Self.Id}) attempted group mail to {userList?.Count ?? 0} recipients, which is not supported");
+            return MailResult.CanNotBeMailed;
+        }
+
+        // The three money fields come off the wire as unsigned 64-bit values (FUN_39bdeb70 reads them
+        // with the u64 helper, same as the S2C mail-body money fields). Range-check before the int cast
+        // below so a crafted value can neither wrap the affordability check nor overflow MailBody storage.
         //
-        // Negative amounts made the affordability test below trivially true and then bounced off
-        // SubtractMoney's own "amount < 0" guard, so the mail went out free of charge carrying a negative
-        // balance the recipient could never take - and since GetTotalAttachmentCount counts any non-zero
-        // coin value, the mail kept an attachment forever and could never be deleted.
-        //
-        // Large positive amounts were worse: "mailFee + money0" overflowed int, compared as a negative
-        // against the sender's balance, passed, and was then rejected by SubtractMoney for being negative,
-        // so nothing was charged at all. The recipient still collected the full sum through ChangeMoney,
-        // which adds to Money unchecked. That minted currency out of nothing.
-        if (money0 < 0 || money1 < 0 || money2 < 0)
+        // The original int-overflow history: negative amounts made the affordability test trivially true
+        // and then bounced off SubtractMoney's own "amount < 0" guard, so the mail went out free of charge
+        // carrying a negative balance the recipient could never take - and since GetTotalAttachmentCount
+        // counts any non-zero coin value, the mail kept an attachment forever and could never be deleted.
+        // Large positive amounts overflowed "mailFee + money0" to negative, passed the balance check, and
+        // were then rejected by SubtractMoney, so nothing was charged at all. The recipient still collected
+        // the full sum through ChangeMoney, which adds to Money unchecked. That minted currency.
+        if (money0 > int.MaxValue || money1 > int.MaxValue || money2 > int.MaxValue)
         {
             return MailResult.CanNotBeMailed;
         }
 
-        // title and text were written to the mails row unbounded. Both columns are MySQL text, so anything
-        // past 65535 bytes fails the INSERT on the save tick - and that tick batches every dirty mail on the
-        // server, so one oversized letter takes the whole save down, not just its sender.
-        // TODO(v10): the retail subject and body caps are not yet recovered from the client; CSSendMail notes
-        // 1600 for the body. These bounds only keep the column safe, they are not the client's own limits.
-        if (title != null && Encoding.UTF8.GetByteCount(title) > MaxMailTitleBytes)
+        // The fourth money field (u32 after the three u64 amounts) is the honor-point
+        // attachment (client GetCurrentMailHonorPointStr reads body+0xB98 as u32; money0 is copper,
+        // money1 the charge/COD amount, money2 AA points). It has no server-side storage - the mails
+        // table only has money_amount_1..3 - and no producer yet (the compose UI offers copper/AA
+        // only). Never silently drop player currency: refuse mail carrying any.
+        if (money3 != 0)
+        {
+            Logger.Warn($"{Self.Name} ({Self.Id}) attempted to send mail with honor amount {money3}");
+            return MailResult.CanNotBeMailed;
+        }
+
+        // Retail caps recovered from the 10.0.2 client: the send gate (FUN_39bdf190) requires
+        // XlStringLen(title) &lt; 300 and XlStringLen(text) &lt; 400, and the wire structs cap title at
+        // 1200 bytes and text at 1600 bytes. Enforce both, so a malicious packet can neither desync the
+        // client's bounded-string reads nor fail the mails-row INSERT (that save tick batches every
+        // dirty mail on the server, so one oversized letter would take the whole save down).
+        if (title != null && (title.Length > MaxMailTitleChars || Encoding.UTF8.GetByteCount(title) > MaxMailTitleBytes))
         {
             return MailResult.SubjectLengthLimited;
         }
 
-        if (text != null && Encoding.UTF8.GetByteCount(text) > MaxMailTextBytes)
+        if (text != null && (text.Length > MaxMailTextChars || Encoding.UTF8.GetByteCount(text) > MaxMailTextBytes))
         {
             return MailResult.TextLengthLimited;
         }
@@ -266,7 +291,7 @@ public class CharacterMails
             }
         };
 
-        mail.AttachMoney(money0, money1, money2);
+        mail.AttachMoney((int)money0, (int)money1, (int)money2);
 
         // First verify source items, and add them to the attachments of body
         if (!mail.PrepareAttachmentItems(itemSlots))
@@ -276,9 +301,10 @@ public class CharacterMails
         }
 
         // With attachments in place, we can calculate the send fee.
-        // Widened to long so the sum cannot wrap past the balance check.
+        // Widened to long so the sum cannot wrap past the balance check (money0 is range-checked
+        // to int above, so the cast back down is safe).
         var mailFee = mail.GetMailFee();
-        var totalCost = (long)mailFee + money0;
+        var totalCost = (long)mailFee + (long)money0;
         if (totalCost > Self.Money)
         {
             // Self.SendErrorMessage(ErrorMessageType.MailNotEnoughMoney);
@@ -295,7 +321,10 @@ public class CharacterMails
         // Send it
         if (mail.Send())
         {
-            Self.SendPacket(new SCMailSentPacket(mail.Header, itemSlots.ToArray()));
+            // The client's SCMailSent reader (FUN_39a9ecf0) expects the group flag and the mailbox
+            // counters after the header; refresh so they are current.
+            RefreshAllMailCounts();
+            Self.SendPacket(new SCMailSentPacket(false, mail.Header, UnreadMailCount, itemSlots.ToArray()));
             // Take the fee. totalCost is bounded by the balance check above, so the cast is safe.
             Self.SubtractMoney(SlotType.Inventory, (int)totalCost);
             return MailResult.Success;

--- a/AAEmu.Game/Models/Game/Mails/MailPlayerToPlayer.cs
+++ b/AAEmu.Game/Models/Game/Mails/MailPlayerToPlayer.cs
@@ -95,10 +95,16 @@ public class MailPlayerToPlayer : BaseMail
         for (var i = 0; i < Body.Attachments.Count; i++)
         {
             var tempItem = Body.Attachments[i];
+            // Snapshot the source coordinates BEFORE the move: AddOrMoveExistingItem runs with
+            // ItemTaskType.Invalid (so it sends nothing itself) and rewrites SlotType/Slot onto the
+            // mail container. Building the Seize from the item afterwards would target the mail slot
+            // the client never saw, leaving a ghost of the item in the sender's bag.
+            var sourceSlotType = tempItem.SlotType;
+            var sourceSlot = (byte)tempItem.Slot;
             // Move Item to sender's Mail ItemContainer, technically speaking this can never fail
             if (_sender.Inventory.MailAttachments.AddOrMoveExistingItem(ItemTaskType.Invalid, tempItem))
             {
-                _sender.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.Mail, [new ItemRemove(tempItem)], []));
+                _sender.SendPacket(new SCItemTaskSuccessPacket(ItemTaskType.Mail, [new ItemRemoveSlot(tempItem.Id, sourceSlotType, sourceSlot)], []));
                 // Technically not needed, I just want to sync it up
                 tempItem.SlotType = SlotType.Mail;
                 tempItem.Slot = i;

--- a/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
@@ -82,13 +82,14 @@ public sealed class MailTests
         var title = "test";
         var text = "test";
         var attachments = (byte)0;
-        var money0 = 500;
-        var money1 = 0;
-        var money2 = 0;
+        var money0 = 500ul;
+        var money1 = 0ul;
+        var money2 = 0ul;
+        var money3 = 0u;
         var extra = 0;
         var itemSlots = new List<(SlotType slotType, byte slot)>();
 
-        await Assert.That(_mails.SendMailToPlayer(type, receiverCharName, title, text, attachments, money0, money1, money2, extra, itemSlots)).IsEqualTo(MailResult.Success);
+        await Assert.That(_mails.SendMailToPlayer(type, receiverCharName, title, text, attachments, money0, money1, money2, money3, extra, itemSlots)).IsEqualTo(MailResult.Success);
         await Assert.That(_character.Money).IsEqualTo(400);
     }
 
@@ -101,13 +102,14 @@ public sealed class MailTests
         var title = "test";
         var text = "test";
         var attachments = (byte)0;
-        var money0 = 500;
-        var money1 = 0;
-        var money2 = 0;
+        var money0 = 500ul;
+        var money1 = 0ul;
+        var money2 = 0ul;
+        var money3 = 0u;
         var extra = 0;
         var itemSlots = new List<(SlotType slotType, byte slot)>();
 
-        await Assert.That(_mails.SendMailToPlayer(type, receiverCharName, title, text, attachments, money0, money1, money2, extra, itemSlots)).IsNotEqualTo(MailResult.Success);
+        await Assert.That(_mails.SendMailToPlayer(type, receiverCharName, title, text, attachments, money0, money1, money2, money3, extra, itemSlots)).IsNotEqualTo(MailResult.Success);
         await Assert.That(_character.Money).IsEqualTo(1000);
     }
 }

--- a/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
@@ -17,6 +17,7 @@ public sealed class MailTests
     private CharacterMock _character;
     private CharacterMails _mails;
     private MailManager _mailManager;
+    private Mock<IWorldManager> _mockWorldManager;
 
     [Before(Test)]
     public void Setup()
@@ -28,25 +29,27 @@ public sealed class MailTests
         var nameManager = new NameManager();
         nameManager.Load([], [], []);
         nameManager.AddCharacter(_character.Id, _character.Name, 1);
+        nameManager.AddCharacter(2u, "Sender", 1);
 
         var mailIdManager = new MailIdManager();
         mailIdManager.Initialize();
 
+        _mockWorldManager = Mock.Of<IWorldManager>();
         _mailManager = new MailManager(
             mailIdManager,
             nameManager,
             Mock.Of<IItemManager>().Object,
             Mock.Of<ITaskManager>().Object,
-            Mock.Of<IWorldManager>().Object,
+            _mockWorldManager.Object,
             new Lazy<IHousingManager>(() => Mock.Of<IHousingManager>().Object),
             Mock.Of<ILocalizationManager>().Object);
 
         // Reset singleton caches so Instance properties resolve via ServiceProvider
         typeof(Singleton<MailManager>)
-            .GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic)
+            .GetField("s_instance", BindingFlags.Static | BindingFlags.NonPublic)
             ?.SetValue(null, null);
         typeof(Singleton<NameManager>)
-            .GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic)
+            .GetField("s_instance", BindingFlags.Static | BindingFlags.NonPublic)
             ?.SetValue(null, null);
 
         var services = new ServiceCollection();
@@ -64,13 +67,14 @@ public sealed class MailTests
         _character = null;
         _mails = null;
         _mailManager = null;
+        _mockWorldManager = null;
 
         SingletonContainer.ServiceProvider = null;
         typeof(Singleton<MailManager>)
-            .GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic)
+            .GetField("s_instance", BindingFlags.Static | BindingFlags.NonPublic)
             ?.SetValue(null, null);
         typeof(Singleton<NameManager>)
-            .GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic)
+            .GetField("s_instance", BindingFlags.Static | BindingFlags.NonPublic)
             ?.SetValue(null, null);
     }
 
@@ -111,5 +115,87 @@ public sealed class MailTests
 
         await Assert.That(_mails.SendMailToPlayer(type, receiverCharName, title, text, attachments, money0, money1, money2, money3, extra, itemSlots)).IsNotEqualTo(MailResult.Success);
         await Assert.That(_character.Money).IsEqualTo(1000);
+    }
+
+    private BaseMail SeedInboxMail(long id, MailStatus status = MailStatus.Unread)
+    {
+        var now = DateTime.UtcNow;
+        var mail = new BaseMail
+        {
+            Id = id,
+            MailType = MailType.Normal,
+            Title = "test",
+            ReceiverName = _character.Name,
+            OpenDate = now,
+        };
+        mail.Header.SenderId = 2u;
+        mail.Header.SenderName = "Sender";
+        mail.Header.ReceiverId = _character.Id;
+        mail.Header.Status = status;
+        mail.Body.Text = "test";
+        mail.Body.SendDate = now.AddMinutes(-31);
+        mail.Body.RecvDate = now.AddMinutes(-1);
+        _mailManager.AllPlayerMails[id] = mail;
+        return mail;
+    }
+
+    private void MakeReturnable()
+    {
+        // TryReturnToSenderCore refreshes the returner's counters through the world character,
+        // so the mock world has to resolve it as online. CharacterMock never runs DB Load (the
+        // only place Character.Mails is assigned), so wire it explicitly as well.
+        _character.Mails = new CharacterMails(_character);
+        _mockWorldManager.GetCharacterById(Any<uint>()).Returns(_character);
+        _character.IsOnline = true;
+    }
+
+    [Test]
+    public async Task ReturnMail_LastUnreadLetter_CountsGoToZero()
+    {
+        MakeReturnable();
+        var mail = SeedInboxMail(5001L);
+        _character.Mails.RefreshAllMailCounts();
+        await Assert.That(_character.Mails.UnreadMailCount.TotalReceived).IsEqualTo(1);
+        await Assert.That(_character.Mails.UnreadMailCount.Received).IsEqualTo(1);
+
+        _character.Mails.ReturnMail(5001L);
+
+        // Returning turns the letter around; it is not deleted.
+        await Assert.That(mail.Header.ReceiverId).IsEqualTo(2u);
+        await Assert.That(mail.Header.Returned).IsTrue();
+        await Assert.That(_character.Mails.UnreadMailCount.TotalReceived).IsEqualTo(0);
+        await Assert.That(_character.Mails.UnreadMailCount.Received).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ReturnMail_ReadLetter_TotalDecrementsUnreadUnchanged()
+    {
+        MakeReturnable();
+        SeedInboxMail(5002L, MailStatus.Read);
+        _character.Mails.RefreshAllMailCounts();
+        await Assert.That(_character.Mails.UnreadMailCount.TotalReceived).IsEqualTo(1);
+        await Assert.That(_character.Mails.UnreadMailCount.Received).IsEqualTo(0);
+
+        _character.Mails.ReturnMail(5002L);
+
+        await Assert.That(_character.Mails.UnreadMailCount.TotalReceived).IsEqualTo(0);
+        await Assert.That(_character.Mails.UnreadMailCount.Received).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ReturnMail_WithAnotherLetterRemaining_OnlyReturnedLeaves()
+    {
+        MakeReturnable();
+        SeedInboxMail(5003L);
+        var remaining = SeedInboxMail(5004L);
+        _character.Mails.RefreshAllMailCounts();
+        await Assert.That(_character.Mails.UnreadMailCount.TotalReceived).IsEqualTo(2);
+        await Assert.That(_character.Mails.UnreadMailCount.Received).IsEqualTo(2);
+
+        _character.Mails.ReturnMail(5003L);
+
+        await Assert.That(_character.Mails.UnreadMailCount.TotalReceived).IsEqualTo(1);
+        await Assert.That(_character.Mails.UnreadMailCount.Received).IsEqualTo(1);
+        await Assert.That(remaining.Header.ReceiverId).IsEqualTo(_character.Id);
     }
 }


### PR DESCRIPTION
## Summary
- Player-to-player mail was unusable on 10.0.2: every send failed the mailbox check, the sent toast parsed garbage, and returned mail carried no counters. All recovered from the 10.0.2 client (Ghidra), no opcode changes, no DB migration.
- `CSSendMailPacket` (0xDB): read rewritten to the client layout (`FUN_39bdeb70` + group tail `FUN_39ac17e0`, sender in `part_26025.c`): u8 type, str receiver (cap 128), **u64** refId, str title (0x4b0), str text (0x640), u8 attachments, **3×u64 money + u32 money3**, u64 extra, bool groupMail, 10×(u8 slotType, u8 slot), u32 doodad (Bc), u64 groupMoney, u32 userCount + u64 list. The old u32 + 3×i32 read shifted every later field (~21 bytes), so the doodad lookup — and every send — failed.
- `SendMailToPlayer`: money params widened to u64/u32 with int-range checks (keeps the int-overflow guards meaningful); honor-point attachments (u32 `money3`, per client `GetCurrentMailHonorPointStr`) and group sends refused cleanly instead of misparsed (neither has server-side storage — the mails table has money_amount_1..3); retail title/text caps enforced (300/400 chars + 1200/1600 bytes per `FUN_39bdf190`) via the existing `SubjectLengthLimited`/`TextLengthLimited` results.
- `SCMailSentPacket` (0x15C): adds the leading `groupSending` bool, `CountUnreadMail`, and pads slots to 10 (client `FUN_39a9ecf0` reads all three unconditionally).
- `SCMailReturnedPacket` (0x165): appends `CountUnreadMail` (client `FUN_39a9f110`).
- `MailPlayerToPlayer.FinalizeAttachments`: the bag-clear `Seize` is now built from pre-move coordinates (`ItemRemoveSlot` with source slot). It was built from the item post-move, targeting the mail slot the client never saw, so sent items ghosted in the sender's bag until relog.
- `CSTakeAttachmentSequentially`: null-guard for unknown mail ids (was an NRE on crafted packets).

## Test plan
- [x] Send normal/express mail ± coin/item between two characters (10.0.2 client, private server)
- [x] List inbox/sent, read, take money-only / item-only / collect-all, return, delete
- [x] Sender bag clears on send with no relog; receiver retrieves coin + items
- [x] Restart persistence (mails + attachments survive save/load)
- [x] Unit tests: `MailTests` (updated for u64 money params)
- [ ] Marketplace/commercial claim regression (shared list/body paths, untouched but adjacent)
- [ ] Reviewer in-game pass on a second server
