### PR TITLE
feat(auction): implement 10.0 house listing, search, and sold history

### DIFF
--- a/AAEmu.Game/Configurations/Features.json
+++ b/AAEmu.Game/Configurations/Features.json
@@ -20,7 +20,7 @@
             "nexonPcRoom": true,
             "ranking": true,
             "customsaveload": true,
-            "aaPoint": true,
+            "aaPoint": false,               // no AA Point wallet / shop convert; AH stays gold
             "butler": true,
             "freeLpRaise": true,
             "use_slash_open_chat": true,
@@ -151,7 +151,7 @@
             "fset_20_2_unknown": true,      // ScriptBindCustomizingUnit — appearance preview mannequin Lua API
             "fset_20_5_unknown": true,      // Lua Item object from catalog template id (look-convert / preview slots)
             "fset_24_3_unknown": true,      // housing builder rotation (HouseBuilder::UpdateRotating)
-            "fset_24_7_unknown": true,      // ui_eventProfile content-info panel
+            "fset_24_7_unknown": false,     // ui_eventProfile + fgt (encyclopedia / AH / craft)
             "fset_25_1_unknown": true,      // Bless Uthstin page copy/expand CS packets
             "fset_25_3_unknown": true,      // notice / event board record (title, body, schedule)
             "fset_28_6_unknown": true,      // multilingual auction search packet

--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -329,12 +329,20 @@ public class AuctionManager(
             AuctionHouseRules.ReturnToHouseEscrow(slice, leftover?.OwnerId ?? slice.OwnerId);
     }
 
+    /// <summary>
+    /// Undo a delivery that never reached the buyer. By this point every copper bid on the
+    /// lot has been refunded: an outbid bidder in <see cref="BidOnAuctionLot"/>, the buyer's
+    /// own earlier bid inside <paramref name="soldAmount"/>, or the expiry winner here. The
+    /// restored listing must therefore carry no standing bid, or expiry would hand the item
+    /// to a bidder who already has their money back.
+    /// </summary>
     private void AbortSaleDelivery_NoLock(AuctionLot lot, Item item, uint buyerId, long soldAmount, string reason)
     {
         SendBidRefund(buyerId, lot, soldAmount);
         AuctionHouseRules.ReturnToHouseEscrow(item, lot.ClientId);
+        AuctionHouseRules.ClearStandingBid(lot);
         RestoreLot_NoLock(lot);
-        Logger.Error("Sale aborted lot={0} buyer={1}: {2}; listing restored", lot.Id, buyerId, reason);
+        Logger.Error("Sale aborted lot={0} buyer={1}: {2}; listing restored without a bid", lot.Id, buyerId, reason);
     }
 
     private void SettleExpire_NoLock(AuctionLot lot)
@@ -376,6 +384,7 @@ public class AuctionManager(
 
         lock (_houseLock)
         {
+            using var persist = MailManager.Instance.DeferPersist();
             var auctionLot = GetAuctionLotFromId(auctionId);
             if (auctionLot == null)
             {
@@ -454,6 +463,10 @@ public class AuctionManager(
 
         lock (_houseLock)
         {
+            // One snapshot after the charge, the refund letter, the bid replacement or the
+            // settle. The refund mail alone used to force a save that still held the bid it
+            // had just refunded.
+            using var persist = MailManager.Instance.DeferPersist();
             var auctionLot = GetAuctionLotFromId(bid.LotId);
             if (auctionLot?.Item == null || DateTime.UtcNow >= auctionLot.EndTime)
             {
@@ -513,8 +526,9 @@ public class AuctionManager(
                 SendHouseMessage(previousBidderId, AuctionMessageKind.Outbid, auctionLot.Item.TemplateId, previousBid);
                 Logger.Info("Outbid lot={0} previous={1} refund={2} by {3} ({4})",
                     auctionLot.Id, previousBidderId, previousBid, player.Name, player.Id);
-                if (isBuyout && stack < liveItem.Count)
-                    AuctionHouseRules.ClearStandingBid(auctionLot);
+                // The refunded bid must not survive on the lot: a leftover stack is a fresh
+                // listing, and a full buyout that fails delivery is restored as one.
+                AuctionHouseRules.ClearStandingBid(auctionLot);
             }
 
             var standing = isBuyout ? auctionLot.DirectMoney : bid.Money;
@@ -567,6 +581,7 @@ public class AuctionManager(
             Logger.Info("Bid lot={0} bidder={1} ({2}) standing={3} charged={4}",
                 auctionLot.Id, player.Name, player.Id, standing, charge);
             player.SendPacket(new SCAuctionBidPacket(bid, false, liveItem.TemplateId));
+            MailManager.Instance.PersistNow();
         }
     }
 
@@ -637,6 +652,7 @@ public class AuctionManager(
         lock (_houseLock)
         {
             Logger.Trace("Updating Auction House");
+            using var persist = MailManager.Instance.DeferPersist();
             var itemsToRemove = AuctionLots.Values.Where(c => DateTime.UtcNow > c.EndTime).ToList();
             foreach (var lot in itemsToRemove)
             {

--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -85,12 +85,13 @@ public class AuctionManager(
         player.SendPacket(new SCAuctionSearchedPacket(page, lots, (short)error, DateTime.UtcNow));
     }
 
-    private void RecordSale(AuctionLot lot, long soldAmount)
+    private void RecordSale(AuctionLot lot, long soldAmount, Item sold = null)
     {
-        if (lot?.Item == null || soldAmount <= 0)
+        var item = sold ?? lot?.Item;
+        if (item == null || soldAmount <= 0)
             return;
 
-        var sale = new AuctionSale(lot.Item.TemplateId, lot.Item.Grade, DateTime.UtcNow, soldAmount, lot.Item.Count);
+        var sale = new AuctionSale(item.TemplateId, item.Grade, DateTime.UtcNow, soldAmount, item.Count);
         lock (_soldLock)
         {
             _soldRecords.Add(sale);
@@ -197,22 +198,21 @@ public class AuctionManager(
 
         var listingDeposit = Fees.GetListingDeposit(lot.DirectMoney, lot.Duration);
         var buyMail = new MailForAuction(item, lot.ClientId, soldAmount, listingDeposit);
-        if (!buyMail.FinalizeForSaleBuyer(buyerId) || !buyMail.Send())
+        if (!buyMail.FinalizeForSaleBuyer(buyerId))
         {
-            SendBidRefund(buyerId, lot, soldAmount);
-            if (AuctionHouseRules.IsHeldByHouse(item) && !string.IsNullOrEmpty(lot.ClientName))
-            {
-                var failMail = new MailForAuction(item, lot.ClientId, lot.DirectMoney, listingDeposit);
-                if (failMail.FinalizeForFail())
-                    failMail.Send();
-            }
-
-            Logger.Error("Buyer mail failed lot={0} buyer={1}; bid refunded", lot.Id, buyerId);
-            ForgetLot_NoLock(lot);
+            AbortSaleDelivery_NoLock(lot, item, buyerId, soldAmount, "buyer name");
             return;
         }
 
-        var saleCharge = Fees.GetSaleCharge(soldAmount, item.Template?.AuctionSettings?.EffectiveChargeRate ?? 0);
+        if (!buyMail.Send())
+        {
+            buyMail.RevertBuyerClaim();
+            AbortSaleDelivery_NoLock(lot, item, buyerId, soldAmount, "buyer mail");
+            return;
+        }
+
+        var saleCharge = AuctionHouseRules.SaleChargeForLot(
+            Fees, soldAmount, lot.ChargePercent, item.Template?.AuctionSettings?.EffectiveChargeRate ?? 0);
         var moneyAfterFee = soldAmount - saleCharge;
         if (!string.IsNullOrEmpty(lot.ClientName))
         {
@@ -226,8 +226,114 @@ public class AuctionManager(
         Logger.Info("Sale settle lot={0} seller={1} ({2}) buyer={3} sold={4} net={5} charge={6}",
             lot.Id, lot.ClientName, lot.ClientId, buyer, soldAmount, moneyAfterFee, saleCharge);
         SendHouseMessage(lot.ClientId, AuctionMessageKind.Sold, item.TemplateId, soldAmount);
-        RecordSale(lot, soldAmount);
+        RecordSale(lot, soldAmount, item);
         ForgetLot_NoLock(lot);
+    }
+
+    private void SettleSoldSlice_NoLock(AuctionLot lot, Item sold, string buyer, long soldAmount)
+    {
+        var leftover = lot.Item != null ? itemManager.GetItemByItemId(lot.Item.Id) : null;
+        var buyerId = nameManager.GetCharacterId(buyer);
+        if (sold == null || buyerId == 0 || !AuctionHouseRules.IsHeldByHouse(sold))
+        {
+            MergeHouseStack(leftover, sold);
+            if (buyerId != 0)
+                SendBidRefund(buyerId, lot, soldAmount);
+            Logger.Error("Partial sale aborted lot={0} buyer={1}: slice is not in house escrow", lot.Id, buyer);
+            return;
+        }
+
+        var listingDeposit = Fees.GetListingDeposit(lot.DirectMoney, lot.Duration);
+        var buyMail = new MailForAuction(sold, lot.ClientId, soldAmount, listingDeposit);
+        if (!buyMail.FinalizeForSaleBuyer(buyerId))
+        {
+            MergeHouseStack(leftover, sold);
+            SendBidRefund(buyerId, lot, soldAmount);
+            Logger.Error("Partial sale aborted lot={0} buyer={1}: buyer name", lot.Id, buyerId);
+            return;
+        }
+
+        if (!buyMail.Send())
+        {
+            buyMail.RevertBuyerClaim();
+            MergeHouseStack(leftover, sold);
+            SendBidRefund(buyerId, lot, soldAmount);
+            Logger.Error("Partial sale aborted lot={0} buyer={1}: buyer mail", lot.Id, buyerId);
+            return;
+        }
+
+        var saleCharge = AuctionHouseRules.SaleChargeForLot(
+            Fees, soldAmount, lot.ChargePercent, sold.Template?.AuctionSettings?.EffectiveChargeRate ?? 0);
+        var moneyAfterFee = soldAmount - saleCharge;
+        if (!string.IsNullOrEmpty(lot.ClientName))
+        {
+            var sellMail = new MailForAuction(sold, lot.ClientId, soldAmount, listingDeposit);
+            if (sellMail.FinalizeForSaleSeller(moneyAfterFee, saleCharge))
+                sellMail.Send();
+            else
+                Logger.Error("Seller mail failed lot={0} seller={1} after a partial delivery", lot.Id, lot.ClientId);
+        }
+
+        Logger.Info("Partial sale settle lot={0} seller={1} ({2}) buyer={3} sold={4} leftover={5} net={6} charge={7}",
+            lot.Id, lot.ClientName, lot.ClientId, buyer, soldAmount, leftover?.Count ?? 0, moneyAfterFee, saleCharge);
+        SendHouseMessage(lot.ClientId, AuctionMessageKind.Sold, sold.TemplateId, soldAmount);
+        RecordSale(lot, soldAmount, sold);
+        if (leftover != null)
+        {
+            var stacks = AuctionHouseRules.ClampStacks(leftover.Count, lot.MinStack, lot.MaxStack, AllowPartialBuy);
+            lot.MinStack = stacks.minStack;
+            lot.MaxStack = stacks.maxStack;
+            lot.IsDirty = true;
+        }
+    }
+
+    private Item TrySplitHouseStack(Item source, int amount)
+    {
+        if (source == null || !ItemSplitRules.IsSplitAmount(source.Count, amount))
+            return null;
+
+        var split = itemManager.Create(source.TemplateId, amount, source.Grade);
+        if (split == null)
+            return null;
+
+        ItemSplitRules.CopyStackFields(source, split);
+        split.TemplateId = source.TemplateId;
+        split.Template = source.Template;
+        split.Grade = source.Grade;
+        split.Count = amount;
+        var before = source.Count;
+        source.Count -= amount;
+        if (!ItemSplitRules.ConservesCount(before, amount, source.Count, split.Count))
+        {
+            source.Count = before;
+            itemManager.ReleaseId(split.Id);
+            return null;
+        }
+
+        AuctionHouseRules.ReturnToHouseEscrow(split, source.OwnerId);
+        return split;
+    }
+
+    private void MergeHouseStack(Item leftover, Item slice)
+    {
+        if (leftover != null && slice != null && leftover.Id != slice.Id)
+        {
+            leftover.Count += slice.Count;
+            AuctionHouseRules.ReturnToHouseEscrow(leftover, leftover.OwnerId);
+            itemManager.ReleaseId(slice.Id);
+            return;
+        }
+
+        if (slice != null)
+            AuctionHouseRules.ReturnToHouseEscrow(slice, leftover?.OwnerId ?? slice.OwnerId);
+    }
+
+    private void AbortSaleDelivery_NoLock(AuctionLot lot, Item item, uint buyerId, long soldAmount, string reason)
+    {
+        SendBidRefund(buyerId, lot, soldAmount);
+        AuctionHouseRules.ReturnToHouseEscrow(item, lot.ClientId);
+        RestoreLot_NoLock(lot);
+        Logger.Error("Sale aborted lot={0} buyer={1}: {2}; listing restored", lot.Id, buyerId, reason);
     }
 
     private void SettleExpire_NoLock(AuctionLot lot)
@@ -388,6 +494,10 @@ public class AuctionManager(
                 return;
             }
 
+            var stack = AuctionHouseRules.ResolveBidStack(
+                bid.StackSize, liveItem.Count, auctionLot.MinStack, auctionLot.MaxStack, AllowPartialBuy);
+            bid.StackSize = stack;
+
             if (!player.SubtractMoney(SlotType.Inventory, charge, ItemTaskType.Auction))
             {
                 player.SendErrorMessage(ErrorMessageType.NotEnoughMoney);
@@ -410,10 +520,27 @@ public class AuctionManager(
             bid.BidderId = player.Id;
             bid.WorldId = ServerWorldId;
             bid.Money = standing;
-            bid.StackSize = liveItem.Count;
 
             if (isBuyout)
             {
+                var delivered = liveItem;
+                if (stack < liveItem.Count)
+                {
+                    delivered = TrySplitHouseStack(liveItem, stack);
+                    if (delivered == null)
+                    {
+                        player.AddMoney(SlotType.Inventory, charge, ItemTaskType.Auction);
+                        player.SendErrorMessage(ErrorMessageType.AucInternalError);
+                        return;
+                    }
+
+                    Logger.Info("Partial buyout lot={0} buyer={1} ({2}) stack={3} leftover={4} price={5}",
+                        auctionLot.Id, player.Name, player.Id, stack, liveItem.Count, standing);
+                    player.SendPacket(new SCAuctionBidPacket(bid, true, delivered.TemplateId));
+                    SettleSoldSlice_NoLock(auctionLot, delivered, player.Name, standing);
+                    return;
+                }
+
                 if (!TryDetachLot_NoLock(auctionLot.Id, out auctionLot))
                 {
                     player.AddMoney(SlotType.Inventory, charge, ItemTaskType.Auction);
@@ -702,21 +829,35 @@ public class AuctionManager(
 
         if (!_deletedAuctionItemIds.IsEmpty)
         {
-            var ids = _deletedAuctionItemIds.ToArray();
-            _deletedAuctionItemIds.Clear();
-            using var command = connection.CreateCommand();
-            command.Connection = connection;
-            command.Transaction = transaction;
-            var names = new string[ids.Length];
-            for (var i = 0; i < ids.Length; i++)
-            {
-                names[i] = "@d" + i;
-                command.Parameters.AddWithValue(names[i], ids[i]);
-            }
+            var ids = new List<long>();
+            while (_deletedAuctionItemIds.TryTake(out var id))
+                ids.Add(id);
 
-            command.CommandText = "DELETE FROM auction_house WHERE `id` IN(" + string.Join(",", names) + ")";
-            command.Prepare();
-            deletedCount = command.ExecuteNonQuery();
+            if (ids.Count > 0)
+            {
+                try
+                {
+                    using var command = connection.CreateCommand();
+                    command.Connection = connection;
+                    command.Transaction = transaction;
+                    var names = new string[ids.Count];
+                    for (var i = 0; i < ids.Count; i++)
+                    {
+                        names[i] = "@d" + i;
+                        command.Parameters.AddWithValue(names[i], ids[i]);
+                    }
+
+                    command.CommandText = "DELETE FROM auction_house WHERE `id` IN(" + string.Join(",", names) + ")";
+                    command.Prepare();
+                    deletedCount = command.ExecuteNonQuery();
+                }
+                catch
+                {
+                    foreach (var id in ids)
+                        _deletedAuctionItemIds.Add(id);
+                    throw;
+                }
+            }
         }
 
         foreach (var lot in AuctionLots.Values.Where(c => c.IsDirty))
@@ -920,7 +1061,10 @@ public class AuctionManager(
             }
 
             var lot = CreateAuctionLot(player.Id, player.Name, item, startPrice, buyoutPrice, duration, minStack, maxStack);
-            lot.ChargePercent = AuctionFeeSchedule.ApplyPercentDiscount(Fees.SaleChargeRate, ChargeDiscount(player));
+            lot.ChargePercent = AuctionHouseRules.ListingChargeRate(
+                Fees.SaleChargeRate,
+                item.Template?.AuctionSettings?.EffectiveChargeRate ?? 0,
+                ChargeDiscount(player));
             lot.DepositPercent = AuctionFeeSchedule.ApplyPercentDiscount(Fees.GetDepositRate(duration), DepositDiscount(player));
 
             var auctionFee = Fees.GetListingDeposit(lot.DirectMoney, duration, DepositDiscount(player));

--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -4,11 +4,14 @@ using System.Text;
 using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Auction;
 using AAEmu.Game.Models.Game.Auction.Templates;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Features;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Mails;
@@ -19,401 +22,553 @@ using NLog;
 
 namespace AAEmu.Game.Core.Managers;
 
-public class AuctionManager(IItemManager itemManager, INameManager nameManager, IAuctionIdManager auctionIdManager, ILocalizationManager localizationManager, ITaskManager taskManager) : Singleton<AuctionManager>, IAuctionManager
+public class AuctionManager(
+    IItemManager itemManager,
+    INameManager nameManager,
+    IAuctionIdManager auctionIdManager,
+    ILocalizationManager localizationManager,
+    ITaskManager taskManager) : Singleton<AuctionManager>, IAuctionManager
 {
-    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+    private static Logger Logger { get; } = LogManager.GetLogger("AuctionHouse");
 
     public ConcurrentDictionary<ulong, AuctionLot> AuctionLots { get; } = [];
     public ConcurrentBag<long> _deletedAuctionItemIds { get; } = [];
 
-    /// <summary>Listing deposit and sale commission, read from content_configs. See <see cref="AuctionFeeSchedule"/>.</summary>
     public AuctionFeeSchedule Fees { get; } = new();
 
-    private void RemoveAuctionLotSold(AuctionLot itemToRemove, string buyer, int soldAmount)
+    private readonly List<AuctionSale> _soldRecords = [];
+    private readonly object _soldLock = new();
+    private readonly object _houseLock = new();
+    private readonly HashSet<ulong> _listedItemIds = [];
+    private bool? _houseHasExtendedColumns;
+    private bool _tickStarted;
+
+    private bool HouseIsOpen => AppConfiguration.Instance.InitialConfig.CanUseAuction;
+
+    private bool AllowPartialBuy =>
+        FeaturesManager.Fsets != null && FeaturesManager.Fsets.Check(Feature.auctionPartialBuy);
+
+    private bool HasAuctionPostBuff(Character player)
     {
-        if (AuctionLots.ContainsKey(itemToRemove.Id))
+        if (player == null)
+            return false;
+        var worldId = AppConfiguration.Instance.Id;
+        return AccountAttributeManager.Instance.Get(player.AccountId, worldId)
+            .Any(a => a.KindId == (uint)AccountAttributeKind.AuctionPost);
+    }
+
+    private int ChargeDiscount(Character player) =>
+        HasAuctionPostBuff(player) ? Fees.SaleChargeAccountBuffDiscount : 0;
+
+    private int DepositDiscount(Character player) =>
+        HasAuctionPostBuff(player) ? Fees.DepositAccountBuffDiscount : 0;
+
+    private string LocalizedItemName(uint templateId)
+    {
+        var template = itemManager.GetTemplate(templateId);
+        return localizationManager.Get("items", "name", templateId, template?.Name ?? string.Empty);
+    }
+
+    private IReadOnlyList<string> LocalizedItemNames(uint templateId) =>
+        localizationManager.GetAll("items", "name", templateId) ?? [];
+
+    private static byte ServerWorldId => AppConfiguration.Instance.Id;
+
+    private void SendHouseMessage(uint characterId, AuctionMessageKind kind, uint templateId, long money)
+    {
+        var online = WorldManager.Instance.GetCharacterById(characterId);
+        online?.SendPacket(new SCAuctionMessagePacket(kind, templateId, money));
+    }
+
+    private void SendSearchPage(Character player, int page, IReadOnlyList<AuctionLot> lots, ErrorMessageType error = ErrorMessageType.NoErrorMessage)
+    {
+        player.SendPacket(new SCAuctionSearchedPacket(page, lots, (short)error, DateTime.UtcNow));
+    }
+
+    private void RecordSale(AuctionLot lot, long soldAmount)
+    {
+        if (lot?.Item == null || soldAmount <= 0)
+            return;
+
+        var sale = new AuctionSale(lot.Item.TemplateId, lot.Item.Grade, DateTime.UtcNow, soldAmount, lot.Item.Count);
+        lock (_soldLock)
         {
-            var newItem = itemManager.GetItemByItemId(itemToRemove.Item.Id);
-            if (newItem != null)
-            {
-                /*
-                var itemList = new Item[10].ToList();
-                itemList[0] = newItem;
-                */
+            _soldRecords.Add(sale);
+            TrimSoldRecordsLocked(DateTime.UtcNow);
+        }
 
-                // A handful of items bill a commission of their own instead of the house rate.
-                var saleCharge = Fees.GetSaleCharge(soldAmount, newItem.Template?.AuctionSettings?.EffectiveChargeRate ?? 0);
-                var moneyAfterFee = soldAmount - saleCharge;
-
-                var recalculatedFee = Fees.GetListingDeposit(itemToRemove.DirectMoney, itemToRemove.Duration);
-
-                if (itemToRemove.ClientName != "")
-                {
-                    var sellMail = new MailForAuction(newItem, itemToRemove.ClientId, soldAmount, recalculatedFee);
-                    sellMail.FinalizeForSaleSeller(moneyAfterFee, saleCharge);
-                    sellMail.Send();
-                }
-
-                var buyMail = new MailForAuction(newItem, itemToRemove.ClientId, soldAmount, recalculatedFee);
-                var buyerId = nameManager.GetCharacterId(buyer);
-                buyMail.FinalizeForSaleBuyer(buyerId);
-                buyMail.Send();
-            }
-
-            RemoveAuctionLot(itemToRemove);
+        try
+        {
+            using var connection = MySQL.CreateConnection();
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                "INSERT INTO auction_sold_records (item_template_id, item_grade, sold_at, price, stack) " +
+                "VALUES (@template, @grade, @sold_at, @price, @stack)";
+            command.Parameters.AddWithValue("@template", sale.ItemTemplateId);
+            command.Parameters.AddWithValue("@grade", sale.Grade);
+            command.Parameters.AddWithValue("@sold_at", sale.SoldAt);
+            command.Parameters.AddWithValue("@price", sale.Price);
+            command.Parameters.AddWithValue("@stack", sale.Stack);
+            command.Prepare();
+            command.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Failed to persist sold record template={0} grade={1} price={2}",
+                sale.ItemTemplateId, sale.Grade, sale.Price);
         }
     }
 
-    private void RemoveAuctionLotFail(AuctionLot itemToRemove)
+    private void TrimSoldRecordsLocked(DateTime utcNow)
     {
-        if (!AuctionLots.ContainsKey(itemToRemove.Id))
+        var cutoff = utcNow.Date.AddDays(1 - AuctionHouseRules.SoldRecordDays);
+        _soldRecords.RemoveAll(s => s.SoldAt < cutoff);
+    }
+
+    private void UntrackItem(ulong itemId)
+    {
+        if (itemId != 0)
+            _listedItemIds.Remove(itemId);
+    }
+
+    private bool TryAddLot_NoLock(AuctionLot lot)
+    {
+        if (lot?.Item == null || !AuctionHouseRules.IsHeldByHouse(lot.Item))
+            return false;
+        if (!_listedItemIds.Add(lot.Item.Id))
+        {
+            Logger.Warn("Refuse lot {0}: item {1} is already listed", lot.Id, lot.Item.Id);
+            return false;
+        }
+
+        if (AuctionLots.TryAdd(lot.Id, lot))
+            return true;
+
+        UntrackItem(lot.Item.Id);
+        Logger.Warn("Unable to add lot {0}, possible duplicate Id", lot.Id);
+        return false;
+    }
+
+    private bool TryDetachLot_NoLock(ulong lotId, out AuctionLot lot)
+    {
+        if (!AuctionLots.TryRemove(lotId, out lot))
+            return false;
+        if (lot.Item != null)
+            UntrackItem(lot.Item.Id);
+        return true;
+    }
+
+    private void ForgetLot_NoLock(AuctionLot lot)
+    {
+        if (lot.Item != null)
+            UntrackItem(lot.Item.Id);
+        auctionIdManager.ReleaseId((uint)lot.Id);
+        _deletedAuctionItemIds.Add((long)lot.Id);
+    }
+
+    private void RestoreLot_NoLock(AuctionLot lot)
+    {
+        if (!TryAddLot_NoLock(lot))
+            Logger.Error("Failed to restore lot {0} after an aborted settle", lot.Id);
+    }
+
+    private void SendBidRefund(uint bidderId, AuctionLot lot, long amount)
+    {
+        if (bidderId == 0 || amount <= 0)
             return;
 
-        if (itemToRemove.BidderName != "") // Player won the bid
+        var mail = new MailForAuction(lot.Item?.TemplateId ?? 0, lot.ClientId, lot.DirectMoney, 0);
+        if (mail.FinalizeForBidFail(bidderId, amount))
+            mail.Send();
+    }
+
+    private void SettleSold_NoLock(AuctionLot lot, string buyer, long soldAmount)
+    {
+        var item = lot.Item != null ? itemManager.GetItemByItemId(lot.Item.Id) : null;
+        var buyerId = nameManager.GetCharacterId(buyer);
+        if (item == null || buyerId == 0 || !AuctionHouseRules.IsHeldByHouse(item))
         {
-            RemoveAuctionLotSold(itemToRemove, itemToRemove.BidderName, itemToRemove.BidMoney);
+            if (buyerId != 0)
+                SendBidRefund(buyerId, lot, soldAmount);
+            Logger.Error("Sale aborted lot={0} buyer={1}: item is not in house escrow", lot.Id, buyer);
+            ForgetLot_NoLock(lot);
             return;
         }
 
-        // Item did not sell by end of the timer.
-        var newItem = itemManager.GetItemByItemId(itemToRemove.Item.Id);
-        if (newItem != null)
+        var listingDeposit = Fees.GetListingDeposit(lot.DirectMoney, lot.Duration);
+        var buyMail = new MailForAuction(item, lot.ClientId, soldAmount, listingDeposit);
+        if (!buyMail.FinalizeForSaleBuyer(buyerId) || !buyMail.Send())
         {
-            // var itemList = new Item[10].ToList();
-            // itemList[0] = newItem;
-
-            var recalculatedFee = Fees.GetListingDeposit(itemToRemove.DirectMoney, itemToRemove.Duration);
-
-            if (itemToRemove.ClientName != "")
+            SendBidRefund(buyerId, lot, soldAmount);
+            if (AuctionHouseRules.IsHeldByHouse(item) && !string.IsNullOrEmpty(lot.ClientName))
             {
-                var failMail = new MailForAuction(newItem, itemToRemove.ClientId, itemToRemove.DirectMoney,
-                    recalculatedFee);
-                failMail.FinalizeForFail();
-                failMail.Send();
+                var failMail = new MailForAuction(item, lot.ClientId, lot.DirectMoney, listingDeposit);
+                if (failMail.FinalizeForFail())
+                    failMail.Send();
             }
+
+            Logger.Error("Buyer mail failed lot={0} buyer={1}; bid refunded", lot.Id, buyerId);
+            ForgetLot_NoLock(lot);
+            return;
         }
 
-        RemoveAuctionLot(itemToRemove);
+        var saleCharge = Fees.GetSaleCharge(soldAmount, item.Template?.AuctionSettings?.EffectiveChargeRate ?? 0);
+        var moneyAfterFee = soldAmount - saleCharge;
+        if (!string.IsNullOrEmpty(lot.ClientName))
+        {
+            var sellMail = new MailForAuction(item, lot.ClientId, soldAmount, listingDeposit);
+            if (sellMail.FinalizeForSaleSeller(moneyAfterFee, saleCharge))
+                sellMail.Send();
+            else
+                Logger.Error("Seller mail failed lot={0} seller={1} after the item was delivered", lot.Id, lot.ClientId);
+        }
+
+        Logger.Info("Sale settle lot={0} seller={1} ({2}) buyer={3} sold={4} net={5} charge={6}",
+            lot.Id, lot.ClientName, lot.ClientId, buyer, soldAmount, moneyAfterFee, saleCharge);
+        SendHouseMessage(lot.ClientId, AuctionMessageKind.Sold, item.TemplateId, soldAmount);
+        RecordSale(lot, soldAmount);
+        ForgetLot_NoLock(lot);
+    }
+
+    private void SettleExpire_NoLock(AuctionLot lot)
+    {
+        if (lot.BidderId != 0)
+        {
+            SettleSold_NoLock(lot, lot.BidderName, lot.BidMoney);
+            return;
+        }
+
+        var item = lot.Item != null ? itemManager.GetItemByItemId(lot.Item.Id) : null;
+        if (item != null && AuctionHouseRules.IsHeldByHouse(item) && !string.IsNullOrEmpty(lot.ClientName))
+        {
+            var listingDeposit = Fees.GetListingDeposit(lot.DirectMoney, lot.Duration);
+            var failMail = new MailForAuction(item, lot.ClientId, lot.DirectMoney, listingDeposit);
+            if (failMail.FinalizeForFail())
+                failMail.Send();
+            Logger.Info("Expire unsold lot={0} seller={1} ({2}) item={3}",
+                lot.Id, lot.ClientName, lot.ClientId, item.Id);
+        }
+        else
+        {
+            Logger.Warn("Expire lot={0} with no escrowed item", lot.Id);
+        }
+
+        ForgetLot_NoLock(lot);
     }
 
     public void CancelAuctionLot(Character player, ulong auctionId)
     {
-        var auctionLot = GetAuctionLotFromId(auctionId);
-        if (auctionLot == null)
+        if (player == null)
+            return;
+
+        if (!HouseIsOpen)
         {
-            Logger.Warn($"AuctionLot with ID {auctionId} not found.");
+            player.SendErrorMessage(ErrorMessageType.AucPermissionDeny);
             return;
         }
 
-        // auctionId arrives from the client and was only ever looked up, never checked against the caller,
-        // so any player could cancel any listing on the server by walking the id space.
-        if (auctionLot.ClientId != player.Id)
+        lock (_houseLock)
         {
-            Logger.Warn($"{player.Name} ({player.Id}) tried to cancel auction {auctionId}, listed by {auctionLot.ClientId}");
-            return;
+            var auctionLot = GetAuctionLotFromId(auctionId);
+            if (auctionLot == null)
+            {
+                Logger.Warn("Cancel refused {0} ({1}): lot {2} missing", player.Name, player.Id, auctionId);
+                player.SendErrorMessage(ErrorMessageType.AucRefreshDisplay);
+                return;
+            }
+
+            if (auctionLot.ClientId != player.Id)
+            {
+                Logger.Warn("Cancel refused {0} ({1}): lot {2} owned by {3}",
+                    player.Name, player.Id, auctionId, auctionLot.ClientId);
+                player.SendErrorMessage(ErrorMessageType.AucPermissionDeny);
+                return;
+            }
+
+            if (auctionLot.BidderId != 0 || auctionLot.BidMoney > 0)
+            {
+                Logger.Info("Cancel refused {0} ({1}): lot {2} already has a bid", player.Name, player.Id, auctionId);
+                player.SendErrorMessage(ErrorMessageType.AucCannotCancelIfBid);
+                return;
+            }
+
+            if (!TryDetachLot_NoLock(auctionId, out auctionLot))
+            {
+                player.SendErrorMessage(ErrorMessageType.AucRefreshDisplay);
+                return;
+            }
+
+            var listedItem = auctionLot.Item != null ? itemManager.GetItemByItemId(auctionLot.Item.Id) : null;
+            if (listedItem == null || !AuctionHouseRules.IsHeldByHouse(listedItem))
+            {
+                Logger.Error("Cancel lot={0} had no escrowed item", auctionId);
+                ForgetLot_NoLock(auctionLot);
+                player.SendErrorMessage(ErrorMessageType.AucRefreshDisplay);
+                return;
+            }
+
+            var listingDeposit = Fees.GetListingDeposit(auctionLot.DirectMoney, auctionLot.Duration);
+            if (!player.Inventory.MailAttachments.AddOrMoveExistingItem(ItemTaskType.Auction, listedItem))
+            {
+                RestoreLot_NoLock(auctionLot);
+                player.SendErrorMessage(ErrorMessageType.AucInternalError);
+                return;
+            }
+
+            var cancelMail = new MailForAuction(listedItem, auctionLot.ClientId, auctionLot.DirectMoney, listingDeposit);
+            if (!cancelMail.FinalizeForCancel() || !cancelMail.Send())
+            {
+                player.Inventory.AuctionAttachments.AddOrMoveExistingItem(ItemTaskType.Auction, listedItem);
+                RestoreLot_NoLock(auctionLot);
+                player.SendErrorMessage(ErrorMessageType.AucInternalError);
+                return;
+            }
+
+            Logger.Info("Cancel lot={0} seller={1} ({2}) item={3}",
+                auctionLot.Id, player.Name, player.Id, listedItem.Id);
+            ForgetLot_NoLock(auctionLot);
+            player.SendPacket(new SCAuctionCanceledPacket(auctionLot));
         }
-
-        if (auctionLot.BidderName != "") // Someone has already bid on the item and we do not want to remove it
-        {
-            Logger.Warn($"AuctionLot with ID {auctionId} has already been bid on.");
-            return;
-        }
-
-        // Hand back the item that was listed, not a fresh copy of its template.
-        //
-        // itemManager.Create minted a new item from templateId/count/grade alone, so everything else the
-        // player owned was destroyed on cancel: enchantment level, gems, dye, lifespan, crafter, the item id
-        // itself. It also stranded the original, which is still sitting in the seller's AuctionAttachments
-        // container from when the lot was posted, so each cancellation leaked one item and handed back a
-        // duplicate id. RemoveAuctionLotSold already resolves the real item this way.
-        var listedItem = itemManager.GetItemByItemId(auctionLot.Item.Id);
-        if (listedItem != null)
-        {
-            var recalculatedFee = Fees.GetListingDeposit(auctionLot.DirectMoney, auctionLot.Duration);
-
-            // Move it out of the auction hold and into the mail container it is about to be attached to, so
-            // the item's container membership matches where the mail says it is.
-            player.Inventory.MailAttachments.AddOrMoveExistingItem(ItemTaskType.Auction, listedItem);
-
-            var cancelMail = new MailForAuction(listedItem, auctionLot.ClientId, auctionLot.DirectMoney,
-                recalculatedFee);
-            cancelMail.FinalizeForCancel();
-            cancelMail.Send();
-        }
-
-        //MailManager.Instance.SendMail(0, auctionItem.ClientName, "AuctionHouse", "Cancelled Listing", "See attached.", 1, new int[3], 0, itemList);
-
-        RemoveAuctionLot(auctionLot);
-        player.SendPacket(new SCAuctionCanceledPacket(auctionLot));
     }
 
-    private AuctionLot GetAuctionLotFromId(ulong auctionId)
-    {
-        return AuctionLots.GetValueOrDefault(auctionId);
-    }
+    private AuctionLot GetAuctionLotFromId(ulong auctionId) =>
+        AuctionLots.GetValueOrDefault(auctionId);
 
-    public void BidOnAuctionLot(Character player, uint auctioneerId, uint auctioneerId2, AuctionLot lot, AuctionBid bid)
+    public void BidOnAuctionLot(Character player, AuctionBid bid)
     {
-        if (player == null || lot == null || bid == null)
+        if (player == null || bid == null)
+            return;
+
+        if (!HouseIsOpen)
         {
-            Logger.Warn("Invalid arguments passed to BidOnAuctionLot.");
+            player.SendErrorMessage(ErrorMessageType.AucPermissionDeny);
             return;
         }
 
-        var auctionLot = GetAuctionLotFromId(lot.Id);
-        if (auctionLot == null)
+        lock (_houseLock)
         {
-            Logger.Warn("Invalid auctionItem passed to BidOnAuctionLot.");
-            Logger.Warn($"AuctionLot with ID {lot.Id} not found in the list.");
-            return;
-        }
+            var auctionLot = GetAuctionLotFromId(bid.LotId);
+            if (auctionLot?.Item == null || DateTime.UtcNow >= auctionLot.EndTime)
+            {
+                Logger.Warn("Bid refused {0} ({1}): lot {2} missing or expired", player.Name, player.Id, bid.LotId);
+                player.SendErrorMessage(ErrorMessageType.AucRefreshDisplay);
+                return;
+            }
 
-        if (bid.Money >= auctionLot.DirectMoney && auctionLot.DirectMoney != 0) // Buy now
-        {
-            // Take payment before anything else. SubtractMoney reports whether it actually took the coin, and
-            // that result used to be discarded: a buyer who could not afford the lot still had it handed over
-            // and any standing bidder was still refunded, so the sale both gave away the item and minted the
-            // refund. Order matters too - the outbid mail below must not go out on a purchase that fails.
-            if (!player.SubtractMoney(SlotType.Inventory, auctionLot.DirectMoney, ItemTaskType.Auction))
+            var liveItem = itemManager.GetItemByItemId(auctionLot.Item.Id);
+            if (!AuctionHouseRules.IsHeldByHouse(liveItem))
+            {
+                Logger.Warn("Bid refused {0} ({1}): lot {2} item is not in escrow", player.Name, player.Id, bid.LotId);
+                player.SendErrorMessage(ErrorMessageType.AucRefreshDisplay);
+                return;
+            }
+
+            if (auctionLot.ClientId == player.Id)
+            {
+                player.SendErrorMessage(ErrorMessageType.AucBidSelf);
+                return;
+            }
+
+            var bidderIsCurrent = auctionLot.BidderId == player.Id;
+            if (!AuctionHouseRules.TryGetBidCharge(
+                    bid.Money,
+                    auctionLot.StartMoney,
+                    auctionLot.BidMoney,
+                    auctionLot.DirectMoney,
+                    bidderIsCurrent,
+                    out var charge,
+                    out var isBuyout))
+            {
+                if (AuctionHouseRules.IsBuyoutOffer(bid.Money, auctionLot.DirectMoney))
+                    player.SendErrorMessage(ErrorMessageType.AuctionInvalidBidPrice);
+                else if (auctionLot.StartMoney > 0 && bid.Money < auctionLot.StartMoney)
+                    player.SendErrorMessage(ErrorMessageType.AucBidMoneyUnderStartMoney);
+                else
+                    player.SendErrorMessage(ErrorMessageType.AucBidMoneyUnderTopMost);
+                return;
+            }
+
+            if (!player.SubtractMoney(SlotType.Inventory, charge, ItemTaskType.Auction))
             {
                 player.SendErrorMessage(ErrorMessageType.NotEnoughMoney);
                 return;
             }
 
-            if (auctionLot.BidderId != 0) // send mail to person who bid if item was bought at full price.
+            var previousBidderId = auctionLot.BidderId;
+            var previousBid = auctionLot.BidMoney;
+            if (previousBidderId != 0 && previousBidderId != player.Id)
             {
-                var newMail = new MailForAuction(auctionLot.Item.TemplateId, auctionLot.ClientId, auctionLot.DirectMoney, 0);
-                newMail.FinalizeForBidFail(auctionLot.BidderId, auctionLot.BidMoney);
-                newMail.Send();
+                SendBidRefund(previousBidderId, auctionLot, previousBid);
+                SendHouseMessage(previousBidderId, AuctionMessageKind.Outbid, auctionLot.Item.TemplateId, previousBid);
+                Logger.Info("Outbid lot={0} previous={1} refund={2} by {3} ({4})",
+                    auctionLot.Id, previousBidderId, previousBid, player.Name, player.Id);
             }
 
-            RemoveAuctionLotSold(auctionLot, player.Name, auctionLot.DirectMoney);
-        }
-        else if (bid.Money > auctionLot.BidMoney) // Bid
-        {
-            // bid.Money is client supplied; a bid at or below zero can never outrank a standing bid, but guard
-            // it anyway so a malformed packet cannot reach SubtractMoney's own negative check.
-            if (bid.Money <= 0)
-            {
-                return;
-            }
-
-            // Same discarded-result bug as buy-now, and worse here: the old bidder's refund went out first, so
-            // a bid the player could not pay for still returned the previous bidder's coin and left the lot
-            // held by someone who paid nothing.
-            if (!player.SubtractMoney(SlotType.Inventory, bid.Money, ItemTaskType.Auction))
-            {
-                player.SendErrorMessage(ErrorMessageType.NotEnoughMoney);
-                return;
-            }
-
-            if (auctionLot.BidderName != "" && auctionLot.BidderId != 0) // Send mail to old bidder.
-            {
-                var recalculatedFee = Fees.GetListingDeposit(auctionLot.DirectMoney, auctionLot.Duration);
-
-                var cancelMail = new MailForAuction(auctionLot.Item.TemplateId, auctionLot.ClientId, auctionLot.DirectMoney, recalculatedFee);
-                cancelMail.FinalizeForBidFail(auctionLot.BidderId, auctionLot.BidMoney);
-                cancelMail.Send();
-            }
-
-            // Set info to new bidders info
-            auctionLot.BidderName = player.Name;
-            auctionLot.BidderId = player.Id;
-            auctionLot.BidWorldId = (byte)player.Transform.WorldId;
-            auctionLot.BidMoney = bid.Money;
-
+            var standing = isBuyout ? auctionLot.DirectMoney : bid.Money;
+            bid.LotId = auctionLot.Id;
             bid.BidderName = player.Name;
             bid.BidderId = player.Id;
-            bid.WorldId = (byte)player.Transform.WorldId;
+            bid.WorldId = ServerWorldId;
+            bid.Money = standing;
+            bid.StackSize = liveItem.Count;
 
-            player.SendPacket(new SCAuctionBidPacket(bid, false, auctionLot.Item.TemplateId));
+            if (isBuyout)
+            {
+                if (!TryDetachLot_NoLock(auctionLot.Id, out auctionLot))
+                {
+                    player.AddMoney(SlotType.Inventory, charge, ItemTaskType.Auction);
+                    player.SendErrorMessage(ErrorMessageType.AucRefreshDisplay);
+                    return;
+                }
+
+                Logger.Info("Buyout lot={0} buyer={1} ({2}) price={3} charged={4} item={5}",
+                    auctionLot.Id, player.Name, player.Id, standing, charge, liveItem.Id);
+                player.SendPacket(new SCAuctionBidPacket(bid, true, liveItem.TemplateId));
+                SettleSold_NoLock(auctionLot, player.Name, standing);
+                return;
+            }
+
+            auctionLot.BidderName = player.Name;
+            auctionLot.BidderId = player.Id;
+            auctionLot.BidWorldId = ServerWorldId;
+            auctionLot.BidMoney = standing;
             auctionLot.IsDirty = true;
 
-            // Обновление данных в списке AuctionLots
-            UpdateAuctionLotInList(auctionLot);
-        }
-    }
-
-    private void UpdateAuctionLotInList(AuctionLot auctionLot)
-    {
-        if (auctionLot == null)
-        {
-            Logger.Warn("Invalid auctionItem passed to UpdateAuctionLotInList.");
-            return;
-        }
-
-        var existingLot = AuctionLots.GetValueOrDefault(auctionLot.Id);
-        if (existingLot != null)
-        {
-            // Update lot data
-            existingLot.BidderName = auctionLot.BidderName;
-            existingLot.BidderId = auctionLot.BidderId;
-            existingLot.BidWorldId = auctionLot.BidWorldId;
-            existingLot.BidMoney = auctionLot.BidMoney;
-            existingLot.Item = auctionLot.Item;
-            existingLot.IsDirty = auctionLot.IsDirty;
-        }
-        else
-        {
-            Logger.Warn($"AuctionLot with ID {auctionLot.Id} not found in the list.");
+            Logger.Info("Bid lot={0} bidder={1} ({2}) standing={3} charged={4}",
+                auctionLot.Id, player.Name, player.Id, standing, charge);
+            player.SendPacket(new SCAuctionBidPacket(bid, false, liveItem.TemplateId));
         }
     }
 
     public void GetBidAuctionLots(Character player, int page)
     {
-        var searchedArticles = AuctionLots.Values.Where(lot => lot.BidderId == player.Id).ToList();
-        if (searchedArticles.Count <= 0)
+        if (player == null)
+            return;
+
+        if (!HouseIsOpen)
         {
-            player.SendPacket(new SCAuctionSearchedPacket(0, 0, [], (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
+            SendSearchPage(player, page, [], ErrorMessageType.AucPermissionDeny);
             return;
         }
 
-        var articles = SortArticles(searchedArticles, AuctionSearchSortKind.Default, AuctionSearchSortOrder.Asc).ToArray();
-        var dividedLists = Helpers.SplitArray(articles, 9); // Разделяем массив на массивы по 9 значений
-           
-        if (page < 0 || page >= dividedLists.Length) //Stops client DC when requesting an out-of-bounds page
-        {
-            Logger.Warn($"[AH-BIDS] {player.Name} requested an out-of-bounds page: {page}/{dividedLists.Length - 1}");
-            player.SendPacket(new SCAuctionSearchedPacket(page, 0, [], (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
-            return;
-        }
-        player.SendPacket(new SCAuctionSearchedPacket(page, dividedLists[page].Length, dividedLists[page].ToList(), (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
-    }
-
-    private AuctionLot GetCheapestAuctionLot(uint templateId)
-    {
-        var tempList = AuctionLots.Values.Where(lot => lot.Item.TemplateId == templateId).ToList();
-        if (tempList.Count <= 0)
-        {
-            return null;
-        }
-
-        tempList = tempList.OrderBy(x => x.DirectMoney).ToList();
-
-        return tempList.First();
+        var mine = AuctionLots.Values.Where(lot => lot.BidderId == player.Id).ToList();
+        var sorted = AuctionHouseRules.Sort(mine, AuctionSearchSortKind.Default, AuctionSearchSortOrder.Asc).ToList();
+        SendSearchPage(player, page, AuctionHouseRules.Page(sorted, page));
     }
 
     public void CheapestAuctionLot(Character player, uint templateId, byte itemGrade = 0)
     {
-        var DirectMoney = 0;
-        var cheapestItem = GetCheapestAuctionLot(templateId);
-        if (cheapestItem != null)
-        {
-            DirectMoney = cheapestItem.DirectMoney;
-        }
-
-        player.SendPacket(new SCAuctionLowestPricePacket(templateId, itemGrade, DirectMoney));
-    }
-
-    private string GetLocalizedItemNameById(uint id)
-    {
-        return localizationManager.Get("items", "name", id, itemManager.GetTemplate(id).Name ?? "");
-    }
-
-    /* Unused
-
-    private ulong GetNextId()
-    {
-        if (AuctionLots.Count == 0)
-            return 1;
-
-        var maxId = AuctionLots.Max(item => item.Id);
-        if (maxId == ulong.MaxValue)
-            throw new OverflowException("No more IDs available.");
-
-        return maxId + 1;
-    }
-    */
-
-    private void RemoveAuctionLot(AuctionLot itemToRemove)
-    {
-        var copyOfLots = AuctionLots.ToList();
-        if (!AuctionLots.ContainsKey(itemToRemove.Id))
-        {
+        if (player == null)
             return;
+
+        if (!HouseIsOpen)
+            return;
+
+        var cheapest = AuctionLots.Values
+            .Where(lot => lot.Item != null
+                          && lot.Item.TemplateId == templateId
+                          && (itemGrade == 0 || lot.Item.Grade == itemGrade))
+            .OrderBy(AuctionHouseRules.DisplayPrice)
+            .FirstOrDefault();
+
+        player.SendPacket(new SCAuctionLowestPricePacket(templateId, itemGrade, cheapest == null ? 0 : AuctionHouseRules.DisplayPrice(cheapest)));
+    }
+
+    public void SearchSoldRecords(Character player, uint templateId, byte grade, bool askMarketPriceUi)
+    {
+        if (player == null)
+            return;
+
+        if (!HouseIsOpen)
+            return;
+
+        List<AuctionSale> snapshot;
+        lock (_soldLock)
+        {
+            TrimSoldRecordsLocked(DateTime.UtcNow);
+            snapshot = _soldRecords.ToList();
         }
 
-        auctionIdManager.ReleaseId((uint)itemToRemove.Id);
-        _deletedAuctionItemIds.Add((long)itemToRemove.Id);
-        if (!AuctionLots.TryRemove(itemToRemove.Id, out _))
-        {
-            Logger.Warn($"Unable to remove Auction Lot with Id {itemToRemove?.Id}");
-        }
+        var days = AuctionSoldRecordRules.BuildDays(snapshot, templateId, grade, DateTime.UtcNow);
+        player.SendPacket(new SCAuctionSoldRecordSearchedPacket(templateId, grade, askMarketPriceUi, days));
     }
 
     public void AddAuctionLot(AuctionLot lot)
     {
-        if (!AuctionLots.TryAdd(lot.Id, lot))
+        lock (_houseLock)
         {
-            Logger.Warn($"Unable to add Auction Lot with Id {lot.Id}, possible duplicate Id");
+            if (!TryAddLot_NoLock(lot))
+                auctionIdManager.ReleaseId((uint)lot.Id);
         }
     }
 
     public void UpdateAuctionHouse()
     {
-        Logger.Trace("Updating Auction House!");
-        var itemsToRemove = AuctionLots.Values.Where(c => DateTime.UtcNow > c.EndTime).ToList();
-
-        foreach (var item in itemsToRemove)
+        lock (_houseLock)
         {
-            if (item.BidderId != 0)
-                RemoveAuctionLotSold(item, item.BidderName, item.BidMoney);
-            else
-                RemoveAuctionLotFail(item);
+            Logger.Trace("Updating Auction House");
+            var itemsToRemove = AuctionLots.Values.Where(c => DateTime.UtcNow > c.EndTime).ToList();
+            foreach (var lot in itemsToRemove)
+            {
+                if (!TryDetachLot_NoLock(lot.Id, out var detached))
+                    continue;
+                SettleExpire_NoLock(detached);
+            }
         }
     }
 
-    public AuctionLot CreateAuctionLot(uint playerId, string playerName, Item itemToList, int startPrice, int buyoutPrice, AuctionDuration duration, int minStack = 1, int maxStack = 1)
+    public AuctionLot CreateAuctionLot(
+        uint playerId,
+        string playerName,
+        Item itemToList,
+        long startPrice,
+        long buyoutPrice,
+        AuctionDuration duration,
+        int minStack = 1,
+        int maxStack = 1)
     {
-        ulong timeLeft;
-        switch (duration)
+        var now = DateTime.UtcNow;
+        var stacks = AuctionHouseRules.ClampStacks(itemToList?.Count ?? 1, minStack, maxStack, AllowPartialBuy);
+        return new AuctionLot
         {
-            case AuctionDuration.AuctionDuration6Hours:
-                timeLeft = 6; // 6 hours
-                break;
-            case AuctionDuration.AuctionDuration12Hours:
-                timeLeft = 12;
-                break;
-            case AuctionDuration.AuctionDuration24Hours:
-                timeLeft = 24; // 24 hours
-                break;
-            case AuctionDuration.AuctionDuration48Hours:
-                timeLeft = 48; // 48 hours
-                break;
-            default:
-                timeLeft = 6; // default to 6 hours
-                break;
-        }
-
-        var newAuctionLot = new AuctionLot
-        {
-            Id = auctionIdManager.GetNextId(), Duration = duration, Item = itemToList, EndTime = DateTime.UtcNow.AddHours(timeLeft),
-            WorldId = 1,
+            Id = auctionIdManager.GetNextId(),
+            Duration = duration,
+            Item = itemToList,
+            EndTime = now.AddHours(AuctionHouseRules.HoursFor(duration)),
+            WorldId = ServerWorldId,
             ClientId = playerId,
-            ClientName = playerName,
+            ClientName = playerName ?? string.Empty,
             StartMoney = startPrice,
             DirectMoney = buyoutPrice,
-            PostDate = DateTime.UtcNow,
-            //ChargePercent = 100, // added in 5+
-            BidWorldId = 255,
+            PostDate = now,
+            Asked = (ulong)Helpers.UnixTime(now),
+            ChargePercent = Fees.SaleChargeRate,
+            DepositPercent = Fees.GetDepositRate(duration),
+            ServiceKind = 0,
+            BidWorldId = AuctionHouseRules.UnsetWorldId,
             BidderId = 0,
-            BidderName = "",
+            BidderName = string.Empty,
             BidMoney = 0,
-            Extra = 0,
-            //MinStack = minStack, // added in 5+
-            //MaxStack = maxStack, // added in 5+
+            ExtraMoney = 0,
+            MinStack = stacks.minStack,
+            MaxStack = stacks.maxStack,
             IsDirty = true
         };
-
-        return newAuctionLot;
     }
 
     public void Load()
     {
         try
         {
-            AuctionLots.Clear();
-            _deletedAuctionItemIds.Clear();
+            lock (_houseLock)
+            {
+                AuctionLots.Clear();
+                _listedItemIds.Clear();
+                _deletedAuctionItemIds.Clear();
+            }
+
+            lock (_soldLock)
+                _soldRecords.Clear();
 
             Fees.Load();
 
@@ -423,45 +578,122 @@ public class AuctionManager(IItemManager itemManager, INameManager nameManager, 
                 {
                     command.CommandText = "SELECT * FROM auction_house";
                     command.Prepare();
-                    using (var reader = command.ExecuteReader())
+                    using var reader = command.ExecuteReader();
+                    while (reader.Read())
                     {
-                        while (reader.Read())
+                        var itemId = reader.GetUInt64("item_id");
+                        var auctionLot = new AuctionLot
                         {
-                            var auctionLot = new AuctionLot
-                            {
-                                Id = reader.GetUInt64("id"),
-                                Duration = (AuctionDuration)reader.GetByte("duration"), // 8 is 6 hours, 9 is 12 hours, 10 is 24 hours, 11 is 48 hours
-                                Item = itemManager.GetItemByItemId(reader.GetUInt32("item_id")),
-                                PostDate = reader.GetDateTime("post_date"),
-                                EndTime = reader.GetDateTime("end_time"),
-                                WorldId = reader.GetByte("world_id"),
-                                ClientId = reader.GetUInt32("client_id"),
-                                ClientName = reader.GetString("client_name"),
-                                StartMoney = reader.GetInt32("start_money"),
-                                DirectMoney = reader.GetInt32("direct_money"),
-                                //ChargePercent = reader.GetInt32("charge_percent"), // added in 5+
-                                BidWorldId = (byte)reader.GetInt32("bid_world_id"),
-                                BidderId = reader.GetUInt32("bidder_id"),
-                                BidderName = reader.GetString("bidder_name"),
-                                BidMoney = reader.GetInt32("bid_money"),
-                                Extra = reader.GetInt32("extra"),
-                                //MinStack = reader.GetInt32("min_stack"), // added in 5+
-                                //MaxStack = reader.GetInt32("max_stack") // added in 5+
-                            };
+                            Id = reader.GetUInt64("id"),
+                            Duration = (AuctionDuration)reader.GetByte("duration"),
+                            Item = itemManager.GetItemByItemId(itemId),
+                            PostDate = reader.GetDateTime("post_date"),
+                            EndTime = reader.GetDateTime("end_time"),
+                            WorldId = reader.GetByte("world_id"),
+                            ClientId = reader.GetUInt32("client_id"),
+                            ClientName = reader.GetString("client_name"),
+                            StartMoney = reader.GetInt64("start_money"),
+                            DirectMoney = reader.GetInt64("direct_money"),
+                            Asked = ReadOptionalUInt64(reader, "asked"),
+                            ChargePercent = ReadOptionalInt32(reader, "charge_percent"),
+                            DepositPercent = ReadOptionalInt32(reader, "deposit_percent"),
+                            ServiceKind = ReadOptionalByte(reader, "service_kind"),
+                            BidWorldId = (byte)reader.GetInt32("bid_world_id"),
+                            BidderId = reader.GetUInt32("bidder_id"),
+                            BidderName = reader.GetString("bidder_name"),
+                            BidMoney = reader.GetInt64("bid_money"),
+                            ExtraMoney = reader.GetInt64("extra"),
+                            MinStack = ReadOptionalInt32(reader, "min_stack", 1),
+                            MaxStack = ReadOptionalInt32(reader, "max_stack", 1),
+                        };
+                        if (auctionLot.Asked == 0)
+                            auctionLot.Asked = (ulong)Helpers.UnixTime(auctionLot.PostDate);
+                        if (auctionLot.Item == null || !AuctionHouseRules.IsHeldByHouse(auctionLot.Item))
+                        {
+                            Logger.Warn("Skip lot {0}: item {1} is not in house escrow", auctionLot.Id, itemId);
+                            _deletedAuctionItemIds.Add((long)auctionLot.Id);
+                            auctionIdManager.ReleaseId((uint)auctionLot.Id);
+                            continue;
+                        }
 
-                            AddAuctionLot(auctionLot);
+                        lock (_houseLock)
+                        {
+                            if (!TryAddLot_NoLock(auctionLot))
+                            {
+                                Logger.Warn("Skip lot {0}: item {1} is already listed", auctionLot.Id, itemId);
+                                _deletedAuctionItemIds.Add((long)auctionLot.Id);
+                                auctionIdManager.ReleaseId((uint)auctionLot.Id);
+                            }
                         }
                     }
                 }
+
+                LoadSoldRecords(connection);
             }
-            var auctionTask = new AuctionHouseTask();
-            taskManager.Schedule(auctionTask, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+
+            if (!_tickStarted)
+            {
+                taskManager.Schedule(new AuctionHouseTask(), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+                _tickStarted = true;
+            }
+
+            Logger.Info("Loaded {0} lots", AuctionLots.Count);
         }
         catch (Exception ex)
         {
-            Logger.Error($"Failed to load auction data: {ex.Message}");
+            Logger.Error(ex, "Failed to load auction data");
         }
     }
+
+    private void LoadSoldRecords(MySqlConnection connection)
+    {
+        try
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText =
+                "SELECT item_template_id, item_grade, sold_at, price, stack FROM auction_sold_records " +
+                "WHERE sold_at >= @cutoff";
+            command.Parameters.AddWithValue("@cutoff", DateTime.UtcNow.Date.AddDays(1 - AuctionHouseRules.SoldRecordDays));
+            command.Prepare();
+            using var reader = command.ExecuteReader();
+            lock (_soldLock)
+            {
+                while (reader.Read())
+                {
+                    _soldRecords.Add(new AuctionSale(
+                        reader.GetUInt32("item_template_id"),
+                        reader.GetByte("item_grade"),
+                        reader.GetDateTime("sold_at"),
+                        reader.GetInt64("price"),
+                        reader.GetInt32("stack")));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn(ex, "auction_sold_records is missing or unreadable; sold history stays empty until the table exists");
+        }
+    }
+
+    private static bool HasColumn(MySqlDataReader reader, string name)
+    {
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            if (string.Equals(reader.GetName(i), name, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static int ReadOptionalInt32(MySqlDataReader reader, string name, int fallback = 0) =>
+        HasColumn(reader, name) && !reader.IsDBNull(reader.GetOrdinal(name)) ? reader.GetInt32(name) : fallback;
+
+    private static byte ReadOptionalByte(MySqlDataReader reader, string name, byte fallback = 0) =>
+        HasColumn(reader, name) && !reader.IsDBNull(reader.GetOrdinal(name)) ? reader.GetByte(name) : fallback;
+
+    private static ulong ReadOptionalUInt64(MySqlDataReader reader, string name, ulong fallback = 0) =>
+        HasColumn(reader, name) && !reader.IsDBNull(reader.GetOrdinal(name)) ? reader.GetUInt64(name) : fallback;
 
     public (int, int) Save(MySqlConnection connection, MySqlTransaction transaction)
     {
@@ -470,19 +702,24 @@ public class AuctionManager(IItemManager itemManager, INameManager nameManager, 
 
         if (!_deletedAuctionItemIds.IsEmpty)
         {
-            using (var command = connection.CreateCommand())
-            {
-                command.Connection = connection;
-                command.Transaction = transaction;
-                command.CommandText = "DELETE FROM auction_house WHERE `id` IN(" + string.Join(",", _deletedAuctionItemIds) + ")";
-                command.Prepare();
-                deletedCount = command.ExecuteNonQuery();
-            }
+            var ids = _deletedAuctionItemIds.ToArray();
             _deletedAuctionItemIds.Clear();
+            using var command = connection.CreateCommand();
+            command.Connection = connection;
+            command.Transaction = transaction;
+            var names = new string[ids.Length];
+            for (var i = 0; i < ids.Length; i++)
+            {
+                names[i] = "@d" + i;
+                command.Parameters.AddWithValue(names[i], ids[i]);
+            }
+
+            command.CommandText = "DELETE FROM auction_house WHERE `id` IN(" + string.Join(",", names) + ")";
+            command.Prepare();
+            deletedCount = command.ExecuteNonQuery();
         }
 
-        var dirtyItems = AuctionLots.Values.Where(c => c.IsDirty == true);
-        foreach (var lot in dirtyItems)
+        foreach (var lot in AuctionLots.Values.Where(c => c.IsDirty))
         {
             if (lot.Item == null)
                 continue;
@@ -493,60 +730,78 @@ public class AuctionManager(IItemManager itemManager, INameManager nameManager, 
                     continue;
 
                 if (lot.Item._holdingContainer != null)
-                {
                     lot.Item.SlotType = itemManager.GetContainerSlotTypeByContainerId(lot.Item._holdingContainer.ContainerId);
-                }
 
                 if (lot.Item.SlotType != SlotType.None)
-                {
-                    Logger.Warn($"Slot type for {lot.Item.Id} was None, changing to {lot.Item.SlotType}");
-                }
+                    Logger.Warn("Slot type for {0} was None, changing to {1}", lot.Item.Id, lot.Item.SlotType);
                 else
-                {
                     continue;
-                }
             }
+
             if (!Enum.IsDefined(typeof(SlotType), lot.Item.SlotType))
             {
-                Logger.Warn($"Found SlotType.{lot.Item.SlotType} in itemslist, skipping ID:{lot.Item.Id} - Template:{lot.Item.TemplateId}");
+                Logger.Warn("Found SlotType.{0} in itemslist, skipping ID:{1} - Template:{2}",
+                    lot.Item.SlotType, lot.Item.Id, lot.Item.TemplateId);
                 continue;
             }
 
-            var details = new Commons.Network.PacketStream();
-            lot.Item.WriteDetails(details);
-
-            using (var command = connection.CreateCommand())
-            {
-                command.Connection = connection;
-                command.Transaction = transaction;
-                command.CommandText = BuildInsertQuery(lot);
-                AddParametersToCommand(command, lot);
-                command.Prepare();
-                updatedCount += command.ExecuteNonQuery();
-                lot.IsDirty = false;
-            }
+            using var command = connection.CreateCommand();
+            command.Connection = connection;
+            command.Transaction = transaction;
+            var extended = HouseHasExtendedColumns(connection, transaction);
+            command.CommandText = BuildInsertQuery(extended);
+            AddParametersToCommand(command, lot, extended);
+            command.Prepare();
+            updatedCount += command.ExecuteNonQuery();
+            lot.IsDirty = false;
         }
 
         return (updatedCount, deletedCount);
     }
 
-    private string BuildInsertQuery(AuctionLot lot)
+    private bool HouseHasExtendedColumns(MySqlConnection connection, MySqlTransaction transaction)
+    {
+        if (_houseHasExtendedColumns.HasValue)
+            return _houseHasExtendedColumns.Value;
+
+        using var command = connection.CreateCommand();
+        command.Connection = connection;
+        command.Transaction = transaction;
+        command.CommandText =
+            "SELECT COUNT(*) FROM information_schema.COLUMNS " +
+            "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'auction_house' AND COLUMN_NAME = 'charge_percent'";
+        command.Prepare();
+        var found = Convert.ToInt32(command.ExecuteScalar()) > 0;
+        _houseHasExtendedColumns = found;
+        if (!found)
+            Logger.Warn("auction_house is missing the 10.0 listing columns; apply SQL/updates/2026-09-05_aaemu_game_auction_house_10_0.sql");
+        return found;
+    }
+
+    private static string BuildInsertQuery(bool extended)
     {
         var sb = new StringBuilder();
         sb.Append("REPLACE INTO auction_house(");
         sb.Append("`id`, `duration`, `item_id`, `post_date`, `stack_size`, `end_time`, ");
         sb.Append("`world_id`, `client_id`, `client_name`, `start_money`, `direct_money`, ");
+        if (extended)
+            sb.Append("`asked`, `charge_percent`, `deposit_percent`, `service_kind`, ");
         sb.Append("`bid_world_id`, `bidder_id`, `bidder_name`, `bid_money`, `extra`");
+        if (extended)
+            sb.Append(", `min_stack`, `max_stack`");
         sb.Append(") VALUES (");
         sb.Append("@id, @duration, @item_id, @post_date, @stack_size, @end_time, ");
         sb.Append("@world_id, @client_id, @client_name, @start_money, @direct_money, ");
+        if (extended)
+            sb.Append("@asked, @charge_percent, @deposit_percent, @service_kind, ");
         sb.Append("@bid_world_id, @bidder_id, @bidder_name, @bid_money, @extra");
+        if (extended)
+            sb.Append(", @min_stack, @max_stack");
         sb.Append(" )");
-
         return sb.ToString();
     }
 
-    private void AddParametersToCommand(MySqlCommand command, AuctionLot lot)
+    private static void AddParametersToCommand(MySqlCommand command, AuctionLot lot, bool extended)
     {
         command.Parameters.AddWithValue("@id", lot.Id);
         command.Parameters.AddWithValue("@duration", (byte)lot.Duration);
@@ -559,224 +814,150 @@ public class AuctionManager(IItemManager itemManager, INameManager nameManager, 
         command.Parameters.AddWithValue("@client_name", lot.ClientName);
         command.Parameters.AddWithValue("@start_money", lot.StartMoney);
         command.Parameters.AddWithValue("@direct_money", lot.DirectMoney);
-        //command.Parameters.AddWithValue("@charge_percent", lot.ChargePercent); // added in 5+
+        if (extended)
+        {
+            command.Parameters.AddWithValue("@asked", lot.Asked != 0 ? lot.Asked : (ulong)Helpers.UnixTime(lot.PostDate));
+            command.Parameters.AddWithValue("@charge_percent", lot.ChargePercent);
+            command.Parameters.AddWithValue("@deposit_percent", lot.DepositPercent);
+            command.Parameters.AddWithValue("@service_kind", lot.ServiceKind);
+        }
         command.Parameters.AddWithValue("@bid_world_id", lot.BidWorldId);
         command.Parameters.AddWithValue("@bidder_id", lot.BidderId);
         command.Parameters.AddWithValue("@bidder_name", lot.BidderName);
         command.Parameters.AddWithValue("@bid_money", lot.BidMoney);
-        command.Parameters.AddWithValue("@extra", lot.Extra);
-        //command.Parameters.AddWithValue("@min_stack", lot.MinStack); // added in 5+
-        //command.Parameters.AddWithValue("@max_stack", lot.MaxStack); // added in 5+
-    }
-
-    private List<AuctionLot> SortArticles(List<AuctionLot> articles, AuctionSearchSortKind kind, AuctionSearchSortOrder order)
-    {
-        var sortedArticles = articles.AsQueryable();
-
-        switch (kind)
+        command.Parameters.AddWithValue("@extra", lot.ExtraMoney);
+        if (extended)
         {
-            case AuctionSearchSortKind.BidPrice:
-                sortedArticles = order == AuctionSearchSortOrder.Asc
-                    ? sortedArticles.OrderBy(o => o.BidMoney)
-                    : sortedArticles.OrderByDescending(o => o.BidMoney);
-                break;
-            case AuctionSearchSortKind.DirectPrice:
-                sortedArticles = order == AuctionSearchSortOrder.Asc
-                    ? sortedArticles.OrderBy(o => o.DirectMoney)
-                    : sortedArticles.OrderByDescending(o => o.DirectMoney);
-                break;
-            case AuctionSearchSortKind.ExpireDate:
-                sortedArticles = order == AuctionSearchSortOrder.Asc
-                    ? sortedArticles.OrderBy(o => o.PostDate)
-                    : sortedArticles.OrderByDescending(o => o.PostDate);
-                break;
-            case AuctionSearchSortKind.ItemLevel:
-                sortedArticles = order == AuctionSearchSortOrder.Asc
-                    ? sortedArticles.OrderBy(o => o.Item.Template.Level)
-                    : sortedArticles.OrderByDescending(o => o.Item.Template.Level);
-                break;
+            command.Parameters.AddWithValue("@min_stack", lot.MinStack);
+            command.Parameters.AddWithValue("@max_stack", lot.MaxStack);
         }
-
-        return sortedArticles.ToList();
     }
 
     public void SearchAuctionLots(Character player, AuctionSearch search)
     {
-        var searchedArticles = new List<AuctionLot>();
+        if (player == null || search == null)
+            return;
 
-        var detectedLanguage = LanguageDetector.DetectLanguage(search.Keyword);
-        Logger.Info($"Detected language for keyword '{search.Keyword}': {detectedLanguage}");
-
-        foreach (var (lotId, lot) in AuctionLots)
+        if (!HouseIsOpen)
         {
-            var template = lot.Item.Template;
-            var settings = template.AuctionSettings;
+            SendSearchPage(player, search.Page, [], ErrorMessageType.AucPermissionDeny);
+            return;
+        }
 
-            template.Name = GetLocalizedItemNameById(template.Id);
-
-            // Проверка по ClientId
-            if (search.ClientId != 0 && lot.ClientId != search.ClientId)
-            {
+        var matched = new List<AuctionLot>();
+        foreach (var lot in AuctionLots.Values)
+        {
+            if (lot.Item?.Template == null)
                 continue;
+
+            var names = LocalizedItemNames(lot.Item.TemplateId);
+            if (AuctionHouseRules.Matches(lot, search, search.ItemTemplateIds, names))
+                matched.Add(lot);
+        }
+
+        var sorted = AuctionHouseRules.Sort(matched, search.SortKind, search.SortOrder).ToList();
+        SendSearchPage(player, search.Page, AuctionHouseRules.Page(sorted, search.Page));
+    }
+
+    public bool PostLotOnAuction(
+        Character player,
+        ulong itemId,
+        long startPrice,
+        long buyoutPrice,
+        AuctionDuration duration,
+        int minStack,
+        int maxStack)
+    {
+        if (player == null)
+            return false;
+
+        if (!HouseIsOpen)
+        {
+            player.SendErrorMessage(ErrorMessageType.AucPermissionDeny);
+            Logger.Info("Post refused {0} ({1}): house closed", player.Name, player.Id);
+            return false;
+        }
+
+        if (!AuctionHouseRules.IsValidDuration(duration))
+        {
+            Logger.Info("Post refused {0} ({1}): duration {2} is not a house step", player.Name, player.Id, (byte)duration);
+            player.SendErrorMessage(ErrorMessageType.AucWrongDirectMoney);
+            return false;
+        }
+
+        lock (_houseLock)
+        {
+            var item = player.Inventory?.Bag?.GetItemByItemId(itemId);
+            if (item == null || !AuctionHouseRules.IsOwnedInBag(item, player.Id))
+            {
+                Logger.Info("Post refused {0} ({1}): item {2} missing or not in bag", player.Name, player.Id, itemId);
+                player.SendErrorMessage(ErrorMessageType.AucInvalidItemOrNotInYourBag);
+                return false;
             }
 
-            // Проверка по ключевому слову
-            if (!string.IsNullOrEmpty(search.Keyword))
+            if (_listedItemIds.Contains(item.Id))
             {
-                var itemName = template.Name.ToLower();
-                var keyword = search.Keyword.ToLower();
+                Logger.Warn("Post refused {0} ({1}): item {2} is already listed", player.Name, player.Id, item.Id);
+                player.SendErrorMessage(ErrorMessageType.AucInvalidItemOrNotInYourBag);
+                return false;
+            }
 
-                if (search.ExactMatch)
-                {
-                    if (itemName != keyword)
-                    {
-                        continue;
-                    }
-                }
+            if (!AuctionHouseRules.IsListableItem(item))
+            {
+                if (AuctionHouseRules.IsSoulBound(item))
+                    player.SendErrorMessage(ErrorMessageType.AucSoulBoundItem);
+                else if (AuctionHouseRules.HasUcc(item))
+                    player.SendErrorMessage(ErrorMessageType.AuctionUccPost);
                 else
-                {
-                    if (!itemName.Contains(keyword))
-                    {
-                        continue;
-                    }
-                }
+                    player.SendErrorMessage(ErrorMessageType.AucNotSellable);
+                return false;
             }
-            // Keyword and item filters are cumulative. A keyword search must not bypass
-            // the selected category, grade, or level range.
-            if (settings.CategoryA != search.CategoryA && search.CategoryA != 0)
+
+            if (!AuctionHouseRules.PricesAreListable(startPrice, buyoutPrice))
             {
-                continue;
+                player.SendErrorMessage(ErrorMessageType.AucWrongDirectMoney);
+                return false;
             }
 
-            if (settings.CategoryB != search.CategoryB && search.CategoryB != 0)
+            var lot = CreateAuctionLot(player.Id, player.Name, item, startPrice, buyoutPrice, duration, minStack, maxStack);
+            lot.ChargePercent = AuctionFeeSchedule.ApplyPercentDiscount(Fees.SaleChargeRate, ChargeDiscount(player));
+            lot.DepositPercent = AuctionFeeSchedule.ApplyPercentDiscount(Fees.GetDepositRate(duration), DepositDiscount(player));
+
+            var auctionFee = Fees.GetListingDeposit(lot.DirectMoney, duration, DepositDiscount(player));
+            if (auctionFee > 0 && !player.SubtractMoney(SlotType.Inventory, auctionFee, ItemTaskType.Auction))
             {
-                continue;
+                auctionIdManager.ReleaseId((uint)lot.Id);
+                Logger.Info("Post refused {0} ({1}): cannot pay deposit {2}", player.Name, player.Id, auctionFee);
+                player.SendErrorMessage(ErrorMessageType.CanNotPutupMoney);
+                return false;
             }
 
-            if (settings.CategoryC != search.CategoryC && search.CategoryC != 0)
+            if (!player.Inventory.AuctionAttachments.AddOrMoveExistingItem(ItemTaskType.Auction, item))
             {
-                continue;
+                if (auctionFee > 0)
+                    player.AddMoney(SlotType.Inventory, auctionFee, ItemTaskType.Auction);
+                auctionIdManager.ReleaseId((uint)lot.Id);
+                Logger.Warn("Post refused {0} ({1}): could not move item {2} into escrow", player.Name, player.Id, item.Id);
+                player.SendErrorMessage(ErrorMessageType.AucInternalError);
+                return false;
             }
 
-            if (lot.Item.Grade != search.Grade && search.Grade != 0)
+            if (!TryAddLot_NoLock(lot))
             {
-                continue;
+                player.Inventory.Bag.AddOrMoveExistingItem(ItemTaskType.Auction, item);
+                if (auctionFee > 0)
+                    player.AddMoney(SlotType.Inventory, auctionFee, ItemTaskType.Auction);
+                auctionIdManager.ReleaseId((uint)lot.Id);
+                player.SendErrorMessage(ErrorMessageType.AucInternalError);
+                return false;
             }
 
-            if (template.Level > search.MaxItemLevel && search.MaxItemLevel != 0)
-            {
-                continue;
-            }
-
-            if (template.Level < search.MinItemLevel && search.MinItemLevel != 0)
-            {
-                continue;
-            }
-
-            searchedArticles.Add(lot);
-        }
-
-        if (searchedArticles.Count == 0)
-        {
-            player.SendPacket(new SCAuctionSearchedPacket(0, 0, [], (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
-            return;
-        }
-
-        var articles = SortArticles(searchedArticles, search.SortKind, search.SortOrder).ToArray();
-        var dividedLists = Helpers.SplitArray(articles, 9); // Разделяем массив на массивы по 9 значений
-
-        if (search.Page < 0 || search.Page >= dividedLists.Length) // Stops client DC when requesting an out-of-bounds page
-        {
-            Logger.Warn($"[AH] {player.Name} requested an out-of-bounds page: {search.Page}/{dividedLists.Length - 1}");
-            player.SendPacket(new SCAuctionSearchedPacket(search.Page, 0, [], (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
-            return;
-        }
-        player.SendPacket(new SCAuctionSearchedPacket(search.Page, dividedLists[search.Page].Length, dividedLists[search.Page].ToList(), (short)ErrorMessageType.NoErrorMessage, DateTime.UtcNow));
-    }
-
-    public void PostLotOnAuction(Character player, uint npcId, uint npcId2, ulong itemId, int startPrice, int buyoutPrice, AuctionDuration duration)
-    {
-        var item = itemManager.GetItemByItemId(itemId);
-        if (item == null)
-        {
-            return;
-        }
-
-        // itemId comes off the wire and was resolved straight out of the global item store, so a crafted
-        // packet could list an item belonging to somebody else - the lot, and the proceeds, went to whoever
-        // sent the packet. Require the item to actually be sitting in this player's own bag.
-        if (player == null || item.OwnerId != player.Id || item.SlotType != SlotType.Inventory)
-        {
-            Logger.Warn($"{player?.Name} ({player?.Id}) tried to list item {itemId} owned by {item.OwnerId} in {item.SlotType}");
-            player?.SendErrorMessage(ErrorMessageType.CanNotPutupItem);
-            return;
-        }
-
-        // Prices are client supplied ints. A negative buyout produced a negative deposit, and the fee was
-        // charged as ChangeMoney(-fee) - negating a negative added the money to the seller's purse instead of
-        // taking it, so listing at a negative price minted currency.
-        if (startPrice < 0 || buyoutPrice < 0 || (startPrice == 0 && buyoutPrice == 0))
-        {
-            player.SendErrorMessage(ErrorMessageType.CanNotPutupMoney);
-            return;
-        }
-
-        var lot = CreateAuctionLot(player.Id, player.Name, item, startPrice, buyoutPrice, duration);
-        if (lot == null)
-        {
-            return;
-        }
-
-        var auctionFee = Fees.GetListingDeposit(lot.DirectMoney, duration);
-
-        // Deduct AH fee
-        if (!player.SubtractMoney(SlotType.Inventory, auctionFee, ItemTaskType.Auction))
-        {
-            player.SendErrorMessage(ErrorMessageType.CanNotPutupMoney);
-            return;
-        }
-
-        player?.Inventory.AuctionAttachments.AddOrMoveExistingItem(ItemTaskType.Auction, item);
-
-        AddAuctionLot(lot);
-        player?.SendPacket(new SCAuctionPostedPacket(lot));
-    }
-
-    private class LanguageDetector
-    {
-        // private static readonly string[] CyrillicLanguages = ["ru", "uk", "bg", "sr", "mk"];
-        // private static readonly string[] LatinLanguages = ["en", "es", "fr", "de", "it"];
-
-        public static string DetectLanguage(string text)
-        {
-            if (string.IsNullOrEmpty(text))
-            {
-                return "unknown";
-            }
-
-            // Проверка на кириллицу
-            if (text.Any(c => IsCyrillic(c)))
-            {
-                return "ru"; // Предполагаем русский язык, если есть кириллические символы
-            }
-
-            // Проверка на латиницу
-            if (text.Any(c => IsLatin(c)))
-            {
-                return "en"; // Предполагаем английский язык, если есть латинские символы
-            }
-
-            return "unknown";
-        }
-
-        private static bool IsCyrillic(char c)
-        {
-            return (c >= '\u0400' && c <= '\u04FF') || (c >= '\u0500' && c <= '\u052F');
-        }
-
-        private static bool IsLatin(char c)
-        {
-            return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+            player.SendPacket(new SCAuctionPostedPacket(lot));
+            Logger.Info(
+                "Post lot={0} seller={1} ({2}) item={3} tpl={4} stack={5} start={6} buyout={7} duration={8} deposit={9} charge%={10} deposit%={11}",
+                lot.Id, player.Name, player.Id, item.Id, item.TemplateId, item.Count,
+                startPrice, buyoutPrice, duration, auctionFee, lot.ChargePercent, lot.DepositPercent);
+            return true;
         }
     }
 }

--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -236,10 +236,7 @@ public class AuctionManager(
         var buyerId = nameManager.GetCharacterId(buyer);
         if (sold == null || buyerId == 0 || !AuctionHouseRules.IsHeldByHouse(sold))
         {
-            MergeHouseStack(leftover, sold);
-            if (buyerId != 0)
-                SendBidRefund(buyerId, lot, soldAmount);
-            Logger.Error("Partial sale aborted lot={0} buyer={1}: slice is not in house escrow", lot.Id, buyer);
+            AbortSliceDelivery_NoLock(lot, leftover, sold, buyerId, soldAmount, "slice is not in house escrow");
             return;
         }
 
@@ -247,18 +244,14 @@ public class AuctionManager(
         var buyMail = new MailForAuction(sold, lot.ClientId, soldAmount, listingDeposit);
         if (!buyMail.FinalizeForSaleBuyer(buyerId))
         {
-            MergeHouseStack(leftover, sold);
-            SendBidRefund(buyerId, lot, soldAmount);
-            Logger.Error("Partial sale aborted lot={0} buyer={1}: buyer name", lot.Id, buyerId);
+            AbortSliceDelivery_NoLock(lot, leftover, sold, buyerId, soldAmount, "buyer name");
             return;
         }
 
         if (!buyMail.Send())
         {
             buyMail.RevertBuyerClaim();
-            MergeHouseStack(leftover, sold);
-            SendBidRefund(buyerId, lot, soldAmount);
-            Logger.Error("Partial sale aborted lot={0} buyer={1}: buyer mail", lot.Id, buyerId);
+            AbortSliceDelivery_NoLock(lot, leftover, sold, buyerId, soldAmount, "buyer mail");
             return;
         }
 
@@ -345,6 +338,20 @@ public class AuctionManager(
         Logger.Error("Sale aborted lot={0} buyer={1}: {2}; listing restored without a bid", lot.Id, buyerId, reason);
     }
 
+    /// <summary>
+    /// Partial-buyout counterpart of <see cref="AbortSaleDelivery_NoLock"/>. The lot never left
+    /// the house; the slice is merged back and, since the buyer's whole
+    /// <paramref name="soldAmount"/> is refunded, a standing bid of theirs on the stack is
+    /// cleared with it.
+    /// </summary>
+    private void AbortSliceDelivery_NoLock(AuctionLot lot, Item leftover, Item slice, uint buyerId, long soldAmount, string reason)
+    {
+        MergeHouseStack(leftover, slice);
+        SendBidRefund(buyerId, lot, soldAmount);
+        AuctionHouseRules.ClearStandingBid(lot);
+        Logger.Error("Partial sale aborted lot={0} buyer={1}: {2}; stack kept without a bid", lot.Id, buyerId, reason);
+    }
+
     private void SettleExpire_NoLock(AuctionLot lot)
     {
         if (lot.BidderId != 0)
@@ -382,9 +389,9 @@ public class AuctionManager(
             return;
         }
 
+        using var persist = MailManager.Instance.DeferPersist();
         lock (_houseLock)
         {
-            using var persist = MailManager.Instance.DeferPersist();
             var auctionLot = GetAuctionLotFromId(auctionId);
             if (auctionLot == null)
             {
@@ -461,12 +468,13 @@ public class AuctionManager(
             return;
         }
 
+        // One snapshot after the charge, the refund letter, the bid replacement or the
+        // settle. The refund mail alone used to force a save that still held the bid it
+        // had just refunded. Opened before the house lock: a save takes the gate first and
+        // the house lock inside Save().
+        using var persist = MailManager.Instance.DeferPersist();
         lock (_houseLock)
         {
-            // One snapshot after the charge, the refund letter, the bid replacement or the
-            // settle. The refund mail alone used to force a save that still held the bid it
-            // had just refunded.
-            using var persist = MailManager.Instance.DeferPersist();
             var auctionLot = GetAuctionLotFromId(bid.LotId);
             if (auctionLot?.Item == null || DateTime.UtcNow >= auctionLot.EndTime)
             {
@@ -649,10 +657,10 @@ public class AuctionManager(
 
     public void UpdateAuctionHouse()
     {
+        using var persist = MailManager.Instance.DeferPersist();
         lock (_houseLock)
         {
             Logger.Trace("Updating Auction House");
-            using var persist = MailManager.Instance.DeferPersist();
             var itemsToRemove = AuctionLots.Values.Where(c => DateTime.UtcNow > c.EndTime).ToList();
             foreach (var lot in itemsToRemove)
             {

--- a/AAEmu.Game/Core/Managers/AuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/AuctionManager.cs
@@ -278,6 +278,7 @@ public class AuctionManager(
             lot.Id, lot.ClientName, lot.ClientId, buyer, soldAmount, leftover?.Count ?? 0, moneyAfterFee, saleCharge);
         SendHouseMessage(lot.ClientId, AuctionMessageKind.Sold, sold.TemplateId, soldAmount);
         RecordSale(lot, soldAmount, sold);
+        AuctionHouseRules.ClearStandingBid(lot);
         if (leftover != null)
         {
             var stacks = AuctionHouseRules.ClampStacks(leftover.Count, lot.MinStack, lot.MaxStack, AllowPartialBuy);
@@ -512,6 +513,8 @@ public class AuctionManager(
                 SendHouseMessage(previousBidderId, AuctionMessageKind.Outbid, auctionLot.Item.TemplateId, previousBid);
                 Logger.Info("Outbid lot={0} previous={1} refund={2} by {3} ({4})",
                     auctionLot.Id, previousBidderId, previousBid, player.Name, player.Id);
+                if (isBuyout && stack < liveItem.Count)
+                    AuctionHouseRules.ClearStandingBid(auctionLot);
             }
 
             var standing = isBuyout ? auctionLot.DirectMoney : bid.Money;

--- a/AAEmu.Game/Core/Managers/HousingManager.cs
+++ b/AAEmu.Game/Core/Managers/HousingManager.cs
@@ -16,6 +16,7 @@ using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.DoodadObj.Static;
+using AAEmu.Game.Models.Game.Auction;
 using AAEmu.Game.Models.Game.Housing;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
@@ -1783,7 +1784,7 @@ public class HousingManager(
 
         // Check Item
         var item = itemManager.GetItemByItemId(itemId);
-        if (item == null || item.OwnerId != player.Id)
+        if (item == null || item.OwnerId != player.Id || !AuctionHouseRules.IsPlayerHeldItem(item))
         {
             // Invalid Item
             return false;

--- a/AAEmu.Game/Core/Managers/IAuctionManager.cs
+++ b/AAEmu.Game/Core/Managers/IAuctionManager.cs
@@ -13,13 +13,14 @@ public interface IAuctionManager : ILoadable
 {
     ConcurrentDictionary<ulong, AuctionLot> AuctionLots { get; }
     void CancelAuctionLot(Character player, ulong auctionId);
-    void BidOnAuctionLot(Character player, uint auctioneerId, uint auctioneerId2, AuctionLot lot, AuctionBid bid);
+    void BidOnAuctionLot(Character player, AuctionBid bid);
     void GetBidAuctionLots(Character player, int page);
     void CheapestAuctionLot(Character player, uint templateId, byte itemGrade = 0);
+    void SearchSoldRecords(Character player, uint templateId, byte grade, bool askMarketPriceUi);
     void AddAuctionLot(AuctionLot lot);
     void UpdateAuctionHouse();
-    AuctionLot CreateAuctionLot(uint playerId, string playerName, Item itemToList, int startPrice, int buyoutPrice, AuctionDuration duration, int minStack = 1, int maxStack = 1);
+    AuctionLot CreateAuctionLot(uint playerId, string playerName, Item itemToList, long startPrice, long buyoutPrice, AuctionDuration duration, int minStack = 1, int maxStack = 1);
     void SearchAuctionLots(Character player, AuctionSearch search);
-    void PostLotOnAuction(Character player, uint npcId, uint npcId2, ulong itemId, int startPrice, int buyoutPrice, AuctionDuration duration);
+    bool PostLotOnAuction(Character player, ulong itemId, long startPrice, long buyoutPrice, AuctionDuration duration, int minStack, int maxStack);
     (int, int) Save(MySqlConnection connection, MySqlTransaction transaction);
 }

--- a/AAEmu.Game/Core/Managers/ILocalizationManager.cs
+++ b/AAEmu.Game/Core/Managers/ILocalizationManager.cs
@@ -4,4 +4,5 @@ public interface ILocalizationManager : ILoadable
 {
     void AddTranslation(string tblName, string tblColumn, long index, string translationValue);
     string Get(string tblName, string tblColumn, long index, string fallbackValue = "");
+    IReadOnlyList<string> GetAll(string tblName, string tblColumn, long index);
 }

--- a/AAEmu.Game/Core/Managers/IMailManager.cs
+++ b/AAEmu.Game/Core/Managers/IMailManager.cs
@@ -23,5 +23,6 @@ public interface IMailManager : ILoadable
     void DeleteHouseMails(uint houseId);
     List<BaseMail> GetMyHouseMails(uint houseId);
     (int, int) Save(MySqlConnection connection, MySqlTransaction transaction);
+    void PersistNow();
     Dictionary<long, BaseMail> AllPlayerMails { get; }
 }

--- a/AAEmu.Game/Core/Managers/IMailManager.cs
+++ b/AAEmu.Game/Core/Managers/IMailManager.cs
@@ -24,5 +24,6 @@ public interface IMailManager : ILoadable
     List<BaseMail> GetMyHouseMails(uint houseId);
     (int, int) Save(MySqlConnection connection, MySqlTransaction transaction);
     void PersistNow();
+    IDisposable DeferPersist();
     Dictionary<long, BaseMail> AllPlayerMails { get; }
 }

--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -6,6 +6,7 @@ using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.GameData;
+using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Auction.Templates;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Formulas;
@@ -1659,7 +1660,9 @@ public class ItemManager(ISkillManager skillManager, IItemIdManager itemIdManage
                     invalidItemCount++;
                     i.Value.Name = "invalid_item_" + i.Value.Id;
                 }
-                i.Value.searchString = (i.Value.Name + " " + localizationManager.Get("items", "name", i.Value.Id)).ToLower();
+                i.Value.searchString = LocalizedTextSearchRules.BuildSearchString(
+                    i.Value.Name,
+                    localizationManager.GetAll("items", "name", i.Value.Id));
             }
 
             Logger.Info($"Loaded {_templates.Count} item templates (with {invalidItemCount} unused) ...");

--- a/AAEmu.Game/Core/Managers/LocalizationManager.cs
+++ b/AAEmu.Game/Core/Managers/LocalizationManager.cs
@@ -1,6 +1,8 @@
 ﻿using AAEmu.Commons.Utils;
 using AAEmu.Game.Models;
+using AAEmu.Game.Models.Game;
 using AAEmu.Game.Utils.DB;
+using Microsoft.Data.Sqlite;
 using NLog;
 
 namespace AAEmu.Game.Core.Managers;
@@ -10,6 +12,7 @@ public class LocalizationManager : Singleton<LocalizationManager>, ILocalization
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
     private readonly Dictionary<string, string> _translations = [];
+    private readonly Dictionary<string, List<string>> _allTranslations = [];
 
     private static string GetLookupKey(string tblName, string tblColumn, long index)
     {
@@ -22,6 +25,10 @@ public class LocalizationManager : Singleton<LocalizationManager>, ILocalization
 
         using (var connection = SQLite.CreateConnection())
         {
+            var languageColumns = ReadLanguageColumns(connection);
+            if (languageColumns.Count == 0)
+                languageColumns.Add(AppConfiguration.Instance.DefaultLanguage);
+
             using (var command = connection.CreateCommand())
             {
                 command.CommandText = "SELECT * FROM localized_texts";
@@ -29,18 +36,38 @@ public class LocalizationManager : Singleton<LocalizationManager>, ILocalization
                 using (var reader = new SQLiteWrapperReader(command.ExecuteReader()))
                 {
                     while (reader.Read())
-                        AddTranslation(reader.GetString("tbl_name"), reader.GetString("tbl_column_name"), reader.GetInt64("idx"), reader.GetString(AppConfiguration.Instance.DefaultLanguage));
+                    {
+                        var tblName = reader.GetString("tbl_name");
+                        var tblColumn = reader.GetString("tbl_column_name");
+                        var index = reader.GetInt64("idx");
+                        var display = ReadDisplay(reader, languageColumns);
+                        var names = ReadLanguageValues(reader, languageColumns);
+
+                        AddTranslation(tblName, tblColumn, index, display);
+                        AddTranslations(tblName, tblColumn, index, names);
+                    }
                 }
             }
-        }
 
-        Logger.Info($"Loaded {_translations.Count} translations in {AppConfiguration.Instance.DefaultLanguage} ...");
+            Logger.Info($"Loaded {_translations.Count} translations across {languageColumns.Count} language columns (display={AppConfiguration.Instance.DefaultLanguage}) ...");
+        }
     }
 
     public void AddTranslation(string tblName, string tblColumn, long index, string translationValue)
     {
-        if (!_translations.TryAdd(GetLookupKey(tblName, tblColumn, index), translationValue))
+        var key = GetLookupKey(tblName, tblColumn, index);
+        if (!_translations.TryAdd(key, translationValue ?? string.Empty))
+        {
             Logger.Error($"Failed to add translation: {tblName}:{tblColumn}:{index}");
+            return;
+        }
+
+        AppendNames(key, [translationValue]);
+    }
+
+    public void AddTranslations(string tblName, string tblColumn, long index, IEnumerable<string> translationValues)
+    {
+        AppendNames(GetLookupKey(tblName, tblColumn, index), translationValues);
     }
 
     public string Get(string tblName, string tblColumn, long index, string fallbackValue = "")
@@ -52,5 +79,69 @@ public class LocalizationManager : Singleton<LocalizationManager>, ILocalization
         }
 
         return fallbackValue;
+    }
+
+    public IReadOnlyList<string> GetAll(string tblName, string tblColumn, long index)
+    {
+        return _allTranslations.TryGetValue(GetLookupKey(tblName, tblColumn, index), out var names)
+            ? names
+            : [];
+    }
+
+    private void AppendNames(string key, IEnumerable<string> values)
+    {
+        var incoming = LocalizedTextSearchRules.UniqueNames(values);
+        if (incoming.Count == 0)
+            return;
+
+        if (!_allTranslations.TryGetValue(key, out var existing))
+        {
+            _allTranslations[key] = incoming;
+            return;
+        }
+
+        _allTranslations[key] = LocalizedTextSearchRules.UniqueNames(existing.Concat(incoming));
+    }
+
+    private static string ReadDisplay(SQLiteWrapperReader reader, IReadOnlyList<string> languageColumns)
+    {
+        var defaultLanguage = AppConfiguration.Instance.DefaultLanguage;
+        return HasLanguage(languageColumns, defaultLanguage)
+            ? reader.GetString(defaultLanguage, string.Empty)
+            : string.Empty;
+    }
+
+    private static List<string> ReadLanguageValues(SQLiteWrapperReader reader, IReadOnlyList<string> languageColumns)
+    {
+        var values = new List<string>(languageColumns.Count);
+        foreach (var column in languageColumns)
+            values.Add(reader.GetString(column, string.Empty));
+        return values;
+    }
+
+    private static bool HasLanguage(IReadOnlyList<string> languageColumns, string language)
+    {
+        if (string.IsNullOrEmpty(language))
+            return false;
+
+        foreach (var column in languageColumns)
+        {
+            if (column.Equals(language, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static List<string> ReadLanguageColumns(SqliteConnection connection)
+    {
+        var tableColumns = new List<string>();
+        using var pragma = connection.CreateCommand();
+        pragma.CommandText = "PRAGMA table_info(localized_texts)";
+        using var reader = pragma.ExecuteReader();
+        while (reader.Read())
+            tableColumns.Add(reader.GetString(1));
+
+        return LocalizedTextSearchRules.LanguageColumns(tableColumns);
     }
 }

--- a/AAEmu.Game/Core/Managers/MailManager.cs
+++ b/AAEmu.Game/Core/Managers/MailManager.cs
@@ -395,20 +395,69 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
         return (updatedCount, deletedCount);
     }
 
+    [ThreadStatic] private static int t_persistDeferDepth;
+    [ThreadStatic] private static bool t_persistRequested;
+
     /// <summary>
-    /// Writes dirty mail (and the rest of the World snapshot) immediately.
+    /// Holds every <see cref="PersistNow"/> request made on this thread until the outermost
+    /// scope is disposed. A money operation that sends mail (player mail with coin, an outbid
+    /// refund, a buyout settle) then reaches the database as one snapshot taken after all of
+    /// its balance, item, lot and mail mutations, instead of a save issued from inside
+    /// <see cref="Send"/> that still shows the sender's pre-charge balance or the bid that was
+    /// just refunded. Requests from other threads are not deferred.
+    /// </summary>
+    public IDisposable DeferPersist()
+    {
+        t_persistDeferDepth++;
+        return new PersistScope(this);
+    }
+
+    /// <summary>
+    /// Writes dirty mail (and the rest of the World snapshot) immediately, or at the end of
+    /// the enclosing <see cref="DeferPersist"/> scope.
     /// Claim/send/delete used to wait for the 5-minute tick; a killed World
     /// then reloaded the pre-claim row and the letter came back unclaimed.
     /// No-ops in tests that do not register <see cref="ISaveManager"/>.
     /// </summary>
     public void PersistNow()
     {
+        if (t_persistDeferDepth > 0)
+        {
+            t_persistRequested = true;
+            return;
+        }
+
+        FlushPersist();
+    }
+
+    private void FlushPersist()
+    {
         var saver = SingletonContainer.ServiceProvider?.GetService<ISaveManager>();
         if (saver == null)
             return;
 
         if (!saver.DoSave())
-            Logger.Warn("Mail persist skipped or failed (save already running?)");
+            Logger.Warn("Mail persist skipped or failed (save already running?); the next save tick carries it");
+    }
+
+    private sealed class PersistScope(MailManager owner) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+
+            if (t_persistDeferDepth > 0)
+                t_persistDeferDepth--;
+            if (t_persistDeferDepth > 0 || !t_persistRequested)
+                return;
+
+            t_persistRequested = false;
+            owner.FlushPersist();
+        }
     }
 
     #endregion

--- a/AAEmu.Game/Core/Managers/MailManager.cs
+++ b/AAEmu.Game/Core/Managers/MailManager.cs
@@ -22,7 +22,7 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
 {
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
-    public Dictionary<long, BaseMail> _allPlayerMails;
+    public Dictionary<long, BaseMail> _allPlayerMails = [];
     public Dictionary<long, BaseMail> AllPlayerMails => _allPlayerMails;
     private List<long> _deletedMailIds = [];
     // Unused: private object _lock = new();
@@ -76,6 +76,7 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
             Logger.Trace("Send() - Assign new mail Id");
             mail.Id = GetNewMailId();
         }
+        _allPlayerMails ??= [];
         lock (_allPlayerMails)
         {
             if (_allPlayerMails.ContainsKey(mail.Id))

--- a/AAEmu.Game/Core/Managers/MailManager.cs
+++ b/AAEmu.Game/Core/Managers/MailManager.cs
@@ -1,6 +1,7 @@
 ﻿using AAEmu.Commons.Exceptions;
 using AAEmu.Commons.Utils;
 using AAEmu.Commons.Utils.DB;
+using Microsoft.Extensions.DependencyInjection;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
@@ -86,6 +87,7 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
             _allPlayerMails.Add(mail.Id, mail);
         }
         NotifyNewMailByNameIfOnline(mail, targetName);
+        PersistNow();
         return true;
     }
 
@@ -156,6 +158,7 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
             originalReceiver.SendPacket(new SCMailReturnedPacket(mail.Id, mail.Header));
 
         NotifyNewMailByNameIfOnline(mail, destinationName);
+        PersistNow();
         return true;
     }
 
@@ -174,8 +177,13 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
                 _deletedMailIds.Add(id);
             mailIdManager.ReleaseId((uint)id);
         }
+
+        bool removed;
         lock (_allPlayerMails)
-            return _allPlayerMails.Remove(id);
+            removed = _allPlayerMails.Remove(id);
+
+        PersistNow();
+        return removed;
     }
 
     public bool DeleteMail(BaseMail mail, bool trashItems = false)
@@ -187,7 +195,15 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
                 try
                 {
                     var item = mail.Body.Attachments[i];
-                    item._holdingContainer.RemoveItem(ItemTaskType.Invalid, item, true);
+                    if (item == null)
+                        continue;
+
+                    // WebAPI / GM Create never parents the item, so there is no container
+                    // to remove from. Release the id instead of dereferencing null.
+                    if (item._holdingContainer != null)
+                        item._holdingContainer.RemoveItem(ItemTaskType.Invalid, item, true);
+                    else
+                        itemManager.ReleaseId(item.Id);
                 }
                 catch (Exception ex)
                 {
@@ -249,10 +265,16 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
                             if (itemId > 0)
                             {
                                 var item = itemManager.GetItemByItemId(itemId);
-                                if (item != null)
+                                if (MailAttachmentLoadRules.CanReload(item))
                                 {
                                     item.OwnerId = tempMail.Header.ReceiverId;
                                     tempMail.Body.Attachments.Add(item);
+                                }
+                                else if (item != null)
+                                {
+                                    Logger.Warn(
+                                        "Skipping mail {0} attachment item {1}: already claimed (slot={2})",
+                                        tempMail.Id, itemId, item.SlotType);
                                 }
                                 else
                                 {
@@ -372,6 +394,22 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
         return (updatedCount, deletedCount);
     }
 
+    /// <summary>
+    /// Writes dirty mail (and the rest of the World snapshot) immediately.
+    /// Claim/send/delete used to wait for the 5-minute tick; a killed World
+    /// then reloaded the pre-claim row and the letter came back unclaimed.
+    /// No-ops in tests that do not register <see cref="ISaveManager"/>.
+    /// </summary>
+    public void PersistNow()
+    {
+        var saver = SingletonContainer.ServiceProvider?.GetService<ISaveManager>();
+        if (saver == null)
+            return;
+
+        if (!saver.DoSave())
+            Logger.Warn("Mail persist skipped or failed (save already running?)");
+    }
+
     #endregion
 
     
@@ -424,6 +462,11 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
                 player.Mails.UnreadMailCount.UpdateReceived(m.MailType, 1);
 
                 player.SendPacket(new SCGotMailPacket(m.Header, player.Mails.UnreadMailCount, addBody ? m.Body : null));
+                // Charged mail only publishes the goods-mailbox event. The portrait
+                // envelope listens to the normal inbox event, so close the inbox
+                // listing (kind 1) to refresh that icon after a shop delivery.
+                if (m.MailType is MailType.Charged or MailType.Promotion)
+                    player.SendPacket(new SCMailListEndPacket(1, player.Mails.UnreadMailCount));
                 m.IsDelivered = true;
                 return true;
             }

--- a/AAEmu.Game/Core/Managers/MailManager.cs
+++ b/AAEmu.Game/Core/Managers/MailManager.cs
@@ -399,15 +399,19 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
     [ThreadStatic] private static bool t_persistRequested;
 
     /// <summary>
-    /// Holds every <see cref="PersistNow"/> request made on this thread until the outermost
-    /// scope is disposed. A money operation that sends mail (player mail with coin, an outbid
-    /// refund, a buyout settle) then reaches the database as one snapshot taken after all of
-    /// its balance, item, lot and mail mutations, instead of a save issued from inside
-    /// <see cref="Send"/> that still shows the sender's pre-charge balance or the bid that was
-    /// just refunded. Requests from other threads are not deferred.
+    /// Marks a money operation. Holds every <see cref="PersistNow"/> request made on this
+    /// thread until the outermost scope is disposed, and holds <see cref="PersistenceGate"/>
+    /// shared so no save on any thread snapshots the operation halfway. A money operation that
+    /// sends mail (player mail with coin, an outbid refund, a buyout settle) then reaches the
+    /// database as one snapshot taken after all of its balance, item, lot and mail mutations,
+    /// instead of a save issued from inside <see cref="Send"/> that still shows the sender's
+    /// pre-charge balance or the bid that was just refunded.
+    /// Open the scope before taking any lock a save also takes (the house lock, for one).
     /// </summary>
     public IDisposable DeferPersist()
     {
+        if (t_persistDeferDepth == 0)
+            PersistenceGate.EnterOperation();
         t_persistDeferDepth++;
         return new PersistScope(this);
     }
@@ -436,8 +440,10 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
         if (saver == null)
             return;
 
+        // A save that is already running took the gate after this operation released it, so
+        // it carries everything the operation wrote. Nothing is lost by not saving twice.
         if (!saver.DoSave())
-            Logger.Warn("Mail persist skipped or failed (save already running?); the next save tick carries it");
+            Logger.Debug("Mail persist folded into the save already in progress");
     }
 
     private sealed class PersistScope(MailManager owner) : IDisposable
@@ -452,7 +458,12 @@ public class MailManager(IMailIdManager mailIdManager, INameManager nameManager,
 
             if (t_persistDeferDepth > 0)
                 t_persistDeferDepth--;
-            if (t_persistDeferDepth > 0 || !t_persistRequested)
+            if (t_persistDeferDepth > 0)
+                return;
+
+            // Release the gate before saving: the save needs it exclusively.
+            PersistenceGate.ExitOperation();
+            if (!t_persistRequested)
                 return;
 
             t_persistRequested = false;

--- a/AAEmu.Game/Core/Managers/PersistenceGate.cs
+++ b/AAEmu.Game/Core/Managers/PersistenceGate.cs
@@ -1,0 +1,36 @@
+namespace AAEmu.Game.Core.Managers;
+
+/// <summary>
+/// Keeps a World save from snapshotting a money operation halfway through.
+///
+/// An operation (player mail with coin, a bid, a buyout settle, an expiry sweep) holds the
+/// gate shared for its whole duration; a save holds it exclusively. A save therefore begins
+/// only after every operation that was in flight has finished, and no operation starts while
+/// the snapshot is being read. Deferring the operation's own save request
+/// (<see cref="MailManager.DeferPersist"/>) is not enough on its own: the save tick, or another
+/// player's letter, can still ask for a snapshot from a different thread in the middle.
+///
+/// Because of this ordering, a save that is already running when an operation asks to flush
+/// necessarily started after that operation completed and carries its state, so the busy
+/// answer from <see cref="ISaveManager.DoSave"/> is a safe skip rather than a lost write.
+/// </summary>
+public static class PersistenceGate
+{
+    private static readonly ReaderWriterLockSlim Gate = new(LockRecursionPolicy.NoRecursion);
+
+    /// <summary>Marks the start of a money operation on this thread. Blocks while a save is reading.</summary>
+    public static void EnterOperation() => Gate.EnterReadLock();
+
+    public static void ExitOperation() => Gate.ExitReadLock();
+
+    /// <summary>Marks the start of a snapshot. Blocks until every in-flight operation has finished.</summary>
+    public static void EnterSave() => Gate.EnterWriteLock();
+
+    public static void ExitSave() => Gate.ExitWriteLock();
+
+    /// <summary>True while this thread is inside an operation.</summary>
+    public static bool IsOperationHeld => Gate.IsReadLockHeld;
+
+    /// <summary>True while this thread is taking a snapshot.</summary>
+    public static bool IsSaveHeld => Gate.IsWriteLockHeld;
+}

--- a/AAEmu.Game/Core/Managers/SaveManager.cs
+++ b/AAEmu.Game/Core/Managers/SaveManager.cs
@@ -61,121 +61,157 @@ public class SaveManager(
         taskManager.Schedule(saveTask, TimeSpan.FromMinutes(Delay), TimeSpan.FromMinutes(Delay));
     }
 
+    /// <summary>
+    /// Writes the World snapshot. Returns false without saving when another save is already
+    /// running; that save took the <see cref="PersistenceGate"/> after every in-flight money
+    /// operation finished, so it already carries the caller's state.
+    /// </summary>
     public bool DoSave()
     {
         if (_isSaving)
             return false;
-        var saved = false;
-        lock (_lock)
+        if (PersistenceGate.IsOperationHeld)
         {
-            _isSaving = true;
-            var stopWatch = new Stopwatch();
-            stopWatch.Start();
-            try
+            // Inside a money operation on this very thread. Taking the gate exclusively here
+            // would deadlock; hand the request to the operation's own end-of-scope flush.
+            mailManager.PersistNow();
+            return false;
+        }
+
+        var saved = false;
+        PersistenceGate.EnterSave();
+        try
+        {
+            lock (_lock)
             {
-                // Save stuff
-                Logger.Debug("Saving DB ...");
-                using (var connection = MySQL.CreateConnection())
+                _isSaving = true;
+                try
                 {
-                    using (var transaction = connection.BeginTransaction())
+                    saved = SaveLocked();
+                }
+                finally
+                {
+                    _isSaving = false;
+                }
+            }
+        }
+        finally
+        {
+            PersistenceGate.ExitSave();
+        }
+
+        return saved;
+    }
+
+    private bool SaveLocked()
+    {
+        var saved = false;
+        var stopWatch = new Stopwatch();
+        stopWatch.Start();
+        try
+        {
+            // Save stuff
+            Logger.Debug("Saving DB ...");
+            using (var connection = MySQL.CreateConnection())
+            {
+                using (var transaction = connection.BeginTransaction())
+                {
+                    // Houses
+                    var savedHouses = housingManager.Save(connection, transaction);
+                    // Mail
+                    var savedMails = mailManager.Save(connection, transaction);
+                    // Items
+                    var saveItems = itemManager.Save(connection, transaction);
+                    // Auction House
+                    var savedAuctionHouse = auctionManager.Save(connection, transaction);
+                    // Crimes
+                    var savedCrimes = crimeManager.Save(connection, transaction);
+                    // Account attributes
+                    var savedAccountAttributes = accountAttributeManager.Save(connection, transaction);
+
+                    // Characters
+                    var savedCharacters = 0;
+                    foreach (var c in worldManager.GetAllCharacters())
                     {
-                        // Houses
-                        var savedHouses = housingManager.Save(connection, transaction);
-                        // Mail
-                        var savedMails = mailManager.Save(connection, transaction);
-                        // Items
-                        var saveItems = itemManager.Save(connection, transaction);
-                        // Auction House
-                        var savedAuctionHouse = auctionManager.Save(connection, transaction);
-                        // Crimes
-                        var savedCrimes = crimeManager.Save(connection, transaction);
-                        // Account attributes
-                        var savedAccountAttributes = accountAttributeManager.Save(connection, transaction);
+                        if (c.Save(connection, transaction))
+                            savedCharacters++;
+                        else
+                            Logger.Error($"Failed to get save data for character {c.Id} - {c.Name}");
+                    }
 
-                        // Characters
-                        var savedCharacters = 0;
-                        foreach (var c in worldManager.GetAllCharacters())
+                    // Slaves
+                    var savedSlaves = 0;
+                    foreach (var worldInstance in worldManager.GetWorlds())
+                    {
+                        foreach (var slave in worldInstance.GetAllSlaves())
                         {
-                            if (c.Save(connection, transaction))
-                                savedCharacters++;
-                            else
-                                Logger.Error($"Failed to get save data for character {c.Id} - {c.Name}");
+                            if (slave.Save(connection, transaction))
+                                savedSlaves++;
                         }
+                    }
 
-                        // Slaves
-                        var savedSlaves = 0;
-                        foreach (var worldInstance in worldManager.GetWorlds())
+                    var totalCommits = 0;
+                    totalCommits += savedHouses.Item1 + savedHouses.Item2;
+                    totalCommits += savedMails.Item1 + savedMails.Item2;
+                    totalCommits += saveItems.Item1 + saveItems.Item2 + saveItems.Item3;
+                    totalCommits += savedAuctionHouse.Item1 + savedAuctionHouse.Item2;
+                    totalCommits += savedCrimes.Item1 + savedCrimes.Item2;
+                    totalCommits += savedCharacters;
+                    totalCommits += savedSlaves;
+
+                    if (totalCommits <= 0)
+                    {
+                        Logger.Debug("No data to update ...");
+                        saved = true;
+                    }
+                    else
+                    {
+                        try
                         {
-                            foreach (var slave in worldInstance.GetAllSlaves())
-                            {
-                                if (slave.Save(connection, transaction))
-                                    savedSlaves++;
-                            }
-                        }
+                            transaction.Commit();
 
-                        var totalCommits = 0;
-                        totalCommits += savedHouses.Item1 + savedHouses.Item2;
-                        totalCommits += savedMails.Item1 + savedMails.Item2;
-                        totalCommits += saveItems.Item1 + saveItems.Item2 + saveItems.Item3;
-                        totalCommits += savedAuctionHouse.Item1 + savedAuctionHouse.Item2;
-                        totalCommits += savedCrimes.Item1 + savedCrimes.Item2;
-                        totalCommits += savedCharacters;
-                        totalCommits += savedSlaves;
+                            if (savedHouses.Item1 + savedHouses.Item2 > 0)
+                                Logger.Debug($"Updated {savedHouses.Item1} and deleted {savedHouses.Item2} houses ...");
+                            if (savedMails.Item1 + savedMails.Item2 > 0)
+                                Logger.Debug($"Updated {savedMails.Item1} and deleted {savedMails.Item2} mails ...");
+                            if (saveItems.Item1 + saveItems.Item2 > 0)
+                                Logger.Debug($"Updated {saveItems.Item1} and deleted {saveItems.Item2} items in {saveItems.Item3} containers ...");
+                            if (saveItems.Item3 > 0)
+                                Logger.Debug($"Updated {saveItems.Item3} item containers ...");
+                            if (savedAuctionHouse.Item1 + savedAuctionHouse.Item2 > 0)
+                                Logger.Debug($"Updated {savedAuctionHouse.Item1} and deleted {savedAuctionHouse.Item2} auction items ...");
+                            if (savedCrimes.Item1 + savedCrimes.Item2 > 0)
+                                Logger.Debug($"Updated {savedCrimes.Item1} and deleted {savedCrimes.Item2} crime events ...");
+                            if (savedCharacters > 0)
+                                Logger.Debug($"Updated {savedCharacters} characters ...");
+                            if (savedSlaves > 0)
+                                Logger.Debug($"Updated {savedSlaves} slaves ...");
 
-                        if (totalCommits <= 0)
-                        {
-                            Logger.Debug("No data to update ...");
                             saved = true;
                         }
-                        else
+                        catch (Exception e)
                         {
+                            Logger.Error(e);
                             try
                             {
-                                transaction.Commit();
-
-                                if (savedHouses.Item1 + savedHouses.Item2 > 0)
-                                    Logger.Debug($"Updated {savedHouses.Item1} and deleted {savedHouses.Item2} houses ...");
-                                if (savedMails.Item1 + savedMails.Item2 > 0)
-                                    Logger.Debug($"Updated {savedMails.Item1} and deleted {savedMails.Item2} mails ...");
-                                if (saveItems.Item1 + saveItems.Item2 > 0)
-                                    Logger.Debug($"Updated {saveItems.Item1} and deleted {saveItems.Item2} items in {saveItems.Item3} containers ...");
-                                if (saveItems.Item3 > 0)
-                                    Logger.Debug($"Updated {saveItems.Item3} item containers ...");
-                                if (savedAuctionHouse.Item1 + savedAuctionHouse.Item2 > 0)
-                                    Logger.Debug($"Updated {savedAuctionHouse.Item1} and deleted {savedAuctionHouse.Item2} auction items ...");
-                                if (savedCrimes.Item1 + savedCrimes.Item2 > 0)
-                                    Logger.Debug($"Updated {savedCrimes.Item1} and deleted {savedCrimes.Item2} crime events ...");
-                                if (savedCharacters > 0)
-                                    Logger.Debug($"Updated {savedCharacters} characters ...");
-                                if (savedSlaves > 0)
-                                    Logger.Debug($"Updated {savedSlaves} slaves ...");
-
-                                saved = true;
+                                transaction.Rollback();
                             }
-                            catch (Exception e)
+                            catch (Exception eRollback)
                             {
-                                Logger.Error(e);
-                                try
-                                {
-                                    transaction.Rollback();
-                                }
-                                catch (Exception eRollback)
-                                {
-                                    Logger.Error(eRollback);
-                                }
+                                Logger.Error(eRollback);
                             }
                         }
                     }
                 }
             }
-            catch (Exception e)
-            {
-                Logger.Error(e, "DoSave Exception\n");
-            }
-            stopWatch.Stop();
-            Logger.Debug("Saving data took {0}", stopWatch.Elapsed);
         }
-        _isSaving = false;
+        catch (Exception e)
+        {
+            Logger.Error(e, "DoSave Exception\n");
+        }
+        stopWatch.Stop();
+        Logger.Debug("Saving data took {0}", stopWatch.Elapsed);
+
         return saved;
     }
 

--- a/AAEmu.Game/Core/Managers/TradeManager.cs
+++ b/AAEmu.Game/Core/Managers/TradeManager.cs
@@ -438,21 +438,7 @@ public class TradeManager(ITradeIdManager tradeIdManager, IWorldManager worldMan
         if (split == null)
             return null;
 
-        split.ItemFlags = source.ItemFlags;
-        split.LifespanMins = source.LifespanMins;
-        split.MadeUnitId = source.MadeUnitId;
-        split.CreateTime = source.CreateTime;
-        split.UnsecureTime = source.UnsecureTime;
-        split.UnpackTime = source.UnpackTime;
-        split.ImageItemTemplateId = source.ImageItemTemplateId;
-        split.UccId = source.UccId;
-        split.ExpirationTime = source.ExpirationTime;
-        split.ExpirationOnlineMinutesLeft = source.ExpirationOnlineMinutesLeft;
-        split.ChargeStartTime = source.ChargeStartTime;
-        split.ChargeCount = source.ChargeCount;
-        split.ChargeUseSkillTime = source.ChargeUseSkillTime;
-        split.DetailType = source.DetailType;
-        split.Detail = source.Detail?.ToArray();
+        ItemSplitRules.CopyStackFields(source, split);
         return split;
     }
 

--- a/AAEmu.Game/Core/Network/Connections/AccountAttributePublisher.cs
+++ b/AAEmu.Game/Core/Network/Connections/AccountAttributePublisher.cs
@@ -47,6 +47,8 @@ public static class AccountAttributePublisher
             }
         }
 
+        AccountAttributeGrantRules.EnsureListingGrant(attributes, connection.AccountId);
+
         if (attributes.Count == 0)
         {
             connection.SendPacket(new SCAccountAttributeListPacket([]));

--- a/AAEmu.Game/Core/Network/Game/GameNetwork.cs
+++ b/AAEmu.Game/Core/Network/Game/GameNetwork.cs
@@ -199,6 +199,7 @@ public class GameNetwork : Singleton<GameNetwork>
         RegisterPacket(CSOffsets.CSAuctionMyBidListPacket, 1, typeof(CSAuctionMyBidListPacket));
         RegisterPacket(CSOffsets.CSAuctionLowestPricePacket, 1, typeof(CSAuctionLowestPricePacket));
         RegisterPacket(CSOffsets.CSSearchAuctionSoldRecordPacket, 1, typeof(CSSearchAuctionSoldRecordPacket));
+        RegisterPacket(CSOffsets.CSAuctionSearchForMultilingualPacket, 1, typeof(CSAuctionSearchForMultilingualPacket));
         RegisterPacket(CSOffsets.CSRollDicePacket, 1, typeof(CSRollDicePacket));
         //0xbf CSRequestNpcSpawnerList
         //0xc8 CSRemoveAllFieldSlaves

--- a/AAEmu.Game/Core/Packets/C2G/CSAuctionLowestPricePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSAuctionLowestPricePacket.cs
@@ -8,13 +8,8 @@ public class CSAuctionLowestPricePacket() : GamePacket(CSOffsets.CSAuctionLowest
 {
     public override void Read(PacketStream stream)
     {
-        var auctioneerId = stream.ReadBc();
-        var auctioneerId2 = stream.ReadBc();
         var itemTemplateId = stream.ReadUInt32();
         var itemGrade = stream.ReadByte();
-
-        Logger.Warn($"AuctionLowestPrice, auctioneerId: {auctioneerId}, auctioneerId2: {auctioneerId2}, TemplateId: {itemTemplateId}, Grade: {itemGrade}");
-
         AuctionManager.Instance.CheapestAuctionLot(Connection.ActiveChar, itemTemplateId, itemGrade);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSAuctionMyBidListPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSAuctionMyBidListPacket.cs
@@ -8,12 +8,7 @@ public class CSAuctionMyBidListPacket() : GamePacket(CSOffsets.CSAuctionMyBidLis
 {
     public override void Read(PacketStream stream)
     {
-        var auctioneerId = stream.ReadBc();
-        var auctioneerId2 = stream.ReadBc();
         var page = stream.ReadInt32();
-
-        Logger.Warn($"AuctionMyBidList, auctioneerId: {auctioneerId}, auctioneerId2: {auctioneerId2}, Page: {page}");
-
         AuctionManager.Instance.GetBidAuctionLots(Connection.ActiveChar, page);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSAuctionPostPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSAuctionPostPacket.cs
@@ -10,14 +10,12 @@ public class CSAuctionPostPacket() : GamePacket(CSOffsets.CSAuctionPostPacket, 1
 {
     public override void Read(PacketStream stream)
     {
-        var auctioneerId = stream.ReadBc();
-        var auctioneerId2 = stream.ReadBc();
         var itemId = stream.ReadUInt64();
-        var startPrice = stream.ReadInt32();
-        var buyoutPrice = stream.ReadInt32();
+        var startPrice = stream.ReadInt64();
+        var buyoutPrice = stream.ReadInt64();
         var duration = (AuctionDuration)stream.ReadByte();
-
-        Logger.Warn($"AuctionMyBidList, auctioneerId: {auctioneerId}, auctioneerId2: {auctioneerId2}, itemId: {itemId}, startPrice: {startPrice}, buyoutPrice: {buyoutPrice}, duration: {duration}");
+        var minStack = stream.ReadInt32();
+        var maxStack = stream.ReadInt32();
 
         var character = Connection.ActiveChar;
         if (character == null)
@@ -31,6 +29,6 @@ public class CSAuctionPostPacket() : GamePacket(CSOffsets.CSAuctionPostPacket, 1
             return;
         }
 
-        AuctionManager.Instance.PostLotOnAuction(character, auctioneerId, auctioneerId2, itemId, startPrice, buyoutPrice, duration);
+        AuctionManager.Instance.PostLotOnAuction(character, itemId, startPrice, buyoutPrice, duration, minStack, maxStack);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSAuctionSearchForMultilingualPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSAuctionSearchForMultilingualPacket.cs
@@ -1,0 +1,31 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models;
+using AAEmu.Game.Models.Game.Auction.Templates;
+
+namespace AAEmu.Game.Core.Packets.C2G;
+
+public class CSAuctionSearchForMultilingualPacket() : GamePacket(CSOffsets.CSAuctionSearchForMultilingualPacket, 1)
+{
+    public override void Read(PacketStream stream)
+    {
+        var auctionSearch = new AuctionSearch();
+        stream.Read(auctionSearch);
+        auctionSearch.ReadItemTemplateIds(stream);
+
+        var character = Connection.ActiveChar;
+        if (character == null)
+            return;
+
+        var minimumLevel = AppConfiguration.Instance.LevelRestrictions.AuctionSearchLevel;
+        if (character.Level + character.HeirLevel < minimumLevel)
+        {
+            Logger.Warn("Rejected multilingual auction search from {0}: total level {1} is below {2}",
+                character.Name, character.Level + character.HeirLevel, minimumLevel);
+            return;
+        }
+
+        AuctionManager.Instance.SearchAuctionLots(character, auctionSearch);
+    }
+}

--- a/AAEmu.Game/Core/Packets/C2G/CSAuctionSearchPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSAuctionSearchPacket.cs
@@ -10,13 +10,8 @@ public class CSAuctionSearchPacket() : GamePacket(CSOffsets.CSAuctionSearchPacke
 {
     public override void Read(PacketStream stream)
     {
-        var auctioneerId = stream.ReadBc();
-        var auctioneerId2 = stream.ReadBc();
-
         var auctionSearch = new AuctionSearch();
         stream.Read(auctionSearch);
-
-        Logger.Warn($"AuctionSearch, auctioneerId: {auctioneerId}, auctioneerId: {auctioneerId2}, Keyword: {auctionSearch.Keyword}");
 
         var character = Connection.ActiveChar;
         if (character == null)

--- a/AAEmu.Game/Core/Packets/C2G/CSBidAuctionPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSBidAuctionPacket.cs
@@ -10,16 +10,10 @@ public class CSBidAuctionPacket() : GamePacket(CSOffsets.CSBidAuctionPacket, 1)
 {
     public override void Read(PacketStream stream)
     {
-        var auctioneerId = stream.ReadBc();
-        var auctioneerId2 = stream.ReadBc();
-
-        var display = new AuctionDisplay();
-        stream.Read(display);
-
+        var lot = new AuctionLot();
+        stream.Read(lot);
         var bid = new AuctionBid();
         stream.Read(bid);
-
-        Logger.Warn($"AuctionBid, auctioneerId: {auctioneerId}, auctioneerId2: {auctioneerId2}, BidderName: {bid.BidderName}, LotId: {display.Lot.Id}:{bid.LotId}, Money: {bid.Money}");
 
         var character = Connection.ActiveChar;
         if (character == null)
@@ -33,6 +27,9 @@ public class CSBidAuctionPacket() : GamePacket(CSOffsets.CSBidAuctionPacket, 1)
             return;
         }
 
-        AuctionManager.Instance.BidOnAuctionLot(character, auctioneerId, auctioneerId2, display.Lot, bid);
+        if (bid.LotId == 0)
+            bid.LotId = lot.Id;
+
+        AuctionManager.Instance.BidOnAuctionLot(character, bid);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSCancelAuctionPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSCancelAuctionPacket.cs
@@ -9,14 +9,8 @@ public class CSCancelAuctionPacket() : GamePacket(CSOffsets.CSCancelAuctionPacke
 {
     public override void Read(PacketStream stream)
     {
-        var auctioneerId = stream.ReadBc();
-        var auctioneerId2 = stream.ReadBc();
-
         var lot = new AuctionLot();
         stream.Read(lot);
-
-        Logger.Warn($"AuctionCancel, auctioneerId: {auctioneerId}, auctioneerId2: {auctioneerId2}, ClientName: {lot.ClientName}, LotId: {lot.Id}");
-
         AuctionManager.Instance.CancelAuctionLot(Connection.ActiveChar, lot.Id);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSDestroyItemPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSDestroyItemPacket.cs
@@ -2,6 +2,7 @@
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Auction;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
 
@@ -25,7 +26,8 @@ public class CSDestroyItemPacket() : GamePacket(CSOffsets.CSDestroyItemPacket, 1
         var item = Connection.ActiveChar.Inventory.GetItem(slotType, slot)
                    ?? Connection.ActiveChar.Inventory.GetItemById(itemId);
 
-        if (item == null || item.Id != itemId || amount == 0 || amount > int.MaxValue || (int)amount > item.Count)
+        if (item == null || item.Id != itemId || amount == 0 || amount > int.MaxValue || (int)amount > item.Count
+            || AuctionHouseRules.IsEscrowSlot(item.SlotType) || AuctionHouseRules.IsEscrowSlot(slotType))
         {
             Logger.Warn($"DestroyItem: Invalid item, itemId {itemId}, slotType {slotType}, slot {slot}, amount {amount}, found {(item == null ? "none" : $"id {item.Id} count {item.Count}")}");
             return;

--- a/AAEmu.Game/Core/Packets/C2G/CSNotifyInGamePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSNotifyInGamePacket.cs
@@ -1,6 +1,7 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Core.Network.Connections;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Chat;
@@ -111,6 +112,11 @@ public class CSNotifyInGamePacket() : GamePacket(CSOffsets.CSNotifyInGamePacket,
 
         // Daily schedule: load persisted contracts for today, then reset-count budget.
         TodayAssignmentManager.Instance.OnCharacterEnterWorld(Connection.ActiveChar);
+
+        // Lobby already sent these during FinishState 0, but the in-world player object
+        // is built later and does not keep that map. Listing authority is read here.
+        Connection.SendPacket(new SCAccountAttributeConfigPacket());
+        AccountAttributePublisher.Send(Connection);
 
         // Mirror interest armed on NotifyInGameCompleted — not here during load.
         Logger.Info($"NotifyInGame: {Connection.ActiveChar?.Name} ({Connection.ActiveChar?.Id}) zoneAuth={WorldIntegration.ZoneAuthority}");

--- a/AAEmu.Game/Core/Packets/C2G/CSOffsets.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSOffsets.cs
@@ -387,7 +387,8 @@ public static class CSOffsets
     public const ushort CSSailingActivityLeavePacket = 0x213;
     public const ushort CSSailingActivityRequestDataPacket = 0x215;
     public const ushort CSSaveAbilitySetPacket = 0x0D7;
-    public const ushort CSSearchAuctionSoldRecordPacket = 0xFE;
+    public const ushort CSSearchAuctionSoldRecordPacket = 0x0FE;
+    public const ushort CSAuctionSearchForMultilingualPacket = 0x20F;
     public const ushort CSSetAccountPrivilegePacket = 0x10C;
     public const ushort CSSetAppellationStampPacket = 0x14D;
     public const ushort CSShowCommonFarmAreaPacket = 0x15E;

--- a/AAEmu.Game/Core/Packets/C2G/CSSearchAuctionSoldRecordPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSearchAuctionSoldRecordPacket.cs
@@ -1,25 +1,16 @@
 using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
-/// <summary>
-/// TODO: the body is parsed but nothing acts on it yet.
-/// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
 public class CSSearchAuctionSoldRecordPacket() : GamePacket(CSOffsets.CSSearchAuctionSoldRecordPacket, 1)
 {
-    public int TypeValue { get; private set; }
-    public sbyte TypeValue2 { get; private set; }
-    public bool AskMarketPriceUi { get; private set; }
-
     public override void Read(PacketStream stream)
     {
-        TypeValue = stream.ReadInt32();
-        TypeValue2 = stream.ReadSByte();
-        AskMarketPriceUi = stream.ReadBoolean();
+        var templateId = stream.ReadUInt32();
+        var grade = stream.ReadByte();
+        var askMarketPriceUi = stream.ReadBoolean();
+        AuctionManager.Instance.SearchSoldRecords(Connection.ActiveChar, templateId, grade, askMarketPriceUi);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSSpawnSlavePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSpawnSlavePacket.cs
@@ -2,6 +2,7 @@ using AAEmu.Commons.Network;
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.Auction;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Templates;
 
@@ -43,9 +44,9 @@ public class CSSpawnSlavePacket() : GamePacket(CSOffsets.CSSpawnSlavePacket, 1)
         // The summon item is authoritative for what gets spawned — the client supplies the slave
         // id, but taking it on trust would let any item summon any slave.
         var item = ItemManager.Instance.GetItemByItemId(itemId);
-        if (item == null || item.OwnerId != character.Id)
+        if (item == null || item.OwnerId != character.Id || !AuctionHouseRules.IsPlayerHeldItem(item))
         {
-            Logger.Warn("SpawnSlave: {0} does not own item {1}", character.Name, itemId);
+            Logger.Warn("SpawnSlave: {0} does not hold item {1}", character.Name, itemId);
             return;
         }
 

--- a/AAEmu.Game/Core/Packets/C2G/CSSplitBagItemPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSplitBagItemPacket.cs
@@ -20,7 +20,7 @@ public class CSSplitBagItemPacket() : GamePacket(CSOffsets.CSSplitBagItemPacket,
 
         var count = stream.ReadInt32();
 
-        Connection.ActiveChar.Inventory.SplitOrMoveItem(ItemTaskType.SwapItems, fromItemId, fromSlotType, fromSlot, toItemId, toSlotType, toSlot, count);
+        Connection.ActiveChar.Inventory.SplitOrMoveItem(ItemTaskType.Split, fromItemId, fromSlotType, fromSlot, toItemId, toSlotType, toSlot, count);
         //Connection.ActiveChar.Inventory.Move(fromItemId, fromSlotType, fromSlot, toItemId, toSlotType, toSlot, count);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSTakeAttachmentSequentially.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSTakeAttachmentSequentially.cs
@@ -1,7 +1,5 @@
 ﻿using AAEmu.Commons.Network;
-using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
-using AAEmu.Game.Models.Game;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -11,14 +9,9 @@ public class CSTakeAttachmentSequentially() : GamePacket(CSOffsets.CSTakeAttachm
     {
         var mailId = stream.ReadInt64();
         Logger.Debug("TakeAttachmentSequentially, mailId: {0}", mailId);
-        var mail = MailManager.Instance.GetMailById(mailId);
-        if (mail.Header.ReceiverId != Connection.ActiveChar.Id) // just a check for hackers trying to steal mails
-        {
-            Connection.ActiveChar.SendErrorMessage(ErrorMessageType.MailInvalid);
-        }
-        else
-        {
-            Connection.ActiveChar.Mails.GetAttached(mailId, true, true, true);
-        }
+        // GetAttached rejects a missing or foreign mail and tells the client the
+        // row is gone. Looking the mail up here used to NRE and leave the
+        // mailbox spinner running.
+        Connection.ActiveChar.Mails.GetAttached(mailId, true, true, true);
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCAccountAttributeConfigPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCAccountAttributeConfigPacket.cs
@@ -1,20 +1,16 @@
 using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-/// <summary>Declares the account-attribute domains implemented by the server.</summary>
-/// <remarks>
-/// <c>account_buff</c>, and <c>ulc</c>. Index 0 has no game-content kind and is reserved.
-/// </remarks>
+/// <summary>Declares the account-attribute domains this world actually uses.</summary>
 public class SCAccountAttributeConfigPacket() : GamePacket(SCOffsets.SCAccountAttributeConfigPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(false); // Native account-attribute kind 0 is reserved.
-        stream.Write(true);  // auction_post
-        stream.Write(true);  // account_buff
-        stream.Write(true);  // ulc
+        foreach (var used in AccountAttributeConfigRules.UsedFlags)
+            stream.Write(used);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCAuctionLimitedPricePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCAuctionLimitedPricePacket.cs
@@ -1,0 +1,35 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+public class SCAuctionLimitedPricePacket(IReadOnlyList<AuctionLimitedPrice> caps)
+    : GamePacket(SCOffsets.SCAuctionLimitedPricePacket, 1)
+{
+    public const int MaxEntries = 10;
+
+    public override PacketStream Write(PacketStream stream)
+    {
+        var entries = caps ?? [];
+        var count = Math.Min(entries.Count, MaxEntries);
+        stream.Write(count);
+        for (var i = 0; i < count; i++)
+            stream.Write(entries[i]);
+        return stream;
+    }
+}
+
+public class AuctionLimitedPrice : PacketMarshaler
+{
+    public uint Type { get; set; }
+    public long First { get; set; }
+    public long Second { get; set; }
+
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(Type);
+        stream.Write(First);
+        stream.Write(Second);
+        return stream;
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCAuctionLowestPricePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCAuctionLowestPricePacket.cs
@@ -3,7 +3,7 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCAuctionLowestPricePacket(uint itemTemplateId, byte itemGrade, int moneyAmount)
+public class SCAuctionLowestPricePacket(uint itemTemplateId, byte itemGrade, long moneyAmount)
     : GamePacket(SCOffsets.SCAuctionLowestPricePacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
@@ -11,7 +11,6 @@ public class SCAuctionLowestPricePacket(uint itemTemplateId, byte itemGrade, int
         stream.Write(itemTemplateId);
         stream.Write(itemGrade);
         stream.Write(moneyAmount);
-
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCAuctionMessagePacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCAuctionMessagePacket.cs
@@ -1,23 +1,17 @@
 using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Auction;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-/// <summary>
-/// TODO: nothing constructs this packet yet.
-/// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
-public class SCAuctionMessagePacket(sbyte unnamed1, sbyte msgType, int @type, ulong moneyAmount) : GamePacket(SCOffsets.SCAuctionMessagePacket, 1)
+public class SCAuctionMessagePacket(AuctionMessageKind kind, uint itemTemplateId, long money)
+    : GamePacket(SCOffsets.SCAuctionMessagePacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(unnamed1);
-        stream.Write(msgType);
-        stream.Write(@type);
-        stream.Write(moneyAmount);
+        stream.Write((byte)kind);
+        stream.Write(itemTemplateId);
+        stream.Write(money);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCAuctionSearchedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCAuctionSearchedPacket.cs
@@ -4,22 +4,20 @@ using AAEmu.Game.Models.Game.Auction;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCAuctionSearchedPacket(int page, int count, List<AuctionLot> lots, short errorMsg, DateTime serverTime)
+public class SCAuctionSearchedPacket(int page, IReadOnlyList<AuctionLot> lots, short errorMsg, DateTime serverTime)
     : GamePacket(SCOffsets.SCAuctionSearchedPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
+        var pageLots = lots ?? [];
+        var count = Math.Min(pageLots.Count, AuctionHouseRules.SearchPageSize);
+
         stream.Write(page);
         stream.Write(count);
-
-        foreach (var lot in lots) // TODO не более 9
-        {
-            stream.Write(lot);
-        }
-
+        for (var i = 0; i < count; i++)
+            stream.Write(pageLots[i]);
         stream.Write(errorMsg);
         stream.Write(serverTime);
-
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCAuctionSoldRecordSearchedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCAuctionSoldRecordSearchedPacket.cs
@@ -1,0 +1,31 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Auction;
+
+namespace AAEmu.Game.Core.Packets.G2C;
+
+public class SCAuctionSoldRecordSearchedPacket(
+    uint itemTemplateId,
+    byte grade,
+    bool askMarketPriceUi,
+    IReadOnlyList<AuctionSoldRecord> days)
+    : GamePacket(SCOffsets.SCAuctionSoldRecordSearchedPacket, 1)
+{
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(itemTemplateId);
+        stream.Write(grade);
+        stream.Write(askMarketPriceUi);
+
+        var rows = days ?? [];
+        for (var i = 0; i < AuctionHouseRules.SoldRecordDays; i++)
+        {
+            if (i < rows.Count)
+                stream.Write(rows[i]);
+            else
+                stream.Write(new AuctionSoldRecord { Day = i, ItemTemplateId = itemTemplateId, Grade = grade });
+        }
+
+        return stream;
+    }
+}

--- a/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCOffsets.cs
@@ -303,6 +303,8 @@ public static class SCOffsets
     public const ushort SCAuctionBidPacket = 0x174; // 10.0.2.13
     public const ushort SCAuctionCanceledPacket = 0x175; // 10.0.2.13
     public const ushort SCAuctionMessagePacket = 0x176; // 10.0.2.13
+    public const ushort SCAuctionSoldRecordSearchedPacket = 0x177; // 10.0.2.13
+    public const ushort SCAuctionLimitedPricePacket = 0x178; // 10.0.2.13
     public const ushort SCDiceValuePacket = 0x179; // 10.0.2.13
     public const ushort SCDiceBidRuleChangedPacket = 0x17A; // 10.0.2.13
     public const ushort SCNpcSpawnerPacket = 0x135;

--- a/AAEmu.Game/Models/Game/AccountAttributeConfigRules.cs
+++ b/AAEmu.Game/Models/Game/AccountAttributeConfigRules.cs
@@ -1,0 +1,32 @@
+namespace AAEmu.Game.Models.Game;
+
+/// <summary>
+/// <c>SCAccountAttributeConfig</c> is four <c>used</c> bytes, one per
+/// <see cref="AccountAttributeKind"/> slot (index 0 is reserved).
+/// </summary>
+/// <remarks>
+/// A used kind means this world offers that domain. Auction listing then also
+/// needs extraKind 0 on <c>SCAccountAttributeList</c> — see
+/// <see cref="AccountAttributeGrantRules"/>. Turning the kind off does not
+/// unlock posting: the in-world player still treats the domain as live.
+/// </remarks>
+public static class AccountAttributeConfigRules
+{
+    public const int KindSlotCount = 4;
+
+    public static bool KindIsUsed(byte slot) => slot switch
+    {
+        (byte)AccountAttributeKind.AuctionPost => true,
+        (byte)AccountAttributeKind.AccountBuff => true,
+        (byte)AccountAttributeKind.Ulc => true,
+        _ => false
+    };
+
+    public static IReadOnlyList<bool> UsedFlags { get; } =
+    [
+        KindIsUsed(0),
+        KindIsUsed((byte)AccountAttributeKind.AuctionPost),
+        KindIsUsed((byte)AccountAttributeKind.AccountBuff),
+        KindIsUsed((byte)AccountAttributeKind.Ulc)
+    ];
+}

--- a/AAEmu.Game/Models/Game/AccountAttributeGrantRules.cs
+++ b/AAEmu.Game/Models/Game/AccountAttributeGrantRules.cs
@@ -1,0 +1,40 @@
+using AAEmu.Game.Core.Managers;
+
+namespace AAEmu.Game.Models.Game;
+
+/// <summary>
+/// Session grants that must travel with <c>SCAccountAttributeList</c>.
+/// </summary>
+/// <remarks>
+/// Compact ships no <c>auction_post</c> rows. The client still treats that kind as live
+/// once <see cref="AccountAttributeConfigRules"/> marks it used, and then refuses a post
+/// unless the list carries extraKind 0 (or the account already has that row).
+/// </remarks>
+public static class AccountAttributeGrantRules
+{
+    public const uint ListingExtraKind = 0;
+
+    public static AccountAttribute CreateListingGrant(uint accountId) => new()
+    {
+        AccountId = accountId,
+        KindId = (uint)AccountAttributeKind.AuctionPost,
+        KindValue = ListingExtraKind,
+        WorldId = 0,
+        Count = 1,
+        Starts = DateTime.UnixEpoch,
+        Expires = DateTime.UnixEpoch
+    };
+
+    public static void EnsureListingGrant(IList<AccountAttribute> attributes, uint accountId)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+        if (!AccountAttributeConfigRules.KindIsUsed((byte)AccountAttributeKind.AuctionPost))
+            return;
+
+        if (attributes.Any(a => a.KindId == (uint)AccountAttributeKind.AuctionPost &&
+                                a.KindValue == ListingExtraKind))
+            return;
+
+        attributes.Add(CreateListingGrant(accountId));
+    }
+}

--- a/AAEmu.Game/Models/Game/Auction/AuctionBid.cs
+++ b/AAEmu.Game/Models/Game/Auction/AuctionBid.cs
@@ -6,30 +6,28 @@ public class AuctionBid : PacketMarshaler
 {
     public ulong LotId { get; set; }
     public byte WorldId { get; set; }
-    public uint BidderId { get; set; }
-    public string BidderName { get; set; }
-    public int Money { get; set; }
-    public uint StackSize { get; set; }
+    public ulong BidderId { get; set; }
+    public string BidderName { get; set; } = string.Empty;
+    public long Money { get; set; }
+    public int StackSize { get; set; }
 
     public override void Read(PacketStream stream)
     {
         LotId = stream.ReadUInt64();
         WorldId = stream.ReadByte();
-        BidderId = (uint)stream.ReadUInt64();
+        BidderId = stream.ReadUInt64();
         BidderName = stream.ReadString();
-        Money = (int)stream.ReadUInt64();
-        StackSize = stream.ReadUInt32();
+        Money = stream.ReadInt64();
+        StackSize = stream.ReadInt32();
     }
 
     public override PacketStream Write(PacketStream stream)
     {
-        // 10.0.2.13 widens the bidder id and the money to u64 and reads a stack size after them; 1.2 sent
-        // both as u32 and omitted the stack, so every field past the bidder id was misaligned.
         stream.Write(LotId);
         stream.Write(WorldId);
-        stream.Write((ulong)BidderId);
-        stream.Write(BidderName);
-        stream.Write((ulong)Money);
+        stream.Write(BidderId);
+        stream.Write(BidderName ?? string.Empty);
+        stream.Write(Money);
         stream.Write(StackSize);
         return stream;
     }

--- a/AAEmu.Game/Models/Game/Auction/AuctionFeeSchedule.cs
+++ b/AAEmu.Game/Models/Game/Auction/AuctionFeeSchedule.cs
@@ -77,33 +77,48 @@ public class AuctionFeeSchedule
 
         // A duration byte off the wire that is not one of the four shipped steps has no deposit row; charge
         // the longest listing rather than falling through to a free one.
-        return key == null ? Get("auction_deposit_48", 20) : Get(key, 0);
-    }
-
-    /// <summary>
-    /// Deposit taken when a lot is listed, worked out from the buyout price and capped by auction_deposit_max.
-    /// </summary>
-    public int GetListingDeposit(int buyoutPrice, AuctionDuration duration)
-    {
-        if (buyoutPrice <= 0)
-            return 0;
-
-        var deposit = (long)buyoutPrice * GetDepositRate(duration) / DepositRateDivisor;
-        return (int)Math.Clamp(deposit, 0, DepositMax);
+        return key == null
+            ? Get("auction_deposit_48", 20)
+            : Get(key, duration switch
+            {
+                AuctionDuration.AuctionDuration6Hours => 5,
+                AuctionDuration.AuctionDuration12Hours => 10,
+                AuctionDuration.AuctionDuration24Hours => 15,
+                _ => 20
+            });
     }
 
     /// <summary>
     /// Commission the house keeps from a completed sale. <paramref name="itemChargeRate"/> is
     /// <c>items.auction_charge</c> when that item overrides the global rate, 0 to use the default.
     /// </summary>
-    public int GetSaleCharge(int soldAmount, int itemChargeRate = 0)
+    public long GetSaleCharge(long soldAmount, int itemChargeRate = 0, int discountPercent = 0)
     {
         if (soldAmount <= 0)
             return 0;
 
         var rate = itemChargeRate > 0 ? itemChargeRate : SaleChargeRate;
-        var charge = (long)soldAmount * rate / ChargeRateDivisor;
-        return (int)Math.Clamp(charge, 0, soldAmount);
+        rate = ApplyPercentDiscount(rate, discountPercent);
+        var charge = soldAmount * rate / ChargeRateDivisor;
+        return Math.Clamp(charge, 0, soldAmount);
+    }
+
+    public long GetListingDeposit(long buyoutPrice, AuctionDuration duration, int discountPercent = 0)
+    {
+        if (buyoutPrice <= 0)
+            return 0;
+
+        var rate = ApplyPercentDiscount(GetDepositRate(duration), discountPercent);
+        var deposit = buyoutPrice * rate / DepositRateDivisor;
+        return Math.Clamp(deposit, 0, DepositMax);
+    }
+
+    public static int ApplyPercentDiscount(int rate, int discountPercent)
+    {
+        if (rate <= 0 || discountPercent <= 0)
+            return rate;
+        var discounted = (long)rate * (DiscountDivisor - Math.Clamp(discountPercent, 0, DiscountDivisor)) / DiscountDivisor;
+        return (int)Math.Max(0, discounted);
     }
 
     public void Load()

--- a/AAEmu.Game/Models/Game/Auction/AuctionHouseRules.cs
+++ b/AAEmu.Game/Models/Game/Auction/AuctionHouseRules.cs
@@ -1,0 +1,275 @@
+using AAEmu.Game.Models.Game.Auction.Templates;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Templates;
+
+namespace AAEmu.Game.Models.Game.Auction;
+
+/// <summary>
+/// House constants and matching that do not need a live World.
+/// </summary>
+public static class AuctionHouseRules
+{
+    public const int SearchPageSize = 9;
+    public const int SoldRecordDays = 14;
+    public const int MultilingualItemIdLimit = 130;
+    public const byte UnsetWorldId = 255;
+    public const long MaxEscrowCopper = int.MaxValue;
+
+    public static int HoursFor(AuctionDuration duration) => duration switch
+    {
+        AuctionDuration.AuctionDuration6Hours => 6,
+        AuctionDuration.AuctionDuration12Hours => 12,
+        AuctionDuration.AuctionDuration24Hours => 24,
+        AuctionDuration.AuctionDuration48Hours => 48,
+        _ => 48
+    };
+
+    public static bool IsSoulBound(Item item) =>
+        item != null && item.HasFlag(ItemFlag.SoulBound);
+
+    public static bool HasUcc(Item item) =>
+        item != null && item.HasFlag(ItemFlag.HasUCC);
+
+    public static bool IsOwnedInBag(Item item, uint playerId) =>
+        item != null && item.OwnerId == playerId && item.SlotType == SlotType.Inventory;
+
+    public static bool IsHeldByHouse(Item item) =>
+        item != null && item.SlotType == SlotType.Auction && item.Count > 0;
+
+    public static bool IsEscrowSlot(SlotType slot) =>
+        slot is SlotType.Auction or SlotType.Mail;
+
+    /// <summary>
+    /// True when the player can still move, use, or summon this item. House and mail holdings
+    /// stay server-owned until a house settle or a mail take moves them.
+    /// </summary>
+    public static bool IsPlayerHeldItem(Item item) =>
+        item != null && item.Count > 0 && item.SlotType is
+            SlotType.Inventory or SlotType.Equipment or SlotType.Bank
+            or SlotType.EquipmentMate or SlotType.EquipmentSlave;
+
+    public static bool IsValidDuration(AuctionDuration duration) =>
+        duration is AuctionDuration.AuctionDuration6Hours
+            or AuctionDuration.AuctionDuration12Hours
+            or AuctionDuration.AuctionDuration24Hours
+            or AuctionDuration.AuctionDuration48Hours;
+
+    public static bool FitsEscrow(long copper) =>
+        copper >= 0 && copper <= MaxEscrowCopper;
+
+    public static bool PricesAreListable(long startPrice, long buyoutPrice) =>
+        FitsEscrow(startPrice) && FitsEscrow(buyoutPrice)
+        && (startPrice > 0 || buyoutPrice > 0)
+        && (buyoutPrice == 0 || startPrice == 0 || buyoutPrice >= startPrice);
+
+    public static bool IsListableItem(Item item)
+    {
+        if (item?.Template == null || item.Count <= 0)
+            return false;
+        if (IsSoulBound(item) || HasUcc(item))
+            return false;
+        if (!item.Template.Sellable)
+            return false;
+        return item.Template.BindType is not (ItemBindType.BindOnPickup or ItemBindType.BindOnPickupPack);
+    }
+
+    public static bool IsBuyoutOffer(long offer, long buyout) =>
+        buyout > 0 && offer >= buyout;
+
+    /// <summary>
+    /// Copper to take from the bidder now. A raise by the standing bidder is only the difference.
+    /// </summary>
+    public static bool TryGetBidCharge(
+        long offer,
+        long startMoney,
+        long currentBid,
+        long buyout,
+        bool bidderIsCurrent,
+        out long charge,
+        out bool isBuyout)
+    {
+        charge = 0;
+        isBuyout = IsBuyoutOffer(offer, buyout);
+        if (offer <= 0 || !FitsEscrow(offer) || !FitsEscrow(startMoney) || !FitsEscrow(currentBid) || !FitsEscrow(buyout))
+            return false;
+
+        var target = isBuyout ? buyout : offer;
+        if (!isBuyout)
+        {
+            if (startMoney > 0 && target < startMoney)
+                return false;
+            if (target <= currentBid)
+                return false;
+        }
+        else if (bidderIsCurrent && currentBid >= buyout)
+        {
+            return false;
+        }
+
+        charge = bidderIsCurrent ? target - currentBid : target;
+        return charge > 0;
+    }
+
+    public static (int minStack, int maxStack) ClampStacks(int itemCount, int minStack, int maxStack, bool allowPartial)
+    {
+        var count = Math.Max(1, itemCount);
+        if (!allowPartial)
+            return (count, count);
+
+        var min = Math.Clamp(minStack, 1, count);
+        var max = Math.Clamp(maxStack, min, count);
+        return (min, max);
+    }
+
+    public static long DisplayPrice(AuctionLot lot)
+    {
+        if (lot == null)
+            return 0;
+        if (lot.DirectMoney > 0)
+            return lot.DirectMoney;
+        if (lot.BidMoney > 0)
+            return lot.BidMoney;
+        return lot.StartMoney;
+    }
+
+    public static bool Matches(AuctionLot lot, AuctionSearch search, IReadOnlyList<uint> templateIds, string localizedName) =>
+        Matches(lot, search, templateIds, string.IsNullOrEmpty(localizedName) ? [] : [localizedName]);
+
+    public static bool Matches(AuctionLot lot, AuctionSearch search, IReadOnlyList<uint> templateIds, IReadOnlyList<string> localizedNames)
+    {
+        if (lot?.Item == null || search == null)
+            return false;
+
+        if (search.ClientId != 0 && lot.ClientId != (uint)search.ClientId)
+            return false;
+
+        if (search.WorldId != 0 && search.WorldId != UnsetWorldId && lot.WorldId != search.WorldId)
+            return false;
+
+        if (templateIds is { Count: > 0 })
+        {
+            if (!templateIds.Contains(lot.Item.TemplateId))
+                return false;
+        }
+        else if (!KeywordMatches(search, KeywordNames(localizedNames, lot.Item.Template?.Name)))
+        {
+            return false;
+        }
+
+        var settings = lot.Item.Template?.AuctionSettings;
+        if (search.CategoryA != 0 && settings != null && settings.CategoryA != search.CategoryA)
+            return false;
+        if (search.CategoryB != 0 && settings != null && settings.CategoryB != search.CategoryB)
+            return false;
+        if (search.CategoryC != 0 && settings != null && settings.CategoryC != search.CategoryC)
+            return false;
+
+        if (search.Grade != 0 && lot.Item.Grade != search.Grade)
+            return false;
+
+        var level = lot.Item.Template?.Level ?? 0;
+        if (search.MaxItemLevel != 0 && level > search.MaxItemLevel)
+            return false;
+        if (search.MinItemLevel != 0 && level < search.MinItemLevel)
+            return false;
+
+        var price = DisplayPrice(lot);
+        if (search.MinPrice > 0 && price < search.MinPrice)
+            return false;
+        if (search.MaxPrice > 0 && price > search.MaxPrice)
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Name search is only for the keyword-only packet. The multilingual packet already
+    /// resolved the typed name to template ids, so a second string check would drop the
+    /// same lots. Keyword-only matches every loaded <c>localized_texts</c> language.
+    /// </summary>
+    public static bool KeywordMatches(AuctionSearch search, params string[] names)
+    {
+        if (search == null || string.IsNullOrEmpty(search.Keyword))
+            return true;
+
+        foreach (var name in names)
+        {
+            if (string.IsNullOrEmpty(name))
+                continue;
+            if (search.ExactMatch)
+            {
+                if (name.Equals(search.Keyword, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            else if (name.Contains(search.Keyword, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string[] KeywordNames(IReadOnlyList<string> localizedNames, string templateName)
+    {
+        var count = (localizedNames?.Count ?? 0) + 1;
+        var names = new string[count];
+        var i = 0;
+        if (localizedNames != null)
+        {
+            foreach (var name in localizedNames)
+                names[i++] = name;
+        }
+
+        names[i] = templateName;
+        return names;
+    }
+
+    public static IEnumerable<AuctionLot> Sort(IEnumerable<AuctionLot> lots, AuctionSearchSortKind kind, AuctionSearchSortOrder order)
+    {
+        var source = lots ?? [];
+        return kind switch
+        {
+            AuctionSearchSortKind.BidPrice => order == AuctionSearchSortOrder.Asc
+                ? source.OrderBy(o => o.BidMoney)
+                : source.OrderByDescending(o => o.BidMoney),
+            AuctionSearchSortKind.DirectPrice => order == AuctionSearchSortOrder.Asc
+                ? source.OrderBy(o => o.DirectMoney)
+                : source.OrderByDescending(o => o.DirectMoney),
+            AuctionSearchSortKind.ExpireDate => order == AuctionSearchSortOrder.Asc
+                ? source.OrderBy(o => o.EndTime)
+                : source.OrderByDescending(o => o.EndTime),
+            AuctionSearchSortKind.ItemLevel => order == AuctionSearchSortOrder.Asc
+                ? source.OrderBy(o => o.Item?.Template?.Level ?? 0)
+                : source.OrderByDescending(o => o.Item?.Template?.Level ?? 0),
+            AuctionSearchSortKind.ItemName => order == AuctionSearchSortOrder.Asc
+                ? source.OrderBy(o => o.Item?.Template?.Name ?? string.Empty)
+                : source.OrderByDescending(o => o.Item?.Template?.Name ?? string.Empty),
+            _ => order == AuctionSearchSortOrder.Asc
+                ? source.OrderBy(o => o.Id)
+                : source.OrderByDescending(o => o.Id)
+        };
+    }
+
+    public static IReadOnlyList<AuctionLot> Page(IReadOnlyList<AuctionLot> lots, int page)
+    {
+        if (lots == null || lots.Count == 0 || page < 0)
+            return [];
+
+        var start = page * SearchPageSize;
+        if (start >= lots.Count)
+            return [];
+
+        var take = Math.Min(SearchPageSize, lots.Count - start);
+        if (start == 0 && take == lots.Count)
+            return lots;
+
+        var pageLots = new List<AuctionLot>(take);
+        for (var i = 0; i < take; i++)
+            pageLots.Add(lots[start + i]);
+        return pageLots;
+    }
+
+    public static int ToMailCopper(long amount) =>
+        (int)Math.Clamp(amount, 0, int.MaxValue);
+}

--- a/AAEmu.Game/Models/Game/Auction/AuctionHouseRules.cs
+++ b/AAEmu.Game/Models/Game/Auction/AuctionHouseRules.cs
@@ -174,6 +174,21 @@ public static class AuctionHouseRules
         item.SlotType = SlotType.Auction;
     }
 
+    /// <summary>
+    /// A leftover stack after a partial buyout is a new listing. A refunded
+    /// standing bid must not stay on it or cancel/expire will treat it as live.
+    /// </summary>
+    public static void ClearStandingBid(AuctionLot lot)
+    {
+        if (lot == null)
+            return;
+        lot.BidderId = 0;
+        lot.BidderName = string.Empty;
+        lot.BidMoney = 0;
+        lot.BidWorldId = UnsetWorldId;
+        lot.IsDirty = true;
+    }
+
     public static long DisplayPrice(AuctionLot lot)
     {
         if (lot == null)

--- a/AAEmu.Game/Models/Game/Auction/AuctionHouseRules.cs
+++ b/AAEmu.Game/Models/Game/Auction/AuctionHouseRules.cs
@@ -121,6 +121,59 @@ public static class AuctionHouseRules
         return (min, max);
     }
 
+    /// <summary>
+    /// How many of a listed stack this bid takes. Partial buy is off unless the
+    /// house feature is on; a missing or zero request then takes the full stack.
+    /// </summary>
+    public static int ResolveBidStack(int requested, int itemCount, int minStack, int maxStack, bool allowPartial)
+    {
+        var count = Math.Max(1, itemCount);
+        var (min, max) = ClampStacks(count, minStack, maxStack, allowPartial);
+        if (!allowPartial)
+            return count;
+
+        var want = requested <= 0 ? max : requested;
+        return Math.Clamp(want, min, max);
+    }
+
+    public static int ClampMultilingualCount(int count)
+    {
+        if (count <= 0)
+            return 0;
+        return Math.Min(count, MultilingualItemIdLimit);
+    }
+
+    /// <summary>
+    /// Listing-time commission rate. Item overrides beat the house default; the
+    /// account-buff discount is applied once here and stored on the lot.
+    /// </summary>
+    public static int ListingChargeRate(int saleChargeRate, int itemChargeRate, int discountPercent)
+    {
+        var rate = itemChargeRate > 0 ? itemChargeRate : saleChargeRate;
+        return AuctionFeeSchedule.ApplyPercentDiscount(rate, discountPercent);
+    }
+
+    /// <summary>
+    /// Settlement uses the stored listing rate when the lot has one. Older rows
+    /// with <c>charge_percent = 0</c> fall back to the item / house rate.
+    /// </summary>
+    public static long SaleChargeForLot(AuctionFeeSchedule fees, long soldAmount, int storedChargePercent, int itemChargeRate)
+    {
+        if (fees == null)
+            return 0;
+        if (storedChargePercent > 0)
+            return fees.GetSaleCharge(soldAmount, storedChargePercent);
+        return fees.GetSaleCharge(soldAmount, itemChargeRate);
+    }
+
+    public static void ReturnToHouseEscrow(Item item, ulong sellerId)
+    {
+        if (item == null)
+            return;
+        item.OwnerId = sellerId;
+        item.SlotType = SlotType.Auction;
+    }
+
     public static long DisplayPrice(AuctionLot lot)
     {
         if (lot == null)

--- a/AAEmu.Game/Models/Game/Auction/AuctionLot.cs
+++ b/AAEmu.Game/Models/Game/Auction/AuctionLot.cs
@@ -1,5 +1,7 @@
 ﻿using AAEmu.Commons.Network;
+using AAEmu.Commons.Utils;
 using AAEmu.Game.Models.Game.Items;
+
 using Newtonsoft.Json;
 
 namespace AAEmu.Game.Models.Game.Auction;
@@ -11,7 +13,7 @@ public class AuctionLot : PacketMarshaler
     public ulong Id { get; set; }
 
     [JsonProperty]
-    public AuctionDuration Duration { get; set; } // 0 is 6 hours, 1 is 12 hours, 2 is 24 hours, 3 is 48 hours
+    public AuctionDuration Duration { get; set; }
 
     [JsonProperty]
     public Item Item { get; set; }
@@ -19,11 +21,8 @@ public class AuctionLot : PacketMarshaler
     [JsonProperty]
     public DateTime EndTime { get; set; }
 
-    /// <summary>
-    /// Seconds left
-    /// </summary>
     [JsonProperty]
-    public ulong TimeLeft { get => (ulong)EndTime.Subtract(DateTime.UtcNow).TotalSeconds; }
+    public ulong TimeLeft => (ulong)Math.Max(0, EndTime.Subtract(DateTime.UtcNow).TotalSeconds);
 
     [JsonProperty]
     public byte WorldId { get; set; }
@@ -32,40 +31,49 @@ public class AuctionLot : PacketMarshaler
     public uint ClientId { get; set; }
 
     [JsonProperty]
-    public string ClientName { get; set; }
+    public string ClientName { get; set; } = string.Empty;
 
     [JsonProperty]
-    public int StartMoney { get; set; }
+    public long StartMoney { get; set; }
 
     [JsonProperty]
-    public int DirectMoney { get; set; }
+    public long DirectMoney { get; set; }
 
     [JsonProperty]
     public DateTime PostDate { get; set; }
 
-    // [JsonProperty]
-    // public int ChargePercent { get; set; } // added in 3+
+    [JsonProperty]
+    public ulong Asked { get; set; }
 
     [JsonProperty]
-    public byte BidWorldId { get; set; }
+    public int ChargePercent { get; set; }
+
+    [JsonProperty]
+    public int DepositPercent { get; set; }
+
+    [JsonProperty]
+    public byte ServiceKind { get; set; }
+
+    [JsonProperty]
+    public byte BidWorldId { get; set; } = AuctionHouseRules.UnsetWorldId;
 
     [JsonProperty]
     public uint BidderId { get; set; }
 
     [JsonProperty]
-    public string BidderName { get; set; }
+    public string BidderName { get; set; } = string.Empty;
 
     [JsonProperty]
-    public int BidMoney { get; set; }
+    public long BidMoney { get; set; }
 
     [JsonProperty]
-    public int Extra { get; set; }
+    public long ExtraMoney { get; set; }
 
-    // [JsonProperty]
-    // public int MinStack { get; set; } // added in 3+
+    [JsonProperty]
+    public int MinStack { get; set; } = 1;
 
-    // [JsonProperty]
-    // public int MaxStack { get; set; } // added in 3+
+    [JsonProperty]
+    public int MaxStack { get; set; } = 1;
 
     [JsonIgnore]
     public bool IsDirty { get; set; }
@@ -74,47 +82,50 @@ public class AuctionLot : PacketMarshaler
     {
         Id = stream.ReadUInt64();
         Duration = (AuctionDuration)stream.ReadByte();
-
-        Item = new Item();
+        Item = new Item(0);
         Item.Read(stream);
-
         WorldId = stream.ReadByte();
-        ClientId = stream.ReadUInt32();
+        ClientId = (uint)stream.ReadUInt64();
         ClientName = stream.ReadString();
-        StartMoney = stream.ReadInt32();
-        DirectMoney = stream.ReadInt32();
-        PostDate = DateTime.FromBinary(stream.ReadInt64());
-        //ChargePercent = stream.ReadInt32();
+        StartMoney = stream.ReadInt64();
+        DirectMoney = stream.ReadInt64();
+        Asked = stream.ReadUInt64();
+        ChargePercent = stream.ReadInt32();
+        DepositPercent = stream.ReadInt32();
+        ServiceKind = stream.ReadByte();
         BidWorldId = stream.ReadByte();
-        BidderId = stream.ReadUInt32();
+        BidderId = (uint)stream.ReadUInt64();
         BidderName = stream.ReadString();
-        BidMoney = stream.ReadInt32();
-        Extra = stream.ReadInt32();
-        //MinStack = stream.ReadInt32();
-        //MaxStack = stream.ReadInt32();
+        BidMoney = stream.ReadInt64();
+        ExtraMoney = stream.ReadInt64();
+        MinStack = stream.ReadInt32();
+        MaxStack = stream.ReadInt32();
     }
 
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(Id);
         stream.Write((byte)Duration);
-
-        stream.Write(Item);
-
+        if (Item == null)
+            stream.Write(0u);
+        else
+            stream.Write(Item);
         stream.Write(WorldId);
-        stream.Write(ClientId);
-        stream.Write(ClientName);
+        stream.Write((ulong)ClientId);
+        stream.Write(ClientName ?? string.Empty);
         stream.Write(StartMoney);
         stream.Write(DirectMoney);
-        stream.Write(PostDate);
-        //stream.Write(ChargePercent);
+        stream.Write(Asked != 0 ? Asked : (ulong)Helpers.UnixTime(PostDate));
+        stream.Write(ChargePercent);
+        stream.Write(DepositPercent);
+        stream.Write(ServiceKind);
         stream.Write(BidWorldId);
-        stream.Write(BidderId);
-        stream.Write(BidderName);
+        stream.Write((ulong)BidderId);
+        stream.Write(BidderName ?? string.Empty);
         stream.Write(BidMoney);
-        stream.Write(Extra);
-        //stream.Write(MinStack);
-        //stream.Write(MaxStack);
+        stream.Write(ExtraMoney);
+        stream.Write(MinStack);
+        stream.Write(MaxStack);
         return stream;
     }
 }

--- a/AAEmu.Game/Models/Game/Auction/AuctionMessageKind.cs
+++ b/AAEmu.Game/Models/Game/Auction/AuctionMessageKind.cs
@@ -1,0 +1,10 @@
+namespace AAEmu.Game.Models.Game.Auction;
+
+/// <summary>
+/// <c>SCAuctionMessage</c> toast. The client only branches on 0 and 1.
+/// </summary>
+public enum AuctionMessageKind : byte
+{
+    Sold = 0,
+    Outbid = 1
+}

--- a/AAEmu.Game/Models/Game/Auction/AuctionSoldRecord.cs
+++ b/AAEmu.Game/Models/Game/Auction/AuctionSoldRecord.cs
@@ -1,0 +1,43 @@
+using AAEmu.Commons.Network;
+
+namespace AAEmu.Game.Models.Game.Auction;
+
+/// <summary>
+/// One day of sold-price history. The sold-record search always writes fourteen of these.
+/// </summary>
+public class AuctionSoldRecord : PacketMarshaler
+{
+    public int Day { get; set; }
+    public uint ItemTemplateId { get; set; }
+    public byte Grade { get; set; }
+    public long MinPrice { get; set; }
+    public long MaxPrice { get; set; }
+    public long AveragePrice { get; set; }
+    public long LastPrice { get; set; }
+    public int Volume { get; set; }
+
+    public override PacketStream Write(PacketStream stream)
+    {
+        stream.Write(ItemTemplateId);
+        stream.Write(Day);
+        stream.Write(MinPrice);
+        stream.Write(MaxPrice);
+        stream.Write(AveragePrice);
+        stream.Write(Volume);
+        stream.Write(Grade);
+        stream.Write(LastPrice);
+        return stream;
+    }
+
+    public override void Read(PacketStream stream)
+    {
+        ItemTemplateId = stream.ReadUInt32();
+        Day = stream.ReadInt32();
+        MinPrice = stream.ReadInt64();
+        MaxPrice = stream.ReadInt64();
+        AveragePrice = stream.ReadInt64();
+        Volume = stream.ReadInt32();
+        Grade = stream.ReadByte();
+        LastPrice = stream.ReadInt64();
+    }
+}

--- a/AAEmu.Game/Models/Game/Auction/AuctionSoldRecordRules.cs
+++ b/AAEmu.Game/Models/Game/Auction/AuctionSoldRecordRules.cs
@@ -1,0 +1,59 @@
+namespace AAEmu.Game.Models.Game.Auction;
+
+public readonly record struct AuctionSale(uint ItemTemplateId, byte Grade, DateTime SoldAt, long Price, int Stack);
+
+/// <summary>
+/// Builds the fourteen-day sold-record page the client always reads.
+/// </summary>
+public static class AuctionSoldRecordRules
+{
+    public static IReadOnlyList<AuctionSoldRecord> BuildDays(
+        IEnumerable<AuctionSale> sales,
+        uint templateId,
+        byte grade,
+        DateTime utcNow)
+    {
+        var day0 = utcNow.Date;
+        var rows = new AuctionSoldRecord[AuctionHouseRules.SoldRecordDays];
+        for (var day = 0; day < rows.Length; day++)
+        {
+            rows[day] = new AuctionSoldRecord
+            {
+                Day = day,
+                ItemTemplateId = templateId,
+                Grade = grade
+            };
+        }
+
+        foreach (var sale in sales.OrderBy(s => s.SoldAt))
+        {
+            if (sale.ItemTemplateId != templateId || sale.Grade != grade)
+                continue;
+
+            var day = (int)(day0 - sale.SoldAt.Date).TotalDays;
+            if (day < 0 || day >= rows.Length)
+                continue;
+
+            var row = rows[day];
+            var unit = sale.Stack > 0 ? sale.Price / sale.Stack : sale.Price;
+            if (row.Volume == 0)
+            {
+                row.MinPrice = unit;
+                row.MaxPrice = unit;
+                row.AveragePrice = unit;
+                row.LastPrice = unit;
+                row.Volume = sale.Stack;
+                continue;
+            }
+
+            row.MinPrice = Math.Min(row.MinPrice, unit);
+            row.MaxPrice = Math.Max(row.MaxPrice, unit);
+            var total = row.AveragePrice * row.Volume + unit * sale.Stack;
+            row.Volume += sale.Stack;
+            row.AveragePrice = row.Volume > 0 ? total / row.Volume : 0;
+            row.LastPrice = unit;
+        }
+
+        return rows;
+    }
+}

--- a/AAEmu.Game/Models/Game/Auction/Templates/AuctionSearchTemplate.cs
+++ b/AAEmu.Game/Models/Game/Auction/Templates/AuctionSearchTemplate.cs
@@ -4,22 +4,24 @@ namespace AAEmu.Game.Models.Game.Auction.Templates;
 
 public class AuctionSearch : PacketMarshaler
 {
-    public string Keyword { get; set; }
+    public string Keyword { get; set; } = string.Empty;
     public bool ExactMatch { get; set; }
     public byte Grade { get; set; }
     public byte CategoryA { get; set; }
     public byte CategoryB { get; set; }
     public byte CategoryC { get; set; }
-    public uint ClientId { get; set; }
     public int Page { get; set; }
+    public ulong ClientId { get; set; }
     public int Filter { get; set; }
+    public int ItemListCount { get; set; }
     public byte WorldId { get; set; }
-    public byte MinItemLevel { get; set; }
-    public byte MaxItemLevel { get; set; }
-    //public uint MinMoneyAmount { get; set; } // added in 3+
-    //public uint MaxMoneyAmount { get; set; } // added in 3+
+    public sbyte MinItemLevel { get; set; }
+    public sbyte MaxItemLevel { get; set; }
+    public long MinPrice { get; set; }
+    public long MaxPrice { get; set; }
     public AuctionSearchSortKind SortKind { get; set; }
     public AuctionSearchSortOrder SortOrder { get; set; }
+    public List<uint> ItemTemplateIds { get; set; } = [];
 
     public override void Read(PacketStream stream)
     {
@@ -30,20 +32,32 @@ public class AuctionSearch : PacketMarshaler
         CategoryB = stream.ReadByte();
         CategoryC = stream.ReadByte();
         Page = stream.ReadInt32();
-        ClientId = stream.ReadUInt32();
+        ClientId = stream.ReadUInt64();
         Filter = stream.ReadInt32();
+        ItemListCount = stream.ReadInt32();
         WorldId = stream.ReadByte();
-        MinItemLevel = stream.ReadByte();
-        MaxItemLevel = stream.ReadByte();
-        //MinMoneyAmount = stream.ReadUInt32(); // moneyAmount
-        //MaxMoneyAmount = stream.ReadUInt32(); // moneyAmount
+        MinItemLevel = stream.ReadSByte();
+        MaxItemLevel = stream.ReadSByte();
+        MinPrice = stream.ReadInt64();
+        MaxPrice = stream.ReadInt64();
         SortKind = (AuctionSearchSortKind)stream.ReadByte();
         SortOrder = (AuctionSearchSortOrder)stream.ReadByte();
     }
 
+    public void ReadItemTemplateIds(PacketStream stream)
+    {
+        var count = stream.ReadInt32();
+        if (count > AuctionHouseRules.MultilingualItemIdLimit)
+            count = AuctionHouseRules.MultilingualItemIdLimit;
+        ItemListCount = count;
+        ItemTemplateIds = new List<uint>(count);
+        for (var i = 0; i < count; i++)
+            ItemTemplateIds.Add(stream.ReadUInt32());
+    }
+
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(Keyword);
+        stream.Write(Keyword ?? string.Empty);
         stream.Write(ExactMatch);
         stream.Write(Grade);
         stream.Write(CategoryA);
@@ -52,11 +66,12 @@ public class AuctionSearch : PacketMarshaler
         stream.Write(Page);
         stream.Write(ClientId);
         stream.Write(Filter);
+        stream.Write(ItemListCount);
         stream.Write(WorldId);
         stream.Write(MinItemLevel);
         stream.Write(MaxItemLevel);
-        //stream.Write(MinMoneyAmount); // moneyAmount
-        //stream.Write(MaxMoneyAmount); // moneyAmount
+        stream.Write(MinPrice);
+        stream.Write(MaxPrice);
         stream.Write((byte)SortKind);
         stream.Write((byte)SortOrder);
         return stream;

--- a/AAEmu.Game/Models/Game/Auction/Templates/AuctionSearchTemplate.cs
+++ b/AAEmu.Game/Models/Game/Auction/Templates/AuctionSearchTemplate.cs
@@ -46,9 +46,7 @@ public class AuctionSearch : PacketMarshaler
 
     public void ReadItemTemplateIds(PacketStream stream)
     {
-        var count = stream.ReadInt32();
-        if (count > AuctionHouseRules.MultilingualItemIdLimit)
-            count = AuctionHouseRules.MultilingualItemIdLimit;
+        var count = AuctionHouseRules.ClampMultilingualCount(stream.ReadInt32());
         ItemListCount = count;
         ItemTemplateIds = new List<uint>(count);
         for (var i = 0; i < count; i++)

--- a/AAEmu.Game/Models/Game/Char/CharacterMails.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterMails.cs
@@ -1,6 +1,7 @@
 ﻿using AAEmu.Game.Core.Managers;
 using System.Linq;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Mails;
@@ -114,8 +115,12 @@ public class CharacterMails
     public void RefreshAllMailCounts()
     {
         UnreadMailCount.ResetAll();
+        var store = MailManager.Instance?.AllPlayerMails;
+        if (store == null)
+            return;
+
         var now = DateTime.UtcNow;
-        foreach (var (_, mail) in MailManager.Instance.AllPlayerMails)
+        foreach (var (_, mail) in store)
         {
             var isForMe = mail.Header.ReceiverId == Self.Id;
             var isFromMe = mail.Header.SenderId == Self.Id && mail.Header.SenderId != 0;
@@ -168,21 +173,50 @@ public class CharacterMails
         return true;
     }
 
+    private static bool TryFindStoredMail(long id, out BaseMail mail)
+    {
+        mail = null;
+        var store = MailManager.Instance?.AllPlayerMails;
+        return store != null && store.TryGetValue(id, out mail);
+    }
+
+    /// <summary>
+    /// Open and take-all wait for a body or attachment packet. A missing row used to
+    /// send nothing (or throw), so the mailbox spinner never cleared.
+    /// </summary>
+    private void NotifyMailGone(long id)
+    {
+        RefreshUnreadCount();
+        Self.SendErrorMessage(ErrorMessageType.MailInvalid);
+        Self.SendPacket(new SCMailDeletedPacket(false, id, true, UnreadMailCount));
+        SendUnreadMailCount();
+    }
+
     public void ReadMail(bool isSent, long id)
     {
-        if (TryGetOwnMail(id, isSent, out var mail))
+        if (!TryFindStoredMail(id, out _))
         {
-            if (mail.Header.Status == MailStatus.Unread && !isSent)
-            {
-                UnreadMailCount.UpdateReceived(mail.MailType, -1);
-                mail.OpenDate = DateTime.UtcNow;
-                mail.Header.Status = MailStatus.Read;
-                mail.IsDelivered = true;
-            }
-            Self.SendPacket(new SCMailBodyPacket(false, isSent, mail.Body, true, UnreadMailCount));
-            Self.SendPacket(new SCMailStatusUpdatedPacket(isSent, id, mail.Header.Status));
-            SendUnreadMailCount();
+            NotifyMailGone(id);
+            return;
         }
+
+        if (!TryGetOwnMail(id, isSent, out var mail))
+        {
+            Self.SendErrorMessage(ErrorMessageType.MailInvalid);
+            return;
+        }
+
+        if (mail.Header.Status == MailStatus.Unread && !isSent)
+        {
+            UnreadMailCount.UpdateReceived(mail.MailType, -1);
+            mail.OpenDate = DateTime.UtcNow;
+            mail.Header.Status = MailStatus.Read;
+            mail.IsDelivered = true;
+        }
+        Self.SendPacket(new SCMailBodyPacket(false, isSent, mail.Body, true, UnreadMailCount));
+        Self.SendPacket(new SCMailStatusUpdatedPacket(isSent, id, mail.Header.Status));
+        SendUnreadMailCount();
+        MailManager.Instance.PersistNow();
     }
 
     public void SendUnreadMailCount()
@@ -309,10 +343,20 @@ public class CharacterMails
     public bool GetAttached(long mailId, bool takeMoney, bool takeItems, bool takeAllSelected, ulong specifiedItemId = 0)
     {
         var res = true;
-        // Attachments only ever come out of the inbox side, never the sent side.
-        if (TryGetOwnMail(mailId, false, out var thisMail))
+        if (!TryFindStoredMail(mailId, out _))
         {
-            var tookMoney = false;
+            NotifyMailGone(mailId);
+            return false;
+        }
+
+        // Attachments only ever come out of the inbox side, never the sent side.
+        if (!TryGetOwnMail(mailId, false, out var thisMail))
+        {
+            Self.SendErrorMessage(ErrorMessageType.MailInvalid);
+            return false;
+        }
+
+        var tookMoney = false;
             if (thisMail.MailType == MailType.AucOffSuccess && thisMail.Body.CopperCoins > 0 && takeMoney)
             {
                 // Both pools pay; see Character.ChangeLabor.
@@ -456,9 +500,8 @@ public class CharacterMails
             // TODO: Make sure attachment settings and mail info is sent back correctly 
             // taking all attachments sometimes doesn't enable the delete button when getting attachments using "GetAllSelected"
 
-            // TODO: if source player is online, update their mail info (sent tab)
-        }
-
+        // TODO: if source player is online, update their mail info (sent tab)
+        MailManager.Instance.PersistNow();
         return res;
     }
 

--- a/AAEmu.Game/Models/Game/Char/CharacterMails.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterMails.cs
@@ -326,7 +326,10 @@ public class CharacterMails
         if (mailType == MailType.Normal)
             mail.Body.RecvDate = DateTime.UtcNow + MailManager.NormalMailDelay;
 
-        // Send it
+        // Send it. The save that Send requests runs when this scope closes, i.e. after the
+        // fee and attached coin have left the sender's wallet; a restart cannot restore the
+        // sender's balance while the recipient already holds the letter.
+        using var persist = MailManager.Instance.DeferPersist();
         if (mail.Send())
         {
             Self.SendPacket(new SCMailSentPacket(mail.Header, itemSlots.ToArray()));

--- a/AAEmu.Game/Models/Game/Char/Inventory.cs
+++ b/AAEmu.Game/Models/Game/Char/Inventory.cs
@@ -4,6 +4,7 @@ using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.Auction;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Items.Containers;
@@ -302,6 +303,16 @@ public class Inventory
     {
         Logger.Trace($"SplitOrMoveItem({fromItemId} {fromType}:{fromSlot} => {toItemId} {toType}:{toSlot} - {count})");
 
+        if (AuctionHouseRules.IsEscrowSlot(fromType) || AuctionHouseRules.IsEscrowSlot(toType) ||
+            AuctionHouseRules.IsEscrowSlot(sourceContainer?.ContainerType ?? SlotType.None) ||
+            AuctionHouseRules.IsEscrowSlot(targetContainer?.ContainerType ?? SlotType.None))
+        {
+            Logger.Warn(
+                "SplitOrMoveItem refused escrow move {0} {1}:{2} => {3} {4}:{5}",
+                fromItemId, fromType, fromSlot, toItemId, toType, toSlot);
+            return false;
+        }
+
         // Try to grab the actual source item
         var fromItem = ItemManager.Instance.GetItemByItemId(fromItemId);
         if (fromItem == null && fromItemId != 0)
@@ -551,13 +562,24 @@ public class Inventory
                 }
                 break;
             case SwapAction.doSplit:
-                fromItem.Count -= count;
-                itemTasks.Add(new ItemCountUpdate(fromItem, -count));
+                if (!ItemSplitRules.IsSplitAmount(fromItem.Count, count))
+                    return false;
                 var ni = ItemManager.Instance.Create(fromItem.TemplateId, count, fromItem.Grade, true);
-                ni.SlotType = toType;
-                ni.Slot = toSlot;
+                if (ni == null)
+                    return false;
+                ItemSplitRules.CopyStackFields(fromItem, ni);
+                ItemSplitRules.PlaceNewStack(ni, targetContainer?.OwnerId ?? fromItem.OwnerId, toType, toSlot);
                 ni._holdingContainer = targetContainer;
+                var sourceBefore = fromItem.Count;
+                fromItem.Count -= count;
+                if (!ItemSplitRules.ConservesCount(sourceBefore, count, fromItem.Count, ni.Count))
+                {
+                    fromItem.Count = sourceBefore;
+                    ItemManager.Instance.ReleaseId(ni.Id);
+                    return false;
+                }
                 targetContainer.Items.Add(ni);
+                itemTasks.Add(new ItemCountUpdate(fromItem, -count));
                 itemTasks.Add(new ItemAdd(ni));
                 if (targetContainer != sourceContainer)
                     targetContainer.UpdateFreeSlotCount();
@@ -632,9 +654,10 @@ public class Inventory
         if (itemInTargetSlot != null)
             itemInTargetSlot.OwnerId = targetContainer?.OwnerId ?? 0;
 
-        // Send Item manipulation packet 
-        if (taskType != ItemTaskType.Invalid && itemTasks.Count > 0)
-            Owner.SendPacket(new SCItemTaskSuccessPacket(taskType, itemTasks, []));
+        // Send Item manipulation packet
+        var reportType = ItemSplitRules.ReportTaskType(action == SwapAction.doSplit, taskType);
+        if (reportType != ItemTaskType.Invalid && itemTasks.Count > 0)
+            Owner.SendPacket(new SCItemTaskSuccessPacket(reportType, itemTasks, []));
 
         // Send ItemContainer events
         if (sourceContainer != targetContainer)

--- a/AAEmu.Game/Models/Game/Features/Feature.cs
+++ b/AAEmu.Game/Models/Game/Features/Feature.cs
@@ -138,7 +138,7 @@ public enum Feature
 
     // ---- fset[19] ----
     heroBonus = 152,
-    fset_19_2_unknown = 154,  // native only - doodad world-map text (SCDoodadWorldmapText*)
+    fset_19_2_unknown = 154,  // native only - doodad world-map text (SCDoodadWorldmapText*) + doodad smart-positioning loop
     hairTwoTone = 156,
     socketChange = 157,
     mate_type_summon = 158,
@@ -178,7 +178,7 @@ public enum Feature
     auctionPartialBuy = 196,
     equipSlotEnchantment = 197,
     loadingTipOfDay = 198,
-    fset_24_7_unknown = 199,  // native only - ui_eventProfile content info
+    fset_24_7_unknown = 199,  // native only - fgt permission pack (encyclopedia / AH / craft) via ui_eventProfile UIC loader
 
     // ---- fset[25] ----
     itemGradeEnchant = 200,

--- a/AAEmu.Game/Models/Game/Items/ItemSplitRules.cs
+++ b/AAEmu.Game/Models/Game/Items/ItemSplitRules.cs
@@ -1,0 +1,67 @@
+using AAEmu.Game.Models.Game.Items.Actions;
+
+namespace AAEmu.Game.Models.Game.Items;
+
+/// <summary>
+/// Bag/trade splits must conserve count and keep the new stack on the same
+/// owner and flags as the source. A fresh <c>ItemManager.Create</c> starts at
+/// <c>OwnerId = 0</c>; listing and save both treat that as "not in the bag".
+/// </summary>
+public static class ItemSplitRules
+{
+    public static bool IsSplitAmount(int sourceCount, int amount) =>
+        amount > 0 && sourceCount > amount;
+
+    /// <summary>
+    /// True when the source lost exactly <paramref name="amount"/> and the new
+    /// stack holds that same amount — never 101 → 100 + 101.
+    /// </summary>
+    public static bool ConservesCount(int sourceBefore, int amount, int sourceAfter, int newCount) =>
+        IsSplitAmount(sourceBefore, amount)
+        && sourceAfter == sourceBefore - amount
+        && newCount == amount
+        && sourceAfter + newCount == sourceBefore;
+
+    public static void CopyStackFields(Item source, Item dest)
+    {
+        if (source == null || dest == null)
+            return;
+
+        dest.ItemFlags = source.ItemFlags;
+        dest.LifespanMins = source.LifespanMins;
+        dest.MadeUnitId = source.MadeUnitId;
+        dest.CreateTime = source.CreateTime;
+        dest.UnsecureTime = source.UnsecureTime;
+        dest.UnpackTime = source.UnpackTime;
+        dest.ImageItemTemplateId = source.ImageItemTemplateId;
+        dest.UccId = source.UccId;
+        dest.ExpirationTime = source.ExpirationTime;
+        dest.ExpirationOnlineMinutesLeft = source.ExpirationOnlineMinutesLeft;
+        dest.ChargeStartTime = source.ChargeStartTime;
+        dest.ChargeCount = source.ChargeCount;
+        dest.ChargeUseSkillTime = source.ChargeUseSkillTime;
+        dest.DetailType = source.DetailType;
+        dest.Detail = source.Detail == null ? null : (byte[])source.Detail.Clone();
+    }
+
+    /// <summary>
+    /// The open bag watches the task reason. A split that reports <c>SwapItems</c>
+    /// leaves the new stack as a ghost until the bag is closed and the full
+    /// contents dump arrives.
+    /// </summary>
+    public static ItemTaskType ReportTaskType(bool wasSplit, ItemTaskType requested)
+    {
+        if (wasSplit)
+            return ItemTaskType.Split;
+        return requested == ItemTaskType.Split ? ItemTaskType.SwapItems : requested;
+    }
+
+    public static void PlaceNewStack(Item dest, ulong ownerId, SlotType slotType, byte slot)
+    {
+        if (dest == null)
+            return;
+        dest.OwnerId = ownerId;
+        dest.SlotType = slotType;
+        dest.Slot = slot;
+    }
+}

--- a/AAEmu.Game/Models/Game/LocalizedTextSearchRules.cs
+++ b/AAEmu.Game/Models/Game/LocalizedTextSearchRules.cs
@@ -1,0 +1,54 @@
+namespace AAEmu.Game.Models.Game;
+
+/// <summary>
+/// Language cells on <c>localized_texts</c> are every column except the row key.
+/// Search uses those cells as they are — empty values are skipped, nothing is invented.
+/// </summary>
+public static class LocalizedTextSearchRules
+{
+    public static bool IsKeyColumn(string column) =>
+        column is "id" or "tbl_name" or "tbl_column_name" or "idx";
+
+    public static List<string> LanguageColumns(IEnumerable<string> tableColumns)
+    {
+        var columns = new List<string>();
+        if (tableColumns == null)
+            return columns;
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var column in tableColumns)
+        {
+            if (string.IsNullOrWhiteSpace(column) || IsKeyColumn(column))
+                continue;
+            if (seen.Add(column))
+                columns.Add(column);
+        }
+
+        return columns;
+    }
+
+    public static List<string> UniqueNames(IEnumerable<string> values)
+    {
+        var names = new List<string>();
+        if (values == null)
+            return names;
+
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                continue;
+            if (seen.Add(value))
+                names.Add(value);
+        }
+
+        return names;
+    }
+
+    public static string BuildSearchString(string templateName, IEnumerable<string> localizedNames)
+    {
+        var names = UniqueNames([templateName]);
+        names.AddRange(UniqueNames(localizedNames));
+        return string.Join(" ", UniqueNames(names)).ToLower();
+    }
+}

--- a/AAEmu.Game/Models/Game/Mails/CountUnreadMail.cs
+++ b/AAEmu.Game/Models/Game/Mails/CountUnreadMail.cs
@@ -55,7 +55,13 @@ public class CountUnreadMail : PacketMarshaler
     public void UpdateReceived(MailType mailType, int amount)
     {
         if (mailType is MailType.Charged or MailType.Promotion)
+        {
             CommercialReceived += amount;
+            // Shop / cash-shop mail is its own mailbox, but the character-card
+            // envelope only reads the normal unread counter. Count it there too
+            // so a marketplace delivery lights the same HUD icon as a letter.
+            Received += amount;
+        }
         else if (mailType == MailType.MiaRecv)
             MiaReceived += amount;
         else

--- a/AAEmu.Game/Models/Game/Mails/MailAttachmentLoadRules.cs
+++ b/AAEmu.Game/Models/Game/Mails/MailAttachmentLoadRules.cs
@@ -1,0 +1,14 @@
+using AAEmu.Game.Models.Game.Items;
+
+namespace AAEmu.Game.Models.Game.Mails;
+
+/// <summary>
+/// A mail row stores attachment item ids. After a claim those items live in the
+/// bag, but a missed save can leave the old ids on the row. Reloading them
+/// would put the same item back on the letter.
+/// </summary>
+public static class MailAttachmentLoadRules
+{
+    public static bool CanReload(Item item) =>
+        item is { Count: > 0, SlotType: SlotType.Mail };
+}

--- a/AAEmu.Game/Models/Game/Mails/MailForAuction.cs
+++ b/AAEmu.Game/Models/Game/Mails/MailForAuction.cs
@@ -102,6 +102,19 @@ public class MailForAuction : BaseMail
     }
 
     /// <summary>
+    /// Undo <see cref="FinalizeForSaleBuyer"/> when the buyer letter never left
+    /// the house. The stack goes back to auction escrow under the seller.
+    /// </summary>
+    public void RevertBuyerClaim()
+    {
+        if (_item == null)
+            return;
+
+        Body.Attachments.Remove(_item);
+        AuctionHouseRules.ReturnToHouseEscrow(_item, _sellerId);
+    }
+
+    /// <summary>
     /// Prepare mail for the person selling the item
     /// </summary>
     /// <returns></returns>

--- a/AAEmu.Game/Models/Game/Mails/MailForAuction.cs
+++ b/AAEmu.Game/Models/Game/Mails/MailForAuction.cs
@@ -1,5 +1,7 @@
 ﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.Auction;
 using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Templates;
 
 namespace AAEmu.Game.Models.Game.Mails;
 
@@ -9,10 +11,10 @@ public class MailForAuction : BaseMail
     private readonly uint _sellerId;
     private readonly Item _item;
     private readonly string _itemName;
-    private readonly int _itemBuyoutPrice;
-    private int _sellerShare;
-    private readonly int _listingFee;
-    private int _tradeTaxFee;
+    private readonly long _itemBuyoutPrice;
+    private long _sellerShare;
+    private readonly long _listingFee;
+    private long _tradeTaxFee;
 
     private static readonly string AuctionName = "Auctioneer";
     // TODO: verify title names
@@ -24,7 +26,7 @@ public class MailForAuction : BaseMail
 
     // Mail examples for 1.2
 
-    public MailForAuction(Item itemToSell, uint sellerId, int buyoutPrice, int listingFee) : base()
+    public MailForAuction(Item itemToSell, uint sellerId, long buyoutPrice, long listingFee) : base()
     {
         _buyerId = 0;
         _sellerId = sellerId;
@@ -50,7 +52,7 @@ public class MailForAuction : BaseMail
     /// <param name="sellerId"></param>
     /// <param name="buyoutPrice"></param>
     /// <param name="listingFee"></param>
-    public MailForAuction(uint itemTemplateIdToSell, uint sellerId, int buyoutPrice, int listingFee) : base()
+    public MailForAuction(uint itemTemplateIdToSell, uint sellerId, long buyoutPrice, long listingFee) : base()
     {
         _buyerId = 0;
         _sellerId = sellerId;
@@ -90,6 +92,8 @@ public class MailForAuction : BaseMail
         Header.ReceiverId = _buyerId;
 
         Body.Text = string.Format("body('{0}', {1}, {2})", _itemName, _item.Count, _itemBuyoutPrice);
+        if (_item.Template?.BindType == ItemBindType.BindOnAuctionWin)
+            _item.SetFlag(ItemFlag.SoulBound);
         _item.OwnerId = _buyerId;
         _item.SlotType = SlotType.Mail;
         Body.Attachments.Add(_item);
@@ -101,7 +105,7 @@ public class MailForAuction : BaseMail
     /// Prepare mail for the person selling the item
     /// </summary>
     /// <returns></returns>
-    public bool FinalizeForSaleSeller(int sellerShare, int tradeTaxFee)
+    public bool FinalizeForSaleSeller(long sellerShare, long tradeTaxFee)
     {
         // /testmail 14 .auctionOffSuccess AHBuy "body('My Sold Item',7, 364000, 400000, 40000, 4000)"
         _sellerShare = sellerShare;
@@ -121,7 +125,7 @@ public class MailForAuction : BaseMail
         Body.Text = string.Format("body('{0}', {1}, {2}, {3}, {4}, {5})",
             _itemName, _item.Count, _sellerShare, _itemBuyoutPrice, _tradeTaxFee, _listingFee);
 
-        AttachMoney(sellerShare);
+        AttachMoney(AuctionHouseRules.ToMailCopper(sellerShare));
 
         return true;
     }
@@ -184,7 +188,7 @@ public class MailForAuction : BaseMail
     /// Prepare mail for the person who was outbid
     /// </summary>
     /// <returns></returns>
-    public bool FinalizeForBidFail(uint previousBuyerId, int previousBid)
+    public bool FinalizeForBidFail(uint previousBuyerId, long previousBid)
     {
         // /testmail 17 .auctionBidFail AHBidFail "body('My Sold Item')"
         _buyerId = previousBuyerId;
@@ -197,12 +201,12 @@ public class MailForAuction : BaseMail
         Header.ReceiverId = _buyerId;
         ReceiverName = nameBuyer;
 
-        MailType = MailType.AucOffFail;
+        MailType = MailType.AucBidFail;
         Title = TitleBidLost;
 
         Body.Text = string.Format("body('{0}')", _itemName);
 
-        AttachMoney(previousBid);
+        AttachMoney(AuctionHouseRules.ToMailCopper(previousBid));
 
         return true;
     }

--- a/AAEmu.Game/Models/Game/Mails/MailHeader.cs
+++ b/AAEmu.Game/Models/Game/Mails/MailHeader.cs
@@ -4,13 +4,24 @@ namespace AAEmu.Game.Models.Game.Mails;
 
 public class MailHeader(BaseMail parent) : PacketMarshaler
 {
+    private MailStatus _status;
+    private byte _attachments;
+
     public long MailId { get => parent.Id; }
     public MailType Type { get => parent.MailType; }
-    public MailStatus Status { get; set; }
+    public MailStatus Status
+    {
+        get => _status;
+        set { _status = value; parent.IsDirty = true; }
+    }
     public string Title { get => parent.Title; } // TODO max length 400
     public uint SenderId { get; set; }
     public string SenderName { get; set; } // TODO max length 128
-    public byte Attachments { get; set; }
+    public byte Attachments
+    {
+        get => _attachments;
+        set { _attachments = value; parent.IsDirty = true; }
+    }
     public uint ReceiverId { get; set; }
     public string ReceiverName { get => parent.ReceiverName; } // TODO max length 128
     public DateTime OpenDate { get => parent.OpenDate; }

--- a/AAEmu.Game/Models/Game/Skills/SkillCaster.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillCaster.cs
@@ -1,5 +1,6 @@
 using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.Auction;
 using AAEmu.Game.Models.Game.Items;
 
 namespace AAEmu.Game.Models.Game.Skills;
@@ -98,7 +99,8 @@ public class SkillItem : SkillCaster
             _itemId = value;
             if (_itemId > 0)
             {
-                SkillSourceItem = ItemManager.Instance.GetItemByItemId(value);
+                var found = ItemManager.Instance.GetItemByItemId(value);
+                SkillSourceItem = AuctionHouseRules.IsPlayerHeldItem(found) ? found : null;
                 ItemTemplateId = SkillSourceItem?.TemplateId ?? 0;
             }
         }

--- a/AAEmu.Game/NLog.config
+++ b/AAEmu.Game/NLog.config
@@ -20,9 +20,17 @@
               archiveNumbering="Date" archiveDateFormat="yyyy-MM-dd" archiveEvery="Day" maxArchiveFiles="9"
               layout="${date:format=HH\:mm\:ss} [${level:uppercase=true}] ${logger:shortName=true} - ${message} ${exception:format=tostring}" 
               keepFileOpen="false" encoding="utf-8" concurrentWrites="false" deleteOldFileOnStartup="true" />
+      <target name="auction"
+              xsi:type="File"
+              fileName="${basedir}/Logs/auction.log"
+              archiveFileName="${basedir}/Logs/auction.{#}.log"
+              archiveNumbering="Date" archiveDateFormat="yyyy-MM-dd" archiveEvery="Day" maxArchiveFiles="14"
+              layout="${date:format=HH\:mm\:ss} [${level:uppercase=true}] ${logger:shortName=true} - ${message} ${exception:format=tostring}"
+              keepFileOpen="false" encoding="utf-8" concurrentWrites="false" deleteOldFileOnStartup="false" />
     </targets>
 
     <rules>
+      <logger name="AuctionHouse" minlevel="Info" writeTo="auction" />
       <logger name="*" minlevel="Debug" writeTo="console" />
       <logger name="*" minlevel="Error" writeTo="errors" />
       <logger name="*" minlevel="Trace" maxlevel="Warn" writeTo="file" />

--- a/AAEmu.Game/Services/WebApi/Controllers/AuctionController.cs
+++ b/AAEmu.Game/Services/WebApi/Controllers/AuctionController.cs
@@ -6,8 +6,6 @@ using System.Text.RegularExpressions;
 using NLog;
 using System.Web;
 using AAEmu.Game.Core.Managers.World;
-using AAEmu.Game.Models.Game.Items;
-using AAEmu.Game.Models.Game.Items.Actions;
 
 namespace AAEmu.Game.Services.WebApi.Controllers;
 
@@ -35,12 +33,10 @@ internal class AuctionController : BaseController, IController
             return BadRequestJson(new { error = "Invalid parameters" });
         }
 
-        var itemId = itemIdElement.GetUInt32();
-        var quantity = quantityElement.GetInt32();
-        var price = priceElement.GetInt32();
+        var itemId = itemIdElement.GetUInt64();
+        var price = priceElement.GetInt64();
         var duration = (AuctionDuration)durationElement.GetInt32();
         var clientId = clientIdElement.GetUInt32();
-        var clientName = clientNameElement.GetString();
 
         try
         {
@@ -50,13 +46,12 @@ internal class AuctionController : BaseController, IController
             {
                 return BadRequestJson(new { error = "Internal server error", details = "Item not found!" });
             }
-            // Create a new auction item
-            var newAuctionItem = AuctionManager.Instance.CreateAuctionLot(player.Id, player.Name, item, price, price, duration, 1, quantity);
 
-            // Add the auction item to the auction house
-            AuctionManager.Instance.AddAuctionLot(newAuctionItem);
-            Logger.Info($"Added auction item: {newAuctionItem}");
-            return OkJson(new { message = "Auction item added successfully", item = newAuctionItem });
+            if (!AuctionManager.Instance.PostLotOnAuction(player, item.Id, price, price, duration, 1, item.Count))
+                return BadRequestJson(new { error = "Listing refused" });
+
+            Logger.Info("Listed item {0} for {1} through the auction API", item.Id, player.Name);
+            return OkJson(new { message = "Auction item added successfully" });
         }
         catch (Exception ex)
         {
@@ -110,12 +105,12 @@ internal class AuctionController : BaseController, IController
             }
             if (queryParams["DirectMoney"] != null)
             {
-                var directMoney = int.Parse(queryParams["DirectMoney"]);
+                var directMoney = long.Parse(queryParams["DirectMoney"]);
                 query = query.Where(item => item.DirectMoney == directMoney);
             }
             if (queryParams["BidMoney"] != null)
             {
-                var bidMoney = int.Parse(queryParams["BidMoney"]);
+                var bidMoney = long.Parse(queryParams["BidMoney"]);
                 query = query.Where(item => item.BidMoney == bidMoney);
             }
             if (queryParams["BidderName"] != null)
@@ -160,58 +155,17 @@ internal class AuctionController : BaseController, IController
         }
 
         var itemTemplateId = itemElement.GetUInt32();
-        var quantity = quantityElement.GetInt32();
-        var gradeId = gradeElement.GetByte();
-        var buyNowPrice = buyNowPriceElement.GetInt32();
-        var startPrice = startPriceElement.GetInt32();
-        var duration = (AuctionDuration)durationElement.GetInt32();
         var clientId = clientIdElement.GetUInt32();
         var clientName = clientNameElement.GetString();
+        _ = quantityElement;
+        _ = gradeElement;
+        _ = buyNowPriceElement;
+        _ = startPriceElement;
+        _ = durationElement;
 
-        try
-        {
-            var playerAhContainer = ItemManager.Instance.GetItemContainerForCharacter(clientId, SlotType.Auction, null, 0);
-            if (!playerAhContainer.AcquireDefaultItemEx(ItemTaskType.Invalid, itemTemplateId, quantity,
-                    gradeId, out var newItems, out _, 0, -1))
-            {
-                var err = $"Unable to create new item {itemTemplateId} for character {clientName} ({clientId})";
-                Logger.Warn(err);
-                return BadRequestJson(err);
-            }
-
-            if (newItems.Count != 1)
-            {
-                Logger.Warn($"Generate auction item request generated more than one entry! ({newItems.Count})");
-            }
-
-            if (newItems.Count < 1)
-            {
-                var err = $"No item was generated with template {itemTemplateId} for character {clientName} ({clientId})";
-                Logger.Warn(err);
-                return BadRequestJson(err);
-            }
-            
-            var newItem = newItems[0]; 
-            
-            var player = NameManager.Instance.GetCharacterName(clientId);
-            var itemTemplate = ItemManager.Instance.GetItemTemplateFromItemId(itemTemplateId);
-            if (player == null || itemTemplate == null)
-            {
-                return BadRequestJson(new { error = "Internal server error", details = "Item not found!" });
-            }
-            // Create a new auction item
-            var newAuctionItem = AuctionManager.Instance.CreateAuctionLot(clientId, clientName, newItem, startPrice, buyNowPrice, duration, 1, quantity);
-
-            // Add the auction item to the auction house
-            AuctionManager.Instance.AddAuctionLot(newAuctionItem);
-            Logger.Info($"Added auction item: {newAuctionItem}");
-            return OkJson(new { message = "Auction item generated successfully", item = newAuctionItem });
-        }
-        catch (Exception ex)
-        {
-            Logger.Error(ex, "Error adding auction item");
-            return BadRequestJson(new { error = "Internal server error", details = ex.Message });
-        }
+        Logger.Warn("Refused auction generate for template {0} by {1} ({2}): minting through this API is disabled",
+            itemTemplateId, clientName, clientId);
+        return BadRequestJson(new { error = "Auction generate is disabled. List an existing bag item through /api/auction/add." });
     }
 
 }

--- a/AAEmu.Game/Services/WebApi/Controllers/MailController.cs
+++ b/AAEmu.Game/Services/WebApi/Controllers/MailController.cs
@@ -305,6 +305,7 @@ internal class MailController : BaseController
             return BadRequestJson("Verification failed.");
         }
 
+        MailManager.Instance.NotifyDeleteMailByNameIfOnline(mail, mail.ReceiverName);
         if (!MailManager.Instance.DeleteMail(mail, deleteRequest.TrashItems))
         {
             return BadRequestJson(new { message = "Mail could not be deleted.", mailId = mail.Id });

--- a/AAEmu.UnitTests/Game/Core/Managers/AuctionManagerSettleTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/AuctionManagerSettleTests.cs
@@ -4,6 +4,7 @@ using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Auction;
+using AAEmu.Game.Models.Game.Features;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Mails;
 using AAEmu.UnitTests.Utils.Mocks;
@@ -38,8 +39,10 @@ public sealed class AuctionManagerSettleTests
     private SequentialMailIdManager _mailIds;
     private RecordingSaveManager _saves;
     private Item _item;
+    private Item _slice;
     private CharacterMock _alice;
     private CharacterMock _bob;
+    private FeatureSet _previousFeatures;
 
     [Before(Test)]
     public void Setup()
@@ -70,8 +73,12 @@ public sealed class AuctionManagerSettleTests
             SlotType = SlotType.Auction
         };
 
+        // The stack a partial buyout splits off. Grade 0 matches the listed item.
+        _slice = new Item(0) { Id = ItemId + 1, TemplateId = ItemTemplateId, Count = 1, OwnerId = SellerId };
+
         var items = Mock.Of<IItemManager>();
         items.GetItemByItemId(ItemId).Returns(_item);
+        items.Create(ItemTemplateId, 1, (byte)0, true).Returns(_slice);
         var auctionIds = Mock.Of<IAuctionIdManager>();
         auctionIds.GetNextId().Returns(LotId);
 
@@ -103,13 +110,13 @@ public sealed class AuctionManagerSettleTests
         _alice = new CharacterMock { AccountId = 3, Id = AliceId, Name = AliceName, Money = StartingMoney };
         _bob = new CharacterMock { AccountId = 2, Id = BobId, Name = BobName, Money = StartingMoney };
 
-        _house.AddAuctionLot(_house.CreateAuctionLot(
-            SellerId, SellerName, _item, StartPrice, BuyoutPrice, AuctionDuration.AuctionDuration48Hours));
+        _previousFeatures = FeaturesManager.Fsets;
     }
 
     [After(Test)]
     public void Teardown()
     {
+        SetFeatures(_previousFeatures);
         SingletonContainer.ServiceProvider = null;
         ResetSingletons();
         _house = null;
@@ -117,13 +124,36 @@ public sealed class AuctionManagerSettleTests
         _mailIds = null;
         _saves = null;
         _item = null;
+        _slice = null;
         _alice = null;
         _bob = null;
+    }
+
+    private void ListItem(int count = 1, int minStack = 1, int maxStack = 1)
+    {
+        _item.Count = count;
+        _house.AddAuctionLot(_house.CreateAuctionLot(
+            SellerId, SellerName, _item, StartPrice, BuyoutPrice, AuctionDuration.AuctionDuration48Hours, minStack, maxStack));
+    }
+
+    private static void SetFeatures(FeatureSet features)
+    {
+        typeof(FeaturesManager)
+            .GetProperty(nameof(FeaturesManager.Fsets), BindingFlags.Static | BindingFlags.Public)
+            ?.SetValue(null, features);
+    }
+
+    private static void EnablePartialBuy()
+    {
+        var features = new FeatureSet();
+        features.Set(Feature.auctionPartialBuy, true);
+        SetFeatures(features);
     }
 
     [Test]
     public async Task FullBuyout_BuyerMailFails_RestoresLotWithoutTheRefundedBid_AndExpiryReturnsItemToSeller()
     {
+        ListItem();
         _house.BidOnAuctionLot(_alice, Bid(150));
         var lot = _house.AuctionLots[LotId];
         await Assert.That(lot.BidderId).IsEqualTo(AliceId);
@@ -160,6 +190,7 @@ public sealed class AuctionManagerSettleTests
     [Test]
     public async Task SelfBuyout_BuyerMailFails_RefundsTheWholePriceAndRestoresLotWithoutABid()
     {
+        ListItem();
         _house.BidOnAuctionLot(_bob, Bid(150));
         await Assert.That(_bob.Money).IsEqualTo(StartingMoney - 150);
 
@@ -177,12 +208,48 @@ public sealed class AuctionManagerSettleTests
     }
 
     /// <summary>
+    /// The standing bidder buys one item of a ten-stack and the letter fails. The whole buyout
+    /// is refunded, so the bid that was folded into it must leave the stack too.
+    /// </summary>
+    [Test]
+    public async Task PartialSelfBuyout_BuyerMailFails_KeepsTheStackWithoutTheRefundedBid_AndExpiryReturnsItToSeller()
+    {
+        EnablePartialBuy();
+        ListItem(count: 10, minStack: 1, maxStack: 10);
+        _house.BidOnAuctionLot(_bob, Bid(150));
+        await Assert.That(_bob.Money).IsEqualTo(StartingMoney - 150);
+
+        BlockNextMailIdAfter(0);
+        _house.BidOnAuctionLot(_bob, new AuctionBid { LotId = LotId, Money = BuyoutPrice, StackSize = 1 });
+
+        var lot = _house.AuctionLots[LotId];
+        await Assert.That(lot.BidderId).IsEqualTo(0u);
+        await Assert.That(lot.BidMoney).IsEqualTo(0L);
+        await Assert.That(_item.Count).IsEqualTo(10);
+        await Assert.That(_item.SlotType).IsEqualTo(SlotType.Auction);
+        await Assert.That(_bob.Money).IsEqualTo(StartingMoney - BuyoutPrice);
+        await Assert.That(RefundMailCopper(BobId)).IsEquivalentTo([(int)BuyoutPrice]);
+
+        lot.EndTime = DateTime.UtcNow.AddSeconds(-1);
+        _house.UpdateAuctionHouse();
+
+        await Assert.That(_house.AuctionLots.ContainsKey(LotId)).IsFalse();
+        await Assert.That(MailsOfType(MailType.AucBidWin)).IsEmpty();
+        var returned = MailsOfType(MailType.AucOffFail);
+        await Assert.That(returned.Count).IsEqualTo(1);
+        await Assert.That(returned[0].Header.ReceiverId).IsEqualTo(SellerId);
+        await Assert.That(returned[0].Body.Attachments).Contains(_item);
+        await Assert.That(_item.Count).IsEqualTo(10);
+    }
+
+    /// <summary>
     /// The save an outbid forces must already show the replacement bidder. Saving from inside
     /// the refund letter committed the bid that letter had just returned.
     /// </summary>
     [Test]
     public async Task Outbid_PersistsOnceWithTheReplacementBidStanding()
     {
+        ListItem();
         var lot = _house.AuctionLots[LotId];
         var committed = new List<(uint bidder, long bid, int mails, long aliceMoney, long bobMoney)>();
         _saves.OnSave = () => committed.Add(

--- a/AAEmu.UnitTests/Game/Core/Managers/AuctionManagerSettleTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/AuctionManagerSettleTests.cs
@@ -1,0 +1,232 @@
+using System.Reflection;
+using AAEmu.Commons.Utils;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.Models.Game.Auction;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Mails;
+using AAEmu.UnitTests.Utils.Mocks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+/// <summary>
+/// Escrow and bid state through the real <see cref="AuctionManager"/> bid / settle / expire
+/// path (AAEmu#1552 review). A buyout delivery is made to fail by occupying the mail id the
+/// winner's letter will take: <see cref="MailManager.Send"/> refuses to replace a stored
+/// mail, the house reverts the claim, and the refund letter that follows still goes through.
+/// </summary>
+[NotInParallel]
+public sealed class AuctionManagerSettleTests
+{
+    private const uint SellerId = 1;
+    private const uint BobId = 2;
+    private const uint AliceId = 3;
+    private const string SellerName = "Seller";
+    private const string BobName = "Bob";
+    private const string AliceName = "Alice";
+    private const ulong ItemId = 500;
+    private const uint ItemTemplateId = 1234;
+    private const uint LotId = 7;
+    private const long StartPrice = 100;
+    private const long BuyoutPrice = 500;
+    private const long StartingMoney = 10_000;
+
+    private AuctionManager _house;
+    private MailManager _mailManager;
+    private SequentialMailIdManager _mailIds;
+    private RecordingSaveManager _saves;
+    private Item _item;
+    private CharacterMock _alice;
+    private CharacterMock _bob;
+
+    [Before(Test)]
+    public void Setup()
+    {
+        var names = new NameManager();
+        names.Load([], [], []);
+        names.AddCharacter(SellerId, SellerName, 1);
+        names.AddCharacter(BobId, BobName, 2);
+        names.AddCharacter(AliceId, AliceName, 3);
+
+        _mailIds = new SequentialMailIdManager();
+        _mailManager = new MailManager(
+            _mailIds,
+            names,
+            Mock.Of<IItemManager>().Object,
+            Mock.Of<ITaskManager>().Object,
+            Mock.Of<IWorldManager>().Object,
+            new Lazy<IHousingManager>(() => Mock.Of<IHousingManager>().Object),
+            Mock.Of<ILocalizationManager>().Object);
+        _mailManager._allPlayerMails = [];
+
+        _item = new Item(0)
+        {
+            Id = ItemId,
+            TemplateId = ItemTemplateId,
+            Count = 1,
+            OwnerId = SellerId,
+            SlotType = SlotType.Auction
+        };
+
+        var items = Mock.Of<IItemManager>();
+        items.GetItemByItemId(ItemId).Returns(_item);
+        var auctionIds = Mock.Of<IAuctionIdManager>();
+        auctionIds.GetNextId().Returns(LotId);
+
+        _house = new AuctionManager(
+            items.Object,
+            names,
+            auctionIds.Object,
+            Mock.Of<ILocalizationManager>().Object,
+            Mock.Of<ITaskManager>().Object);
+
+        var world = new WorldManager(
+            Mock.Of<ITickManager>().Object,
+            Mock.Of<IWorldIdManager>().Object,
+            new Lazy<IZoneManager>(() => Mock.Of<IZoneManager>().Object),
+            new Lazy<IIndunManager>(() => Mock.Of<IIndunManager>().Object),
+            new Lazy<IFamilyManager>(() => Mock.Of<IFamilyManager>().Object));
+
+        _saves = new RecordingSaveManager();
+
+        ResetSingletons();
+        var services = new ServiceCollection();
+        services.AddSingleton(_mailManager);
+        services.AddSingleton(names);
+        services.AddSingleton(new LocalizationManager());
+        services.AddSingleton(world);
+        services.AddSingleton<ISaveManager>(_saves);
+        SingletonContainer.ServiceProvider = services.BuildServiceProvider();
+
+        _alice = new CharacterMock { AccountId = 3, Id = AliceId, Name = AliceName, Money = StartingMoney };
+        _bob = new CharacterMock { AccountId = 2, Id = BobId, Name = BobName, Money = StartingMoney };
+
+        _house.AddAuctionLot(_house.CreateAuctionLot(
+            SellerId, SellerName, _item, StartPrice, BuyoutPrice, AuctionDuration.AuctionDuration48Hours));
+    }
+
+    [After(Test)]
+    public void Teardown()
+    {
+        SingletonContainer.ServiceProvider = null;
+        ResetSingletons();
+        _house = null;
+        _mailManager = null;
+        _mailIds = null;
+        _saves = null;
+        _item = null;
+        _alice = null;
+        _bob = null;
+    }
+
+    [Test]
+    public async Task FullBuyout_BuyerMailFails_RestoresLotWithoutTheRefundedBid_AndExpiryReturnsItemToSeller()
+    {
+        _house.BidOnAuctionLot(_alice, Bid(150));
+        var lot = _house.AuctionLots[LotId];
+        await Assert.That(lot.BidderId).IsEqualTo(AliceId);
+        await Assert.That(_alice.Money).IsEqualTo(StartingMoney - 150);
+
+        // Alice's refund letter takes the first id; Bob's win letter would take the second.
+        BlockNextMailIdAfter(1);
+        _house.BidOnAuctionLot(_bob, Bid(BuyoutPrice));
+
+        // Alice was refunded on the outbid, Bob on the failed delivery. Nobody holds a bid.
+        await Assert.That(_house.AuctionLots.ContainsKey(LotId)).IsTrue();
+        lot = _house.AuctionLots[LotId];
+        await Assert.That(lot.BidderId).IsEqualTo(0u);
+        await Assert.That(lot.BidMoney).IsEqualTo(0L);
+        await Assert.That(lot.BidderName).IsEqualTo(string.Empty);
+        await Assert.That(_item.SlotType).IsEqualTo(SlotType.Auction);
+        await Assert.That(_item.OwnerId).IsEqualTo((ulong)SellerId);
+        await Assert.That(_bob.Money).IsEqualTo(StartingMoney - BuyoutPrice);
+        await Assert.That(RefundMailCopper(AliceId)).IsEquivalentTo([150]);
+        await Assert.That(RefundMailCopper(BobId)).IsEquivalentTo([(int)BuyoutPrice]);
+
+        lot.EndTime = DateTime.UtcNow.AddSeconds(-1);
+        _house.UpdateAuctionHouse();
+
+        await Assert.That(_house.AuctionLots.ContainsKey(LotId)).IsFalse();
+        await Assert.That(MailsOfType(MailType.AucBidWin)).IsEmpty();
+        var returned = MailsOfType(MailType.AucOffFail);
+        await Assert.That(returned.Count).IsEqualTo(1);
+        await Assert.That(returned[0].Header.ReceiverId).IsEqualTo(SellerId);
+        await Assert.That(returned[0].Body.Attachments).Contains(_item);
+        await Assert.That(_item.OwnerId).IsEqualTo((ulong)SellerId);
+    }
+
+    [Test]
+    public async Task SelfBuyout_BuyerMailFails_RefundsTheWholePriceAndRestoresLotWithoutABid()
+    {
+        _house.BidOnAuctionLot(_bob, Bid(150));
+        await Assert.That(_bob.Money).IsEqualTo(StartingMoney - 150);
+
+        // No outbid letter this time: Bob's win letter is the first mail sent.
+        BlockNextMailIdAfter(0);
+        _house.BidOnAuctionLot(_bob, Bid(BuyoutPrice));
+
+        var lot = _house.AuctionLots[LotId];
+        await Assert.That(lot.BidderId).IsEqualTo(0u);
+        await Assert.That(lot.BidMoney).IsEqualTo(0L);
+        await Assert.That(_item.SlotType).IsEqualTo(SlotType.Auction);
+        // Charged 150 then the 350 difference; the refund letter carries the full buyout.
+        await Assert.That(_bob.Money).IsEqualTo(StartingMoney - BuyoutPrice);
+        await Assert.That(RefundMailCopper(BobId)).IsEquivalentTo([(int)BuyoutPrice]);
+    }
+
+    /// <summary>
+    /// The save an outbid forces must already show the replacement bidder. Saving from inside
+    /// the refund letter committed the bid that letter had just returned.
+    /// </summary>
+    [Test]
+    public async Task Outbid_PersistsOnceWithTheReplacementBidStanding()
+    {
+        var lot = _house.AuctionLots[LotId];
+        var committed = new List<(uint bidder, long bid, int mails, long aliceMoney, long bobMoney)>();
+        _saves.OnSave = () => committed.Add(
+            (lot.BidderId, lot.BidMoney, _mailManager._allPlayerMails.Count, _alice.Money, _bob.Money));
+
+        _house.BidOnAuctionLot(_alice, Bid(150));
+        await Assert.That(_saves.SaveCount).IsEqualTo(1);
+        await Assert.That(committed[0]).IsEqualTo((AliceId, 150L, 0, StartingMoney - 150, StartingMoney));
+
+        _house.BidOnAuctionLot(_bob, Bid(200));
+        await Assert.That(_saves.SaveCount).IsEqualTo(2);
+        await Assert.That(committed[1]).IsEqualTo((BobId, 200L, 1, StartingMoney - 150, StartingMoney - 200));
+        await Assert.That(RefundMailCopper(AliceId)).IsEquivalentTo([150]);
+    }
+
+    private static AuctionBid Bid(long money) => new() { LotId = LotId, Money = money };
+
+    /// <summary>Occupies the id of the (<paramref name="lettersBefore"/> + 1)-th letter sent from now on.</summary>
+    private void BlockNextMailIdAfter(int lettersBefore)
+    {
+        var blocked = _mailIds.Next + (uint)lettersBefore;
+        _mailManager._allPlayerMails[blocked] = new BaseMail { Id = blocked, MailType = MailType.InvalidMailType };
+    }
+
+    private List<BaseMail> MailsOfType(MailType type) =>
+        _mailManager._allPlayerMails.Values.Where(m => m.MailType == type).ToList();
+
+    private List<int> RefundMailCopper(uint receiverId) =>
+        MailsOfType(MailType.AucBidFail)
+            .Where(m => m.Header.ReceiverId == receiverId)
+            .Select(m => m.Body.CopperCoins)
+            .ToList();
+
+    private static void ResetSingletons()
+    {
+        foreach (var type in new[]
+                 {
+                     typeof(Singleton<MailManager>),
+                     typeof(Singleton<NameManager>),
+                     typeof(Singleton<LocalizationManager>),
+                     typeof(Singleton<WorldManager>)
+                 })
+        {
+            type.GetField("s_instance", BindingFlags.Static | BindingFlags.NonPublic)?.SetValue(null, null);
+        }
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/LocalizationManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/LocalizationManagerTests.cs
@@ -1,0 +1,39 @@
+using AAEmu.Game.Core.Managers;
+
+namespace AAEmu.UnitTests.Game.Core.Managers;
+
+public class LocalizationManagerTests
+{
+    [Test]
+    public async Task Get_UsesTheDisplayLanguageAndFallsBackWhenThatCellIsEmpty()
+    {
+        var loc = new LocalizationManager();
+        loc.AddTranslation("items", "name", 29656, "");
+        loc.AddTranslations("items", "name", 29656, ["전문화 확장의 인장", "", "博学之章"]);
+
+        await Assert.That(loc.Get("items", "name", 29656, "전문화 확장의 인장")).IsEqualTo("전문화 확장의 인장");
+        await Assert.That(loc.Get("items", "name", 1, "missing")).IsEqualTo("missing");
+    }
+
+    [Test]
+    public async Task GetAll_ReturnsEveryNonEmptyLanguageCell()
+    {
+        var loc = new LocalizationManager();
+        loc.AddTranslation("items", "name", 29656, "Specialization Snowflake");
+        loc.AddTranslations("items", "name", 29656,
+        [
+            "전문화 확장의 인장",
+            "Specialization Snowflake",
+            "博学之章",
+            ""
+        ]);
+
+        var names = loc.GetAll("items", "name", 29656);
+        await Assert.That(names).IsEquivalentTo([
+            "Specialization Snowflake",
+            "전문화 확장의 인장",
+            "博学之章"
+        ]);
+        await Assert.That(loc.GetAll("items", "name", 1)).IsEmpty();
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
@@ -120,6 +120,51 @@ public sealed class MailTests
         await Assert.That(committedMails).IsEquivalentTo([1]);
     }
 
+    /// <summary>
+    /// A save asked for on another thread while a letter is between "stored" and "paid for"
+    /// must wait for the operation to finish, and the operation's own flush must not be lost
+    /// when it finds that save running.
+    /// </summary>
+    [Test]
+    public async Task DeferPersist_SaveOnAnotherThread_WaitsForTheOperationToFinish()
+    {
+        var committed = new List<(long money, int mails)>();
+        _saves.OnSave = () =>
+        {
+            lock (committed)
+                committed.Add((_character.Money, _mailManager._allPlayerMails.Count));
+        };
+
+        using var mailStored = new ManualResetEventSlim();
+        using var proceed = new ManualResetEventSlim();
+
+        var operation = Task.Run(() =>
+        {
+            using var scope = _mailManager.DeferPersist();
+            var mail = new MailPlayerToPlayer(_character, "tester".NormalizeName()) { MailType = MailType.Express, Title = "t" };
+            mail.AttachMoney(500, 0, 0);
+            if (!mail.Send())
+                throw new InvalidOperationException("send failed");
+            mailStored.Set();
+            proceed.Wait();
+            _character.SubtractMoney(SlotType.Inventory, 600);
+        });
+
+        mailStored.Wait();
+        var save = Task.Run(() => _saves.DoSave());
+        await Assert.That(save.Wait(200)).IsFalse();
+        await Assert.That(_saves.SaveCount).IsEqualTo(0);
+
+        proceed.Set();
+        await Task.WhenAll(operation, save);
+
+        await Assert.That(_character.Money).IsEqualTo(400);
+        await Assert.That(_saves.SaveCount).IsGreaterThanOrEqualTo(1);
+        await Assert.That(_saves.SaveCount + _saves.BusySkips).IsEqualTo(2);
+        foreach (var snapshot in committed)
+            await Assert.That(snapshot).IsEqualTo((400L, 1));
+    }
+
     [Test]
     public async Task DeferPersist_NestedScopes_FlushOnceAtTheOutermost()
     {

--- a/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
@@ -110,4 +110,33 @@ public sealed class MailTests
         await Assert.That(_mails.SendMailToPlayer(type, receiverCharName, title, text, attachments, money0, money1, money2, extra, itemSlots)).IsNotEqualTo(MailResult.Success);
         await Assert.That(_character.Money).IsEqualTo(1000);
     }
+
+    [Test]
+    public async Task GetAttached_MissingMail_ReturnsFalse()
+    {
+        await Assert.That(_mails.GetAttached(999, true, true, true)).IsFalse();
+    }
+
+    [Test]
+    public async Task ReadMail_MissingMail_DoesNotThrow()
+    {
+        _mails.ReadMail(false, 999);
+        await Assert.That(_mailManager._allPlayerMails.ContainsKey(999)).IsFalse();
+    }
+
+    [Test]
+    public async Task DeleteMail_TrashAttachmentWithoutContainer_StillRemovesMail()
+    {
+        var mail = new BaseMail
+        {
+            Id = 42,
+            ReceiverName = "tester",
+            Header = { ReceiverId = 1, SenderId = 0 },
+        };
+        mail.Body.Attachments.Add(new Item(99) { SlotType = SlotType.Mail });
+        _mailManager._allPlayerMails[42] = mail;
+
+        await Assert.That(_mailManager.DeleteMail(mail, trashItems: true)).IsTrue();
+        await Assert.That(_mailManager._allPlayerMails.ContainsKey(42)).IsFalse();
+    }
 }

--- a/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
@@ -17,10 +17,12 @@ public sealed class MailTests
     private CharacterMock _character;
     private CharacterMails _mails;
     private MailManager _mailManager;
+    private RecordingSaveManager _saves;
 
     [Before(Test)]
     public void Setup()
     {
+        _saves = new RecordingSaveManager();
         _character = new CharacterMock { AccountId = 1, Id = 1, Name = "tester", Money = 1000 };
 
         _mails = new CharacterMails(_character);
@@ -52,6 +54,7 @@ public sealed class MailTests
         var services = new ServiceCollection();
         services.AddSingleton(_mailManager);
         services.AddSingleton(nameManager);
+        services.AddSingleton<ISaveManager>(_saves);
         SingletonContainer.ServiceProvider = services.BuildServiceProvider();
 
         _mailManager._allPlayerMails = [];
@@ -63,6 +66,7 @@ public sealed class MailTests
         _character = null;
         _mails = null;
         _mailManager = null;
+        _saves = null;
 
         SingletonContainer.ServiceProvider = null;
         typeof(Singleton<MailManager>)
@@ -89,6 +93,54 @@ public sealed class MailTests
 
         await Assert.That(_mails.SendMailToPlayer(type, receiverCharName, title, text, attachments, money0, money1, money2, extra, itemSlots)).IsEqualTo(MailResult.Success);
         await Assert.That(_character.Money).IsEqualTo(400);
+    }
+
+    /// <summary>
+    /// The save a sent letter forces must see the sender already charged. Saving from inside
+    /// Send() committed the paid letter next to the pre-charge balance, and a restart before the
+    /// next tick gave the sender their coin back while the recipient kept the letter.
+    /// </summary>
+    [Test]
+    public async Task SendMailToPlayer_PersistsOnceAfterTheFeeIsCharged()
+    {
+        var committedMoney = new List<long>();
+        var committedMails = new List<int>();
+        _saves.OnSave = () =>
+        {
+            committedMoney.Add(_character.Money);
+            committedMails.Add(_mailManager._allPlayerMails.Count);
+        };
+
+        var result = _mails.SendMailToPlayer(
+            MailType.Express, "tester".NormalizeName(), "test", "test", 0, 500, 0, 0, 0, []);
+
+        await Assert.That(result).IsEqualTo(MailResult.Success);
+        await Assert.That(_saves.SaveCount).IsEqualTo(1);
+        await Assert.That(committedMoney).IsEquivalentTo([400L]);
+        await Assert.That(committedMails).IsEquivalentTo([1]);
+    }
+
+    [Test]
+    public async Task DeferPersist_NestedScopes_FlushOnceAtTheOutermost()
+    {
+        using (_mailManager.DeferPersist())
+        {
+            _mailManager.PersistNow();
+            using (_mailManager.DeferPersist())
+                _mailManager.PersistNow();
+            await Assert.That(_saves.SaveCount).IsEqualTo(0);
+        }
+
+        await Assert.That(_saves.SaveCount).IsEqualTo(1);
+
+        using (_mailManager.DeferPersist())
+        {
+        }
+
+        await Assert.That(_saves.SaveCount).IsEqualTo(1);
+
+        _mailManager.PersistNow();
+        await Assert.That(_saves.SaveCount).IsEqualTo(2);
     }
 
     [Test]

--- a/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/MailTests.cs
@@ -43,10 +43,10 @@ public sealed class MailTests
 
         // Reset singleton caches so Instance properties resolve via ServiceProvider
         typeof(Singleton<MailManager>)
-            .GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic)
+            .GetField("s_instance", BindingFlags.Static | BindingFlags.NonPublic)
             ?.SetValue(null, null);
         typeof(Singleton<NameManager>)
-            .GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic)
+            .GetField("s_instance", BindingFlags.Static | BindingFlags.NonPublic)
             ?.SetValue(null, null);
 
         var services = new ServiceCollection();
@@ -60,17 +60,16 @@ public sealed class MailTests
     [After(Test)]
     public void Teardown()
     {
-        _mailManager._allPlayerMails = null;
         _character = null;
         _mails = null;
         _mailManager = null;
 
         SingletonContainer.ServiceProvider = null;
         typeof(Singleton<MailManager>)
-            .GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic)
+            .GetField("s_instance", BindingFlags.Static | BindingFlags.NonPublic)
             ?.SetValue(null, null);
         typeof(Singleton<NameManager>)
-            .GetField("_instance", BindingFlags.Static | BindingFlags.NonPublic)
+            .GetField("s_instance", BindingFlags.Static | BindingFlags.NonPublic)
             ?.SetValue(null, null);
     }
 

--- a/AAEmu.UnitTests/Game/Core/Packets/G2C/AuctionHousePacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/G2C/AuctionHousePacketTests.cs
@@ -112,6 +112,18 @@ public class AuctionHousePacketTests
     }
 
     [Test]
+    public async Task MultilingualSearch_NegativeCountIsEmpty()
+    {
+        var stream = new PacketStream();
+        stream.Write(-4);
+
+        var search = new AuctionSearch();
+        search.ReadItemTemplateIds(new PacketStream(stream.GetBytes()));
+        await Assert.That(search.ItemTemplateIds.Count).IsEqualTo(0);
+        await Assert.That(search.ItemListCount).IsEqualTo(0);
+    }
+
+    [Test]
     public async Task Message_IsKindTemplateAndMoney()
     {
         var body = new SCAuctionMessagePacket(AuctionMessageKind.Outbid, 27501, 12_000)

--- a/AAEmu.UnitTests/Game/Core/Packets/G2C/AuctionHousePacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/G2C/AuctionHousePacketTests.cs
@@ -1,0 +1,222 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Packets.C2G;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Auction;
+using AAEmu.Game.Models.Game.Auction.Templates;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Mails;
+
+namespace AAEmu.UnitTests.Game.Core.Packets.G2C;
+
+public class AuctionHousePacketTests
+{
+    [Test]
+    public async Task Listing_RoundTripsThe10_0_2_13FieldOrder()
+    {
+        var posted = new DateTime(2026, 9, 5, 9, 0, 0, DateTimeKind.Utc);
+        var lot = new AuctionLot
+        {
+            Id = 99,
+            Duration = AuctionDuration.AuctionDuration24Hours,
+            Item = new Item(1) { TemplateId = 0 },
+            WorldId = 1,
+            ClientId = 7,
+            ClientName = "Seller",
+            StartMoney = 100,
+            DirectMoney = 500,
+            PostDate = posted,
+            Asked = 1_725_000_000,
+            ChargePercent = 200,
+            DepositPercent = 15,
+            ServiceKind = 0,
+            BidWorldId = 255,
+            BidderId = 8,
+            BidderName = "Bidder",
+            BidMoney = 150,
+            ExtraMoney = 0,
+            MinStack = 1,
+            MaxStack = 1
+        };
+
+        var body = lot.Write(new PacketStream());
+        var read = new AuctionLot();
+        read.Read(new PacketStream(body.GetBytes()));
+
+        await Assert.That(read.Id).IsEqualTo(99ul);
+        await Assert.That(read.Duration).IsEqualTo(AuctionDuration.AuctionDuration24Hours);
+        await Assert.That(read.WorldId).IsEqualTo((byte)1);
+        await Assert.That(read.ClientId).IsEqualTo(7u);
+        await Assert.That(read.ClientName).IsEqualTo("Seller");
+        await Assert.That(read.StartMoney).IsEqualTo(100L);
+        await Assert.That(read.DirectMoney).IsEqualTo(500L);
+        await Assert.That(read.Asked).IsEqualTo(1_725_000_000ul);
+        await Assert.That(read.ChargePercent).IsEqualTo(200);
+        await Assert.That(read.DepositPercent).IsEqualTo(15);
+        await Assert.That(read.BidderId).IsEqualTo(8u);
+        await Assert.That(read.BidderName).IsEqualTo("Bidder");
+        await Assert.That(read.BidMoney).IsEqualTo(150L);
+        await Assert.That(read.MinStack).IsEqualTo(1);
+        await Assert.That(read.MaxStack).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task SearchCriteria_RoundTripsWireOrderIncludingPrices()
+    {
+        var search = new AuctionSearch
+        {
+            Keyword = "ore",
+            ExactMatch = true,
+            Grade = 2,
+            CategoryA = 1,
+            CategoryB = 4,
+            CategoryC = 9,
+            Page = 3,
+            ClientId = 77,
+            Filter = 0,
+            ItemListCount = 0,
+            WorldId = 1,
+            MinItemLevel = 5,
+            MaxItemLevel = 40,
+            MinPrice = 10,
+            MaxPrice = 99_999,
+            SortKind = AuctionSearchSortKind.DirectPrice,
+            SortOrder = AuctionSearchSortOrder.Desc
+        };
+
+        var body = search.Write(new PacketStream()).GetBytes();
+        var read = new AuctionSearch();
+        read.Read(new PacketStream(body));
+
+        await Assert.That(read.Keyword).IsEqualTo("ore");
+        await Assert.That(read.ExactMatch).IsTrue();
+        await Assert.That(read.Page).IsEqualTo(3);
+        await Assert.That(read.ClientId).IsEqualTo(77ul);
+        await Assert.That(read.MinPrice).IsEqualTo(10L);
+        await Assert.That(read.MaxPrice).IsEqualTo(99_999L);
+        await Assert.That(read.SortKind).IsEqualTo(AuctionSearchSortKind.DirectPrice);
+        await Assert.That(read.SortOrder).IsEqualTo(AuctionSearchSortOrder.Desc);
+    }
+
+    [Test]
+    public async Task MultilingualSearch_ClampsTheTemplateIdArray()
+    {
+        var stream = new PacketStream();
+        stream.Write(200);
+        for (var i = 0; i < 200; i++)
+            stream.Write((uint)i);
+
+        var search = new AuctionSearch();
+        search.ReadItemTemplateIds(new PacketStream(stream.GetBytes()));
+        await Assert.That(search.ItemTemplateIds.Count).IsEqualTo(AuctionHouseRules.MultilingualItemIdLimit);
+        await Assert.That(search.ItemListCount).IsEqualTo(AuctionHouseRules.MultilingualItemIdLimit);
+    }
+
+    [Test]
+    public async Task Message_IsKindTemplateAndMoney()
+    {
+        var body = new SCAuctionMessagePacket(AuctionMessageKind.Outbid, 27501, 12_000)
+            .Write(new PacketStream())
+            .GetBytes();
+
+        var expected = new PacketStream();
+        expected.Write((byte)AuctionMessageKind.Outbid);
+        expected.Write(27501u);
+        expected.Write(12_000L);
+
+        await Assert.That(body).IsEquivalentTo(expected.GetBytes());
+        await Assert.That(body.Length).IsEqualTo(13);
+    }
+
+    [Test]
+    public async Task LowestPrice_WritesMoneyAsInt64()
+    {
+        var body = new SCAuctionLowestPricePacket(10, 2, 1_500_000_000)
+            .Write(new PacketStream())
+            .GetBytes();
+
+        await Assert.That(BitConverter.ToUInt32(body, 0)).IsEqualTo(10u);
+        await Assert.That(body[4]).IsEqualTo((byte)2);
+        await Assert.That(BitConverter.ToInt64(body, 5)).IsEqualTo(1_500_000_000L);
+        await Assert.That(body.Length).IsEqualTo(13);
+    }
+
+    [Test]
+    public async Task Searched_ClampsThePageToNineLots()
+    {
+        var lots = Enumerable.Range(0, 12).Select(i => new AuctionLot
+        {
+            Id = (ulong)i,
+            Item = new Item(0) { TemplateId = 0 },
+            ClientName = string.Empty,
+            BidderName = string.Empty
+        }).ToList();
+
+        var body = new SCAuctionSearchedPacket(1, lots, 0, new DateTime(2026, 9, 5, 0, 0, 0, DateTimeKind.Utc))
+            .Write(new PacketStream())
+            .GetBytes();
+
+        await Assert.That(BitConverter.ToInt32(body, 0)).IsEqualTo(1);
+        await Assert.That(BitConverter.ToInt32(body, 4)).IsEqualTo(9);
+    }
+
+    [Test]
+    public async Task SoldRecord_AlwaysWritesFourteenDayRows()
+    {
+        var days = AuctionSoldRecordRules.BuildDays([], 10, 1, DateTime.UtcNow);
+        var body = new SCAuctionSoldRecordSearchedPacket(10, 1, true, days)
+            .Write(new PacketStream())
+            .GetBytes();
+
+        var expected = new PacketStream();
+        expected.Write(10u);
+        expected.Write((byte)1);
+        expected.Write(true);
+        foreach (var day in days)
+            expected.Write(day);
+
+        await Assert.That(body).IsEquivalentTo(expected.GetBytes());
+    }
+
+    [Test]
+    public async Task LimitedPrice_EmptyListIsCountZero()
+    {
+        var body = new SCAuctionLimitedPricePacket([])
+            .Write(new PacketStream())
+            .GetBytes();
+
+        await Assert.That(BitConverter.ToInt32(body, 0)).IsEqualTo(0);
+        await Assert.That(body.Length).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task Bid_RoundTripsLotWorldBidderMoneyAndStack()
+    {
+        var bid = new AuctionBid
+        {
+            LotId = 44,
+            WorldId = 1,
+            BidderId = 9,
+            BidderName = "Buyer",
+            Money = 2500,
+            StackSize = 3
+        };
+        var read = new AuctionBid();
+        read.Read(new PacketStream(bid.Write(new PacketStream()).GetBytes()));
+
+        await Assert.That(read.LotId).IsEqualTo(44ul);
+        await Assert.That(read.Money).IsEqualTo(2500L);
+        await Assert.That(read.StackSize).IsEqualTo(3);
+        await Assert.That(read.BidderName).IsEqualTo("Buyer");
+    }
+
+    [Test]
+    public async Task Offsets_MatchThe10_0_2_13AuctionBlock()
+    {
+        await Assert.That(CSOffsets.CSAuctionPostPacket).IsEqualTo((ushort)0x0F8);
+        await Assert.That(CSOffsets.CSAuctionSearchForMultilingualPacket).IsEqualTo((ushort)0x20F);
+        await Assert.That(CSOffsets.CSSearchAuctionSoldRecordPacket).IsEqualTo((ushort)0x0FE);
+        await Assert.That(SCOffsets.SCAuctionSoldRecordSearchedPacket).IsEqualTo((ushort)0x177);
+        await Assert.That(SCOffsets.SCAuctionLimitedPricePacket).IsEqualTo((ushort)0x178);
+        await Assert.That(MailType.AucBidFail).IsEqualTo((MailType)17);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/AccountAttributeConfigRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/AccountAttributeConfigRulesTests.cs
@@ -1,0 +1,80 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game;
+
+namespace AAEmu.UnitTests.Game.Models.Game;
+
+public class AccountAttributeConfigRulesTests
+{
+    [Test]
+    public async Task AuctionPost_IsAdvertised_WithTheOtherLiveKinds()
+    {
+        await Assert.That(AccountAttributeConfigRules.KindIsUsed((byte)AccountAttributeKind.AuctionPost))
+            .IsTrue();
+        await Assert.That(AccountAttributeConfigRules.KindIsUsed((byte)AccountAttributeKind.AccountBuff))
+            .IsTrue();
+        await Assert.That(AccountAttributeConfigRules.KindIsUsed((byte)AccountAttributeKind.Ulc))
+            .IsTrue();
+        await Assert.That(AccountAttributeConfigRules.KindIsUsed(0)).IsFalse();
+    }
+
+    [Test]
+    public async Task ConfigPacket_WritesFourUsedBytesInKindOrder()
+    {
+        var body = new SCAccountAttributeConfigPacket()
+            .Write(new PacketStream())
+            .GetBytes();
+
+        await Assert.That(body).IsEquivalentTo(new byte[] { 0, 1, 1, 1 });
+    }
+
+    [Test]
+    public async Task ListingGrant_AddsExtraKindZeroOnce()
+    {
+        var attributes = new List<AccountAttribute>();
+        AccountAttributeGrantRules.EnsureListingGrant(attributes, 39);
+        AccountAttributeGrantRules.EnsureListingGrant(attributes, 39);
+
+        await Assert.That(attributes).HasCount().EqualTo(1);
+        await Assert.That(attributes[0].KindId).IsEqualTo((uint)AccountAttributeKind.AuctionPost);
+        await Assert.That(attributes[0].KindValue).IsEqualTo(AccountAttributeGrantRules.ListingExtraKind);
+        await Assert.That(attributes[0].Count).IsEqualTo(1);
+        await Assert.That(attributes[0].Starts).IsEqualTo(DateTime.UnixEpoch);
+        await Assert.That(attributes[0].Expires).IsEqualTo(DateTime.UnixEpoch);
+    }
+
+    [Test]
+    public async Task ListingGrant_KeepsAnExistingExtraKindZeroRow()
+    {
+        var existing = AccountAttributeGrantRules.CreateListingGrant(39);
+        existing.Count = 4;
+        var attributes = new List<AccountAttribute> { existing };
+
+        AccountAttributeGrantRules.EnsureListingGrant(attributes, 39);
+
+        await Assert.That(attributes).HasCount().EqualTo(1);
+        await Assert.That(attributes[0].Count).IsEqualTo(4);
+    }
+
+    [Test]
+    public async Task ListingGrant_ListPacket_WritesKindExtraKindCountAndZeroDates()
+    {
+        var grant = AccountAttributeGrantRules.CreateListingGrant(39);
+        var body = new SCAccountAttributeListPacket([grant])
+            .Write(new PacketStream())
+            .GetBytes();
+
+        var expected = new PacketStream()
+            .Write((uint)1)
+            .Write((byte)AccountAttributeKind.AuctionPost)
+            .Write(AccountAttributeGrantRules.ListingExtraKind)
+            .Write((byte)0)
+            .Write((uint)1)
+            .Write(DateTime.UnixEpoch)
+            .Write(DateTime.UnixEpoch)
+            .GetBytes();
+
+        await Assert.That(body).IsEquivalentTo(expected);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionFeeScheduleTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionFeeScheduleTests.cs
@@ -35,4 +35,14 @@ public class AuctionFeeScheduleTests
         await Assert.That(fees.GetSaleCharge(10_000, 0, 25)).IsEqualTo(150);
         await Assert.That(fees.GetListingDeposit(100_000, AuctionDuration.AuctionDuration12Hours, 50)).IsEqualTo(500);
     }
+
+    [Test]
+    public async Task SaleCharge_StoredListingRateIsNotDiscountedAgain()
+    {
+        var fees = new AuctionFeeSchedule();
+        var stored = AuctionHouseRules.ListingChargeRate(fees.SaleChargeRate, 0, 25);
+        await Assert.That(stored).IsEqualTo(150);
+        await Assert.That(AuctionHouseRules.SaleChargeForLot(fees, 10_000, stored, 0)).IsEqualTo(150);
+        await Assert.That(fees.GetSaleCharge(10_000, 0, 25)).IsEqualTo(150);
+    }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionFeeScheduleTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionFeeScheduleTests.cs
@@ -1,0 +1,38 @@
+using AAEmu.Game.Models.Game.Auction;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Auction;
+
+public class AuctionFeeScheduleTests
+{
+    [Test]
+    public async Task ListingDeposit_IsPerMilleOfBuyoutCappedAtAMillion()
+    {
+        var fees = new AuctionFeeSchedule();
+        await Assert.That(fees.GetListingDeposit(100_000, AuctionDuration.AuctionDuration6Hours)).IsEqualTo(500);
+        await Assert.That(fees.GetListingDeposit(100_000, AuctionDuration.AuctionDuration12Hours)).IsEqualTo(1_000);
+        await Assert.That(fees.GetListingDeposit(100_000, AuctionDuration.AuctionDuration24Hours)).IsEqualTo(1_500);
+        await Assert.That(fees.GetListingDeposit(100_000, AuctionDuration.AuctionDuration48Hours)).IsEqualTo(2_000);
+        await Assert.That(fees.GetListingDeposit(1_000_000_000, AuctionDuration.AuctionDuration48Hours)).IsEqualTo(1_000_000);
+        await Assert.That(fees.GetListingDeposit(0, AuctionDuration.AuctionDuration6Hours)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task SaleCharge_IsTwoPercentUnlessTheItemOverrides()
+    {
+        var fees = new AuctionFeeSchedule();
+        await Assert.That(fees.GetSaleCharge(10_000)).IsEqualTo(200);
+        await Assert.That(fees.GetSaleCharge(10_000, 1000)).IsEqualTo(1_000);
+        await Assert.That(fees.GetSaleCharge(0)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task AccountBuffDiscount_CutsTheStoredRate()
+    {
+        await Assert.That(AuctionFeeSchedule.ApplyPercentDiscount(200, 25)).IsEqualTo(150);
+        await Assert.That(AuctionFeeSchedule.ApplyPercentDiscount(20, 0)).IsEqualTo(20);
+
+        var fees = new AuctionFeeSchedule();
+        await Assert.That(fees.GetSaleCharge(10_000, 0, 25)).IsEqualTo(150);
+        await Assert.That(fees.GetListingDeposit(100_000, AuctionDuration.AuctionDuration12Hours, 50)).IsEqualTo(500);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionHouseRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionHouseRulesTests.cs
@@ -171,6 +171,25 @@ public class AuctionHouseRulesTests
     }
 
     [Test]
+    public async Task ClearStandingBid_DropsTheRefundedBidderFromTheLeftoverLot()
+    {
+        var lot = Lot("ore", 1, 0, 0, 0, 0, 500);
+        lot.BidderId = 9;
+        lot.BidderName = "OldBid";
+        lot.BidMoney = 150;
+        lot.BidWorldId = 1;
+        lot.IsDirty = false;
+
+        AuctionHouseRules.ClearStandingBid(lot);
+        await Assert.That(lot.BidderId).IsEqualTo(0u);
+        await Assert.That(lot.BidderName).IsEqualTo(string.Empty);
+        await Assert.That(lot.BidMoney).IsEqualTo(0L);
+        await Assert.That(lot.BidWorldId).IsEqualTo(AuctionHouseRules.UnsetWorldId);
+        await Assert.That(lot.IsDirty).IsTrue();
+        AuctionHouseRules.ClearStandingBid(null);
+    }
+
+    [Test]
     public async Task Matches_FiltersSellerWorldKeywordGradeLevelAndPrice()
     {
         var lot = Lot("iron ore", 10, 2, 1, 2, 3, 500);

--- a/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionHouseRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionHouseRulesTests.cs
@@ -124,6 +124,53 @@ public class AuctionHouseRulesTests
     }
 
     [Test]
+    public async Task ResolveBidStack_TakesTheRequestedSliceWhenPartialBuyIsOn()
+    {
+        await Assert.That(AuctionHouseRules.ResolveBidStack(3, 20, 1, 10, false)).IsEqualTo(20);
+        await Assert.That(AuctionHouseRules.ResolveBidStack(3, 20, 1, 10, true)).IsEqualTo(3);
+        await Assert.That(AuctionHouseRules.ResolveBidStack(0, 20, 1, 10, true)).IsEqualTo(10);
+        await Assert.That(AuctionHouseRules.ResolveBidStack(15, 20, 1, 10, true)).IsEqualTo(10);
+        await Assert.That(AuctionHouseRules.ResolveBidStack(-4, 20, 2, 8, true)).IsEqualTo(8);
+    }
+
+    [Test]
+    public async Task ClampMultilingualCount_DropsNegativeAndCapsTheWireLimit()
+    {
+        await Assert.That(AuctionHouseRules.ClampMultilingualCount(-3)).IsEqualTo(0);
+        await Assert.That(AuctionHouseRules.ClampMultilingualCount(0)).IsEqualTo(0);
+        await Assert.That(AuctionHouseRules.ClampMultilingualCount(4)).IsEqualTo(4);
+        await Assert.That(AuctionHouseRules.ClampMultilingualCount(AuctionHouseRules.MultilingualItemIdLimit + 8))
+            .IsEqualTo(AuctionHouseRules.MultilingualItemIdLimit);
+    }
+
+    [Test]
+    public async Task ListingChargeRate_AppliesTheAccountDiscountOnce()
+    {
+        await Assert.That(AuctionHouseRules.ListingChargeRate(200, 0, 50)).IsEqualTo(100);
+        await Assert.That(AuctionHouseRules.ListingChargeRate(200, 1000, 50)).IsEqualTo(500);
+        await Assert.That(AuctionHouseRules.ListingChargeRate(200, 0, 0)).IsEqualTo(200);
+    }
+
+    [Test]
+    public async Task SaleChargeForLot_PrefersTheStoredListingRate()
+    {
+        var fees = new AuctionFeeSchedule();
+        await Assert.That(AuctionHouseRules.SaleChargeForLot(fees, 10_000, 100, 1000)).IsEqualTo(100);
+        await Assert.That(AuctionHouseRules.SaleChargeForLot(fees, 10_000, 0, 1000)).IsEqualTo(1_000);
+        await Assert.That(AuctionHouseRules.SaleChargeForLot(null, 10_000, 100, 0)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ReturnToHouseEscrow_PutsTheStackBackOnTheSeller()
+    {
+        var item = new Item(0) { OwnerId = 9, SlotType = SlotType.Mail, Count = 2 };
+        AuctionHouseRules.ReturnToHouseEscrow(item, 39);
+        await Assert.That(item.OwnerId).IsEqualTo(39u);
+        await Assert.That(item.SlotType).IsEqualTo(SlotType.Auction);
+        AuctionHouseRules.ReturnToHouseEscrow(null, 39);
+    }
+
+    [Test]
     public async Task Matches_FiltersSellerWorldKeywordGradeLevelAndPrice()
     {
         var lot = Lot("iron ore", 10, 2, 1, 2, 3, 500);

--- a/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionHouseRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionHouseRulesTests.cs
@@ -1,0 +1,280 @@
+using AAEmu.Game.Models.Game.Auction;
+using AAEmu.Game.Models.Game.Auction.Templates;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Auction;
+
+public class AuctionHouseRulesTests
+{
+    [Test]
+    public async Task HoursFor_MapsTheFourDurationBytes()
+    {
+        await Assert.That(AuctionHouseRules.HoursFor(AuctionDuration.AuctionDuration6Hours)).IsEqualTo(6);
+        await Assert.That(AuctionHouseRules.HoursFor(AuctionDuration.AuctionDuration12Hours)).IsEqualTo(12);
+        await Assert.That(AuctionHouseRules.HoursFor(AuctionDuration.AuctionDuration24Hours)).IsEqualTo(24);
+        await Assert.That(AuctionHouseRules.HoursFor(AuctionDuration.AuctionDuration48Hours)).IsEqualTo(48);
+        await Assert.That(AuctionHouseRules.IsValidDuration(AuctionDuration.AuctionDuration6Hours)).IsTrue();
+        await Assert.That(AuctionHouseRules.IsValidDuration((AuctionDuration)4)).IsFalse();
+    }
+
+    [Test]
+    public async Task PlayerHeldItem_ExcludesHouseAndMailEscrow()
+    {
+        var item = new Item(0) { Count = 1, SlotType = SlotType.Inventory };
+        await Assert.That(AuctionHouseRules.IsPlayerHeldItem(item)).IsTrue();
+        await Assert.That(AuctionHouseRules.IsEscrowSlot(SlotType.Inventory)).IsFalse();
+
+        item.SlotType = SlotType.Auction;
+        await Assert.That(AuctionHouseRules.IsPlayerHeldItem(item)).IsFalse();
+        await Assert.That(AuctionHouseRules.IsEscrowSlot(SlotType.Auction)).IsTrue();
+
+        item.SlotType = SlotType.Mail;
+        await Assert.That(AuctionHouseRules.IsPlayerHeldItem(item)).IsFalse();
+        await Assert.That(AuctionHouseRules.IsEscrowSlot(SlotType.Mail)).IsTrue();
+    }
+
+    [Test]
+    public async Task PricesAreListable_RejectsEmptyInvertedAndOverflowBuyout()
+    {
+        await Assert.That(AuctionHouseRules.PricesAreListable(0, 0)).IsFalse();
+        await Assert.That(AuctionHouseRules.PricesAreListable(-1, 100)).IsFalse();
+        await Assert.That(AuctionHouseRules.PricesAreListable(200, 100)).IsFalse();
+        await Assert.That(AuctionHouseRules.PricesAreListable(100, 0)).IsTrue();
+        await Assert.That(AuctionHouseRules.PricesAreListable(0, 100)).IsTrue();
+        await Assert.That(AuctionHouseRules.PricesAreListable(100, 100)).IsTrue();
+        await Assert.That(AuctionHouseRules.PricesAreListable(1, AuctionHouseRules.MaxEscrowCopper + 1)).IsFalse();
+    }
+
+    [Test]
+    public async Task BidCharge_TakesOnlyTheRaiseFromTheStandingBidder()
+    {
+        await Assert.That(AuctionHouseRules.TryGetBidCharge(150, 100, 100, 500, false, out var first, out var buyout)).IsTrue();
+        await Assert.That(first).IsEqualTo(150L);
+        await Assert.That(buyout).IsFalse();
+
+        await Assert.That(AuctionHouseRules.TryGetBidCharge(200, 100, 150, 500, true, out var raise, out _)).IsTrue();
+        await Assert.That(raise).IsEqualTo(50L);
+
+        await Assert.That(AuctionHouseRules.TryGetBidCharge(500, 100, 150, 500, true, out var selfBuy, out var selfBuyout)).IsTrue();
+        await Assert.That(selfBuy).IsEqualTo(350L);
+        await Assert.That(selfBuyout).IsTrue();
+
+        await Assert.That(AuctionHouseRules.TryGetBidCharge(500, 100, 150, 500, false, out var otherBuy, out var otherBuyout)).IsTrue();
+        await Assert.That(otherBuy).IsEqualTo(500L);
+        await Assert.That(otherBuyout).IsTrue();
+
+        await Assert.That(AuctionHouseRules.TryGetBidCharge(150, 100, 150, 500, false, out _, out _)).IsFalse();
+        await Assert.That(AuctionHouseRules.TryGetBidCharge(50, 100, 0, 500, false, out _, out _)).IsFalse();
+        await Assert.That(AuctionHouseRules.TryGetBidCharge(AuctionHouseRules.MaxEscrowCopper + 1, 1, 0, 0, false, out _, out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsOwnedInBag_RejectsOwnerZeroEvenWhenTheSlotLooksLikeInventory()
+    {
+        var item = new Item(0) { Count = 1, SlotType = SlotType.Inventory, OwnerId = 0 };
+        await Assert.That(AuctionHouseRules.IsOwnedInBag(item, 39)).IsFalse();
+
+        item.OwnerId = 39;
+        await Assert.That(AuctionHouseRules.IsOwnedInBag(item, 39)).IsTrue();
+        await Assert.That(AuctionHouseRules.IsOwnedInBag(item, 38)).IsFalse();
+
+        item.SlotType = SlotType.Bank;
+        await Assert.That(AuctionHouseRules.IsOwnedInBag(item, 39)).IsFalse();
+    }
+
+    [Test]
+    public async Task IsListableItem_RejectsBoundUccUnsellableAndEmptyStacks()
+    {
+        var template = new ItemTemplate { Sellable = true, BindType = ItemBindType.Normal };
+        var item = new Item(0) { Template = template, Count = 1 };
+        await Assert.That(AuctionHouseRules.IsListableItem(item)).IsTrue();
+
+        item.SetFlag(ItemFlag.SoulBound);
+        await Assert.That(AuctionHouseRules.IsListableItem(item)).IsFalse();
+        item.RemoveFlag(ItemFlag.SoulBound);
+
+        item.SetFlag(ItemFlag.HasUCC);
+        await Assert.That(AuctionHouseRules.IsListableItem(item)).IsFalse();
+        item.RemoveFlag(ItemFlag.HasUCC);
+
+        template.Sellable = false;
+        await Assert.That(AuctionHouseRules.IsListableItem(item)).IsFalse();
+        template.Sellable = true;
+
+        template.BindType = ItemBindType.BindOnPickup;
+        await Assert.That(AuctionHouseRules.IsListableItem(item)).IsFalse();
+        template.BindType = ItemBindType.BindOnAuctionWin;
+        await Assert.That(AuctionHouseRules.IsListableItem(item)).IsTrue();
+
+        item.Count = 0;
+        await Assert.That(AuctionHouseRules.IsListableItem(item)).IsFalse();
+        await Assert.That(AuctionHouseRules.IsHeldByHouse(item)).IsFalse();
+        item.Count = 1;
+        item.SlotType = SlotType.Auction;
+        await Assert.That(AuctionHouseRules.IsHeldByHouse(item)).IsTrue();
+    }
+
+    [Test]
+    public async Task ClampStacks_ForcesTheFullStackWhenPartialBuyIsOff()
+    {
+        await Assert.That(AuctionHouseRules.ClampStacks(20, 1, 5, false)).IsEqualTo((20, 20));
+        await Assert.That(AuctionHouseRules.ClampStacks(20, 3, 8, true)).IsEqualTo((3, 8));
+        await Assert.That(AuctionHouseRules.ClampStacks(5, 8, 1, true)).IsEqualTo((5, 5));
+    }
+
+    [Test]
+    public async Task Matches_FiltersSellerWorldKeywordGradeLevelAndPrice()
+    {
+        var lot = Lot("iron ore", 10, 2, 1, 2, 3, 500);
+        lot.ClientId = 77;
+        lot.WorldId = 1;
+
+        var search = new AuctionSearch
+        {
+            Keyword = "iron",
+            Grade = 2,
+            CategoryA = 1,
+            MinItemLevel = 5,
+            MaxItemLevel = 15,
+            MinPrice = 100,
+            MaxPrice = 1000,
+            ClientId = 77,
+            WorldId = 1
+        };
+
+        await Assert.That(AuctionHouseRules.Matches(lot, search, [], "iron ore")).IsTrue();
+
+        search.Keyword = "copper";
+        await Assert.That(AuctionHouseRules.Matches(lot, search, [], "iron ore")).IsFalse();
+
+        search.Keyword = "iron ore";
+        search.ExactMatch = true;
+        await Assert.That(AuctionHouseRules.Matches(lot, search, [], "Iron Ore")).IsTrue();
+
+        search.ClientId = 9;
+        await Assert.That(AuctionHouseRules.Matches(lot, search, [], "Iron Ore")).IsFalse();
+    }
+
+    [Test]
+    public async Task Matches_UsesTheMultilingualTemplateListWhenPresent()
+    {
+        var lot = Lot("iron ore", 10, 0, 0, 0, 0, 100);
+        lot.Item.TemplateId = 42;
+
+        await Assert.That(AuctionHouseRules.Matches(lot, new AuctionSearch(), [42, 7], "iron ore")).IsTrue();
+        await Assert.That(AuctionHouseRules.Matches(lot, new AuctionSearch(), [7], "iron ore")).IsFalse();
+    }
+
+    [Test]
+    public async Task Matches_KeepsIdHitsWhenTheTypedKeywordIsAnotherLanguage()
+    {
+        var lot = Lot("전문화 확장의 인장", 1, 0, 6, 18, 0, 100);
+        lot.Item.TemplateId = 29656;
+        lot.ClientId = 39;
+
+        var search = new AuctionSearch
+        {
+            Keyword = "博学之章",
+            ClientId = 39UL | (1UL << 32)
+        };
+
+        await Assert.That(AuctionHouseRules.Matches(lot, search, [29656], string.Empty)).IsTrue();
+        await Assert.That(AuctionHouseRules.Matches(lot, search, [7769], string.Empty)).IsFalse();
+    }
+
+    [Test]
+    public async Task Matches_KeywordOnlyFallsBackToTheTemplateName()
+    {
+        var lot = Lot("전문화 확장의 인장", 1, 0, 0, 0, 0, 100);
+        var search = new AuctionSearch { Keyword = "전문화" };
+
+        await Assert.That(AuctionHouseRules.Matches(lot, search, [], string.Empty)).IsTrue();
+        search.Keyword = "snow flake";
+        await Assert.That(AuctionHouseRules.Matches(lot, search, [], string.Empty)).IsFalse();
+    }
+
+    [Test]
+    public async Task Matches_KeywordOnlyHitsAnyLocalizedName()
+    {
+        var lot = Lot("전문화 확장의 인장", 1, 0, 0, 0, 0, 100);
+        lot.Item.TemplateId = 29656;
+        var names = new[] { "전문화 확장의 인장", "Specialization Snowflake", "博学之章" };
+
+        await Assert.That(AuctionHouseRules.Matches(lot, new AuctionSearch { Keyword = "博学之章" }, [], names)).IsTrue();
+        await Assert.That(AuctionHouseRules.Matches(lot, new AuctionSearch { Keyword = "Specialization Snowflake" }, [], names)).IsTrue();
+        await Assert.That(AuctionHouseRules.Matches(lot, new AuctionSearch { Keyword = "전문화" }, [], names)).IsTrue();
+        await Assert.That(AuctionHouseRules.Matches(lot, new AuctionSearch { Keyword = "snow flake" }, [], names)).IsFalse();
+        await Assert.That(AuctionHouseRules.Matches(lot, new AuctionSearch { Keyword = "Specialization" }, [], ["", "Specialization Snowflake"])).IsTrue();
+    }
+
+    [Test]
+    public async Task Sort_ExpireDateUsesEndTimeNotPostDate()
+    {
+        var early = Lot("a", 1, 0, 0, 0, 0, 1);
+        early.Id = 2;
+        early.EndTime = DateTime.UtcNow.AddHours(1);
+        var late = Lot("b", 1, 0, 0, 0, 0, 1);
+        late.Id = 1;
+        late.EndTime = DateTime.UtcNow.AddHours(5);
+
+        var ordered = AuctionHouseRules.Sort([late, early], AuctionSearchSortKind.ExpireDate, AuctionSearchSortOrder.Asc).ToList();
+        await Assert.That(ordered[0].Id).IsEqualTo(2ul);
+        await Assert.That(ordered[1].Id).IsEqualTo(1ul);
+    }
+
+    [Test]
+    public async Task Page_ReturnsNineLotsAndAnEmptyOutOfRangePage()
+    {
+        var lots = Enumerable.Range(0, 20).Select(i =>
+        {
+            var lot = Lot("x", 1, 0, 0, 0, 0, 1);
+            lot.Id = (ulong)i;
+            return lot;
+        }).ToList();
+
+        var page0 = AuctionHouseRules.Page(lots, 0);
+        var page1 = AuctionHouseRules.Page(lots, 1);
+        var page2 = AuctionHouseRules.Page(lots, 2);
+
+        await Assert.That(page0.Count).IsEqualTo(9);
+        await Assert.That(page0[0].Id).IsEqualTo(0ul);
+        await Assert.That(page1.Count).IsEqualTo(9);
+        await Assert.That(page1[0].Id).IsEqualTo(9ul);
+        await Assert.That(page2.Count).IsEqualTo(2);
+        await Assert.That(AuctionHouseRules.Page(lots, 3)).IsEmpty();
+    }
+
+    [Test]
+    public async Task SoulBoundAndUcc_FollowItemFlags()
+    {
+        var item = new Item(0);
+        await Assert.That(AuctionHouseRules.IsSoulBound(item)).IsFalse();
+        item.SetFlag(ItemFlag.SoulBound);
+        await Assert.That(AuctionHouseRules.IsSoulBound(item)).IsTrue();
+        item.SetFlag(ItemFlag.HasUCC);
+        await Assert.That(AuctionHouseRules.HasUcc(item)).IsTrue();
+    }
+
+    private static AuctionLot Lot(string name, int level, byte grade, int a, int b, int c, long buyout)
+    {
+        var template = new ItemTemplate
+        {
+            Id = 1,
+            Name = name,
+            Level = level,
+            AuctionSettings = new AuctionSettings(a, b, c, 0, true)
+        };
+        return new AuctionLot
+        {
+            Item = new Item(0)
+            {
+                TemplateId = template.Id,
+                Template = template,
+                Grade = grade,
+                Count = 1
+            },
+            DirectMoney = buyout
+        };
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionSoldRecordRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Auction/AuctionSoldRecordRulesTests.cs
@@ -1,0 +1,30 @@
+using AAEmu.Game.Models.Game.Auction;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Auction;
+
+public class AuctionSoldRecordRulesTests
+{
+    [Test]
+    public async Task BuildDays_AlwaysReturnsFourteenRowsAndKeepsTheLatestUnitPrice()
+    {
+        var now = new DateTime(2026, 9, 5, 12, 0, 0, DateTimeKind.Utc);
+        var sales = new[]
+        {
+            new AuctionSale(10, 2, now.AddHours(-2), 400, 2),
+            new AuctionSale(10, 2, now.AddHours(-1), 900, 3),
+            new AuctionSale(10, 2, now.AddDays(-3), 100, 1),
+            new AuctionSale(11, 2, now, 50, 1)
+        };
+
+        var days = AuctionSoldRecordRules.BuildDays(sales, 10, 2, now);
+        await Assert.That(days.Count).IsEqualTo(14);
+        await Assert.That(days[0].Volume).IsEqualTo(5);
+        await Assert.That(days[0].MinPrice).IsEqualTo(200);
+        await Assert.That(days[0].MaxPrice).IsEqualTo(300);
+        await Assert.That(days[0].LastPrice).IsEqualTo(300);
+        await Assert.That(days[0].AveragePrice).IsEqualTo((200L * 2 + 300L * 3) / 5);
+        await Assert.That(days[3].Volume).IsEqualTo(1);
+        await Assert.That(days[3].LastPrice).IsEqualTo(100);
+        await Assert.That(days[1].Volume).IsEqualTo(0);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Features/FeaturesConfigTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Features/FeaturesConfigTests.cs
@@ -61,8 +61,9 @@ public class FeaturesConfigTests
 
         await Assert.That(fset.ToString()).IsEqualTo(
             // All bits on except fset_7_2_unknown (snow), restriction/moderation/dev-security switches,
-            // and scalar bytes 1/8/10/26 (FeaturesManager fills those from level caps at boot).
-            "57 00 00 00 f4 9f 61 02 00 4e 00 fe bf cf 2d 00 00 ff bf " +
-            "f5 7f 9e b7 00 ec bf 00 d0 79 f2 02");
+            // aaPoint (bit 44), fset_24_7_unknown / fgt (bit 199), and scalar bytes 1/8/10/26
+            // (FeaturesManager fills those from level caps at boot).
+            "57 00 00 00 f4 8f 61 02 00 4e 00 fe bf cf 2d 00 00 ff bf " +
+            "f5 7f 9e b7 00 6c bf 00 d0 79 f2 02");
     }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/Items/ItemSplitRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Items/ItemSplitRulesTests.cs
@@ -1,0 +1,71 @@
+using AAEmu.Game.Models.Game.Auction;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.Items.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Items;
+
+public class ItemSplitRulesTests
+{
+    [Test]
+    public async Task IsSplitAmount_RejectsZeroFullAndOverdraw()
+    {
+        await Assert.That(ItemSplitRules.IsSplitAmount(101, 1)).IsTrue();
+        await Assert.That(ItemSplitRules.IsSplitAmount(101, 100)).IsTrue();
+        await Assert.That(ItemSplitRules.IsSplitAmount(101, 0)).IsFalse();
+        await Assert.That(ItemSplitRules.IsSplitAmount(101, 101)).IsFalse();
+        await Assert.That(ItemSplitRules.IsSplitAmount(101, 102)).IsFalse();
+        await Assert.That(ItemSplitRules.IsSplitAmount(1, 1)).IsFalse();
+        await Assert.That(ItemSplitRules.IsSplitAmount(0, 1)).IsFalse();
+    }
+
+    [Test]
+    public async Task ConservesCount_101Split1_Is100And1()
+    {
+        await Assert.That(ItemSplitRules.ConservesCount(101, 1, 100, 1)).IsTrue();
+        await Assert.That(ItemSplitRules.ConservesCount(101, 1, 101, 1)).IsFalse();
+        await Assert.That(ItemSplitRules.ConservesCount(101, 1, 100, 101)).IsFalse();
+        await Assert.That(ItemSplitRules.ConservesCount(101, 1, 99, 1)).IsFalse();
+    }
+
+    [Test]
+    public async Task PlaceNewStack_AssignsTheSourceOwner()
+    {
+        var dest = new Item(9, new ItemTemplate { Id = 29656 }, 1);
+        ItemSplitRules.PlaceNewStack(dest, 39, SlotType.Inventory, 4);
+
+        await Assert.That(dest.OwnerId).IsEqualTo(39u);
+        await Assert.That(dest.SlotType).IsEqualTo(SlotType.Inventory);
+        await Assert.That(dest.Slot).IsEqualTo(4);
+        await Assert.That(AuctionHouseRules.IsOwnedInBag(dest, 39)).IsTrue();
+        await Assert.That(AuctionHouseRules.IsOwnedInBag(dest, 0)).IsFalse();
+    }
+
+    [Test]
+    public async Task CopyStackFields_KeepsSoulBoundSoSplitCannotUnbind()
+    {
+        var source = new Item(1, new ItemTemplate { Id = 29656, Sellable = true }, 101);
+        source.SetFlag(ItemFlag.SoulBound);
+        source.ChargeCount = 3;
+        var dest = new Item(2, new ItemTemplate { Id = 29656, Sellable = true }, 1);
+
+        ItemSplitRules.CopyStackFields(source, dest);
+
+        await Assert.That(dest.HasFlag(ItemFlag.SoulBound)).IsTrue();
+        await Assert.That(dest.ChargeCount).IsEqualTo(3);
+        await Assert.That(AuctionHouseRules.IsListableItem(dest)).IsFalse();
+    }
+
+    [Test]
+    public async Task ReportTaskType_SplitUsesTheSplitReason()
+    {
+        await Assert.That(ItemSplitRules.ReportTaskType(true, ItemTaskType.SwapItems))
+            .IsEqualTo(ItemTaskType.Split);
+        await Assert.That(ItemSplitRules.ReportTaskType(true, ItemTaskType.Split))
+            .IsEqualTo(ItemTaskType.Split);
+        await Assert.That(ItemSplitRules.ReportTaskType(false, ItemTaskType.Split))
+            .IsEqualTo(ItemTaskType.SwapItems);
+        await Assert.That(ItemSplitRules.ReportTaskType(false, ItemTaskType.SwapItems))
+            .IsEqualTo(ItemTaskType.SwapItems);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/LocalizedTextSearchRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/LocalizedTextSearchRulesTests.cs
@@ -1,0 +1,62 @@
+using AAEmu.Game.Models.Game;
+
+namespace AAEmu.UnitTests.Game.Models.Game;
+
+public class LocalizedTextSearchRulesTests
+{
+    [Test]
+    public async Task LanguageColumns_KeepsLocaleCellsAndDropsTheRowKey()
+    {
+        var columns = LocalizedTextSearchRules.LanguageColumns(
+        [
+            "id", "tbl_name", "tbl_column_name", "idx",
+            "ko", "en_us", "zh_cn", "ja", "ru", "zh_tw",
+            "de", "fr", "th", "ind", "en_sg", "pt", "es",
+            "id"
+        ]);
+
+        await Assert.That(columns).IsEquivalentTo([
+            "ko", "en_us", "zh_cn", "ja", "ru", "zh_tw",
+            "de", "fr", "th", "ind", "en_sg", "pt", "es"
+        ]);
+        await Assert.That(LocalizedTextSearchRules.IsKeyColumn("id")).IsTrue();
+        await Assert.That(LocalizedTextSearchRules.IsKeyColumn("ko")).IsFalse();
+        await Assert.That(LocalizedTextSearchRules.LanguageColumns(null)).IsEmpty();
+        await Assert.That(LocalizedTextSearchRules.LanguageColumns(["", "idx", null])).IsEmpty();
+    }
+
+    [Test]
+    public async Task UniqueNames_SkipsEmptyDuplicateAndWhitespaceCells()
+    {
+        var names = LocalizedTextSearchRules.UniqueNames(
+        [
+            "전문화 확장의 인장",
+            "",
+            "  ",
+            null,
+            "Specialization Snowflake",
+            "Specialization Snowflake",
+            "博学之章"
+        ]);
+
+        await Assert.That(names).IsEquivalentTo([
+            "전문화 확장의 인장",
+            "Specialization Snowflake",
+            "博学之章"
+        ]);
+        await Assert.That(LocalizedTextSearchRules.UniqueNames(null)).IsEmpty();
+    }
+
+    [Test]
+    public async Task BuildSearchString_JoinsEveryLoadedLanguage()
+    {
+        var haystack = LocalizedTextSearchRules.BuildSearchString(
+            "전문화 확장의 인장",
+            ["Specialization Snowflake", "", "博学之章"]);
+
+        await Assert.That(haystack.Contains("전문화 확장의 인장", StringComparison.Ordinal)).IsTrue();
+        await Assert.That(haystack.Contains("specialization snowflake", StringComparison.Ordinal)).IsTrue();
+        await Assert.That(haystack.Contains("博学之章", StringComparison.Ordinal)).IsTrue();
+        await Assert.That(LocalizedTextSearchRules.BuildSearchString("iron ore", null)).IsEqualTo("iron ore");
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Mails/CountUnreadMailTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Mails/CountUnreadMailTests.cs
@@ -1,0 +1,59 @@
+using AAEmu.Game.Models.Game.Mails;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Mails;
+
+public class CountUnreadMailTests
+{
+    [Test]
+    public async Task UpdateReceived_Charged_LightsPortraitAndCommercial()
+    {
+        var count = new CountUnreadMail();
+
+        count.AddTotal(MailType.Charged);
+        count.UpdateReceived(MailType.Charged, 1);
+
+        await Assert.That(count.CommercialReceived).IsEqualTo(1);
+        await Assert.That(count.TotalCommercialReceived).IsEqualTo(1);
+        await Assert.That(count.Received).IsEqualTo(1);
+        await Assert.That(count.TotalReceived).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task UpdateReceived_Promotion_MatchesCharged()
+    {
+        var count = new CountUnreadMail();
+
+        count.AddTotal(MailType.Promotion);
+        count.UpdateReceived(MailType.Promotion, 1);
+
+        await Assert.That(count.CommercialReceived).IsEqualTo(1);
+        await Assert.That(count.Received).IsEqualTo(1);
+        await Assert.That(count.TotalReceived).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task UpdateReceived_NormalLetter_DoesNotTouchCommercial()
+    {
+        var count = new CountUnreadMail();
+
+        count.AddTotal(MailType.Normal);
+        count.UpdateReceived(MailType.Normal, 1);
+
+        await Assert.That(count.Received).IsEqualTo(1);
+        await Assert.That(count.TotalReceived).IsEqualTo(1);
+        await Assert.That(count.CommercialReceived).IsEqualTo(0);
+        await Assert.That(count.TotalCommercialReceived).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task UpdateReceived_ReadCharged_ClearsBothUnreadSlots()
+    {
+        var count = new CountUnreadMail();
+        count.UpdateReceived(MailType.Charged, 1);
+
+        count.UpdateReceived(MailType.Charged, -1);
+
+        await Assert.That(count.CommercialReceived).IsEqualTo(0);
+        await Assert.That(count.Received).IsEqualTo(0);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Mails/MailAttachmentLoadRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Mails/MailAttachmentLoadRulesTests.cs
@@ -1,0 +1,29 @@
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Mails;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Mails;
+
+public class MailAttachmentLoadRulesTests
+{
+    [Test]
+    public async Task CanReload_MailHeldItem_IsTrue()
+    {
+        var item = new Item(1) { SlotType = SlotType.Mail, Count = 4 };
+        await Assert.That(MailAttachmentLoadRules.CanReload(item)).IsTrue();
+    }
+
+    [Test]
+    public async Task CanReload_ClaimedInventoryItem_IsFalse()
+    {
+        var item = new Item(1) { SlotType = SlotType.Inventory, Count = 4 };
+        await Assert.That(MailAttachmentLoadRules.CanReload(item)).IsFalse();
+    }
+
+    [Test]
+    public async Task CanReload_MissingOrEmpty_IsFalse()
+    {
+        await Assert.That(MailAttachmentLoadRules.CanReload(null)).IsFalse();
+        await Assert.That(MailAttachmentLoadRules.CanReload(new Item(1) { SlotType = SlotType.Mail, Count = 0 }))
+            .IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Utils/Mocks/RecordingSaveManager.cs
+++ b/AAEmu.UnitTests/Utils/Mocks/RecordingSaveManager.cs
@@ -1,0 +1,35 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Tasks;
+
+namespace AAEmu.UnitTests.Utils.Mocks;
+
+/// <summary>
+/// Stands in for <see cref="ISaveManager"/> so a test can see what a forced save
+/// would have committed. <see cref="OnSave"/> runs at every <see cref="DoSave"/>
+/// and is where the test snapshots balances, bids and mail.
+/// </summary>
+public sealed class RecordingSaveManager : ISaveManager
+{
+    public int SaveCount { get; private set; }
+
+    public Action OnSave { get; set; }
+
+    public ShutdownTask ShutdownTask { get; set; }
+
+    public void Initialize()
+    {
+    }
+
+    public System.Threading.Tasks.Task StopAsync() => System.Threading.Tasks.Task.CompletedTask;
+
+    public void SaveTickStart()
+    {
+    }
+
+    public bool DoSave()
+    {
+        SaveCount++;
+        OnSave?.Invoke();
+        return true;
+    }
+}

--- a/AAEmu.UnitTests/Utils/Mocks/RecordingSaveManager.cs
+++ b/AAEmu.UnitTests/Utils/Mocks/RecordingSaveManager.cs
@@ -4,13 +4,20 @@ using AAEmu.Game.Models.Tasks;
 namespace AAEmu.UnitTests.Utils.Mocks;
 
 /// <summary>
-/// Stands in for <see cref="ISaveManager"/> so a test can see what a forced save
-/// would have committed. <see cref="OnSave"/> runs at every <see cref="DoSave"/>
-/// and is where the test snapshots balances, bids and mail.
+/// Stands in for <see cref="ISaveManager"/> so a test can see what a forced save would have
+/// committed. Mirrors the real manager's coordination: it takes <see cref="PersistenceGate"/>
+/// exclusively for the snapshot and answers false while another save is running.
+/// <see cref="OnSave"/> runs inside the snapshot and is where the test records balances, bids
+/// and mail.
 /// </summary>
 public sealed class RecordingSaveManager : ISaveManager
 {
+    private volatile bool _isSaving;
+
     public int SaveCount { get; private set; }
+
+    /// <summary>How many callers were answered false because a save was already running.</summary>
+    public int BusySkips { get; private set; }
 
     public Action OnSave { get; set; }
 
@@ -28,8 +35,24 @@ public sealed class RecordingSaveManager : ISaveManager
 
     public bool DoSave()
     {
-        SaveCount++;
-        OnSave?.Invoke();
-        return true;
+        if (_isSaving)
+        {
+            BusySkips++;
+            return false;
+        }
+
+        PersistenceGate.EnterSave();
+        try
+        {
+            _isSaving = true;
+            SaveCount++;
+            OnSave?.Invoke();
+            return true;
+        }
+        finally
+        {
+            _isSaving = false;
+            PersistenceGate.ExitSave();
+        }
     }
 }

--- a/AAEmu.UnitTests/Utils/Mocks/SequentialMailIdManager.cs
+++ b/AAEmu.UnitTests/Utils/Mocks/SequentialMailIdManager.cs
@@ -1,0 +1,41 @@
+using AAEmu.Game.Core.Managers.Id;
+
+namespace AAEmu.UnitTests.Utils.Mocks;
+
+/// <summary>
+/// Hands out mail ids in order from <see cref="FirstId"/> without touching MySQL, so a test
+/// can predict which id a given letter will take.
+/// </summary>
+public sealed class SequentialMailIdManager : IMailIdManager
+{
+    public const uint FirstId = 10_000;
+
+    private uint _next = FirstId;
+
+    /// <summary>Id the next <see cref="GetNextId()"/> call will return.</summary>
+    public uint Next => _next;
+
+    public void Load()
+    {
+    }
+
+    public bool Initialize(bool forceReset = false) => true;
+
+    public uint GetNextId() => _next++;
+
+    public uint[] GetNextId(int count)
+    {
+        var ids = new uint[count];
+        for (var i = 0; i < count; i++)
+            ids[i] = GetNextId();
+        return ids;
+    }
+
+    public void ReleaseId(uint usedObjectId)
+    {
+    }
+
+    public void ReleaseId(IEnumerable<uint> usedObjectIds)
+    {
+    }
+}

--- a/AAEmu.WorldServer/AAEmu.World/NLog.config
+++ b/AAEmu.WorldServer/AAEmu.World/NLog.config
@@ -20,9 +20,17 @@
               archiveNumbering="Date" archiveDateFormat="yyyy-MM-dd" archiveEvery="Day" maxArchiveFiles="9"
               layout="${date:format=HH\:mm\:ss} [${level:uppercase=true}] ${logger:shortName=true} - ${message} ${exception:format=tostring}"
               keepFileOpen="false" encoding="utf-8" concurrentWrites="false" deleteOldFileOnStartup="true" />
+      <target name="auction"
+              xsi:type="File"
+              fileName="${basedir}/Logs/auction.log"
+              archiveFileName="${basedir}/Logs/auction.{#}.log"
+              archiveNumbering="Date" archiveDateFormat="yyyy-MM-dd" archiveEvery="Day" maxArchiveFiles="14"
+              layout="${date:format=HH\:mm\:ss} [${level:uppercase=true}] ${logger:shortName=true} - ${message} ${exception:format=tostring}"
+              keepFileOpen="false" encoding="utf-8" concurrentWrites="false" deleteOldFileOnStartup="false" />
     </targets>
 
     <rules>
+      <logger name="AuctionHouse" minlevel="Info" writeTo="auction" />
       <logger name="*" minlevel="Debug" writeTo="console" />
       <logger name="*" minlevel="Error" writeTo="errors" />
       <logger name="*" minlevel="Trace" maxlevel="Warn" writeTo="file" />

--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -88,16 +88,38 @@ CREATE TABLE IF NOT EXISTS `auction_house` (
 	`world_id` TINYINT(4) NOT NULL,
 	`client_id` INT(11) NOT NULL,
 	`client_name` VARCHAR(45) NOT NULL COLLATE 'utf8mb4_general_ci',
-	`start_money` INT(11) NOT NULL,
-	`direct_money` INT(11) NOT NULL,
+	`start_money` BIGINT(20) NOT NULL,
+	`direct_money` BIGINT(20) NOT NULL,
+	`asked` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0,
+	`charge_percent` INT(11) NOT NULL DEFAULT 0,
+	`deposit_percent` INT(11) NOT NULL DEFAULT 0,
+	`service_kind` TINYINT(4) NOT NULL DEFAULT 0,
 	`bid_world_id` INT(11) NOT NULL,
 	`bidder_id` INT(11) NOT NULL,
 	`bidder_name` VARCHAR(45) NOT NULL COLLATE 'utf8mb4_general_ci',
-	`bid_money` INT(11) NOT NULL,
-	`extra` INT(11) NOT NULL,
+	`bid_money` BIGINT(20) NOT NULL,
+	`extra` BIGINT(20) NOT NULL,
+	`min_stack` INT(11) NOT NULL DEFAULT 1,
+	`max_stack` INT(11) NOT NULL DEFAULT 1,
 	PRIMARY KEY (`id`) USING BTREE
 )
 COMMENT='Listed AH Items'
+COLLATE='utf8mb4_general_ci'
+ENGINE=InnoDB
+ROW_FORMAT=DYNAMIC
+;
+
+CREATE TABLE IF NOT EXISTS `auction_sold_records` (
+	`id` BIGINT(20) NOT NULL AUTO_INCREMENT,
+	`item_template_id` INT UNSIGNED NOT NULL,
+	`item_grade` TINYINT UNSIGNED NOT NULL,
+	`sold_at` DATETIME NOT NULL,
+	`price` BIGINT(20) NOT NULL,
+	`stack` INT(11) NOT NULL,
+	PRIMARY KEY (`id`) USING BTREE,
+	INDEX `idx_sold_lookup` (`item_template_id`, `item_grade`, `sold_at`)
+)
+COMMENT='Auction house sold-price history'
 COLLATE='utf8mb4_general_ci'
 ENGINE=InnoDB
 ROW_FORMAT=DYNAMIC

--- a/SQL/updates/2026-09-05_aaemu_game_auction_house_10_0.sql
+++ b/SQL/updates/2026-09-05_aaemu_game_auction_house_10_0.sql
@@ -1,0 +1,32 @@
+-- Widen listing money to match the 10.0.2.13 s64 wire and keep sold-record history
+-- next to the same items/mail rows.
+
+ALTER TABLE `auction_house`
+	MODIFY COLUMN `start_money` BIGINT(20) NOT NULL,
+	MODIFY COLUMN `direct_money` BIGINT(20) NOT NULL,
+	MODIFY COLUMN `bid_money` BIGINT(20) NOT NULL,
+	MODIFY COLUMN `extra` BIGINT(20) NOT NULL;
+
+ALTER TABLE `auction_house`
+	ADD COLUMN `asked` BIGINT(20) UNSIGNED NOT NULL DEFAULT 0 AFTER `direct_money`,
+	ADD COLUMN `charge_percent` INT(11) NOT NULL DEFAULT 0 AFTER `asked`,
+	ADD COLUMN `deposit_percent` INT(11) NOT NULL DEFAULT 0 AFTER `charge_percent`,
+	ADD COLUMN `service_kind` TINYINT(4) NOT NULL DEFAULT 0 AFTER `deposit_percent`,
+	ADD COLUMN `min_stack` INT(11) NOT NULL DEFAULT 1 AFTER `extra`,
+	ADD COLUMN `max_stack` INT(11) NOT NULL DEFAULT 1 AFTER `min_stack`;
+
+CREATE TABLE IF NOT EXISTS `auction_sold_records` (
+	`id` BIGINT(20) NOT NULL AUTO_INCREMENT,
+	`item_template_id` INT UNSIGNED NOT NULL,
+	`item_grade` TINYINT UNSIGNED NOT NULL,
+	`sold_at` DATETIME NOT NULL,
+	`price` BIGINT(20) NOT NULL,
+	`stack` INT(11) NOT NULL,
+	PRIMARY KEY (`id`) USING BTREE,
+	INDEX `idx_sold_lookup` (`item_template_id`, `item_grade`, `sold_at`)
+)
+COMMENT='Auction house sold-price history'
+COLLATE='utf8mb4_general_ci'
+ENGINE=InnoDB
+ROW_FORMAT=DYNAMIC
+;


### PR DESCRIPTION
## Summary
- World owns the 10.0 item house: list, search, bid, cancel, lowest price, and sold history.
- Keyword search matches every `localized_texts` language column. The multilingual packet still resolves names to template ids on the client.
- Bag splits keep the new stack owned and report `ItemTaskType.Split`, so a listed stack is found in inventory.
- House escrow stays off player use/summon/destroy. Listing needs the auction-post account attribute. `aaPoint` is off so the house stays gold. `fset_24_7_unknown` is off so the `fgt` pack does not lock auction / encyclopedia / craft.
- Money columns widen to 64-bit. Sold records live in `auction_sold_records` next to items and mail.

## Test plan
- [ ] Apply `SQL/updates/2026-09-05_aaemu_game_auction_house_10_0.sql` (or a fresh `aaemu_game.sql`).
- [ ] Relog so `SCAccountAttributeConfig` / listing grant arrive.
- [ ] Split a stack, list the new stack without moving it or closing the bag.
- [ ] Search by English name and by another filled locale (client locale must match for the multilingual packet; keyword-only still matches any loaded language).
- [ ] Bid, cancel, and take sold/expired mail.
- [ ] Confirm a listed item cannot be destroyed, summoned, or used from escrow.
- [ ] `dotnet test AAEmu.UnitTests --treenode-filter "/*/*/*AuctionHouseRulesTests/*"` (plus AuctionFeeSchedule, AuctionSoldRecordRules, AuctionHousePacket, ItemSplitRules, LocalizedTextSearchRules, LocalizationManager, AccountAttributeConfigRules, MailAttachmentLoadRules, CountUnreadMail, FeaturesConfig, MailTests).
