### PR TITLE
fix(skills): assign default skills by race and gender

### DIFF
--- a/AAEmu.Game/Core/Managers/ISkillManager.cs
+++ b/AAEmu.Game/Core/Managers/ISkillManager.cs
@@ -1,4 +1,5 @@
-﻿using AAEmu.Game.Models.Game.Skills;
+﻿using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Buffs;
 using AAEmu.Game.Models.Game.Skills.Templates;
 
@@ -15,6 +16,7 @@ public interface ISkillManager : ILoadable
     List<BuffTriggerTemplate> GetBuffTriggerTemplates(uint buffId);
     List<CombatBuffTemplate> GetCombatBuffs(uint reqBuffId);
     List<DefaultSkill> GetDefaultSkills();
+    List<DefaultSkill> GetDefaultSkills(Race race, Gender gender);
     EffectTemplate GetEffectTemplate(uint id);
     EffectTemplate GetEffectTemplate(uint id, string type);
     List<SkillModifier> GetModifiersByOwnerId(uint id);
@@ -27,6 +29,7 @@ public interface ISkillManager : ILoadable
     List<SkillTemplate> GetStartAbilitySkills(AbilityType ability);
     bool IsCommonSkill(uint id);
     bool IsDefaultSkill(uint id);
+    bool IsDefaultSkill(uint id, Race race, Gender gender);
     // ushort NextId();
     // void ReleaseId(ushort id);
 }

--- a/AAEmu.Game/Core/Managers/SkillManager.cs
+++ b/AAEmu.Game/Core/Managers/SkillManager.cs
@@ -29,6 +29,8 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
     private Dictionary<uint, SkillTemplate> _skills = [];
     private readonly Dictionary<string, uint> _constSkillTypes = [];
     private Dictionary<uint, DefaultSkill> _defaultSkills = [];
+    private HashSet<uint> _raceAssignedDefaultSkillIds = [];
+    private Dictionary<(byte Race, byte Gender), HashSet<uint>> _defaultSkillIdsByRaceGender = [];
     private List<uint> _commonSkills = [];
     private Dictionary<AbilityType, List<SkillTemplate>> _startAbilitySkills = [];
     private Dictionary<uint, PassiveBuffTemplate> _passiveBuffs = [];
@@ -105,6 +107,14 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
         return _defaultSkills.ContainsKey(id);
     }
 
+    public bool IsDefaultSkill(uint id, Race race, Gender gender)
+    {
+        if (!_defaultSkills.ContainsKey(id))
+            return false;
+        _defaultSkillIdsByRaceGender.TryGetValue(((byte)race, (byte)gender), out var owned);
+        return DefaultSkillAssignRules.AppliesToCharacter(id, _raceAssignedDefaultSkillIds, owned);
+    }
+
     public bool IsCommonSkill(uint id)
     {
         return _commonSkills.Contains(id);
@@ -120,6 +130,13 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
     public List<DefaultSkill> GetDefaultSkills()
     {
         return [.. _defaultSkills.Values];
+    }
+
+    public List<DefaultSkill> GetDefaultSkills(Race race, Gender gender)
+    {
+        _defaultSkillIdsByRaceGender.TryGetValue(((byte)race, (byte)gender), out var owned);
+        return [.. _defaultSkills.Values.Where(skill =>
+            DefaultSkillAssignRules.AppliesToCharacter(skill.Template.Id, _raceAssignedDefaultSkillIds, owned))];
     }
 
     public BuffTemplate GetBuffTemplate(uint id)
@@ -270,6 +287,8 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
 
         _skills = [];
         _defaultSkills = [];
+        _raceAssignedDefaultSkillIds = [];
+        _defaultSkillIdsByRaceGender = [];
         _commonSkills = [];
         _startAbilitySkills = [];
         _passiveBuffs = [];
@@ -532,6 +551,35 @@ public class SkillManager(IAnimationManager animationManager, IPlotManager plotM
                             AddToSlot = reader.GetBoolean("add_to_slot", true)
                         };
                         _defaultSkills[skill.Template.Id] = skill; // 10.0.2.13 default_skills has duplicate skill_ids (e.g. 33984) -> overwrite, don't crash
+                    }
+                }
+            }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText =
+                    "SELECT ch.char_race_id, ch.char_gender_id, ds.skill_id " +
+                    "FROM character_default_skills cds " +
+                    "JOIN default_skills ds ON ds.id = cds.default_skill_id " +
+                    "JOIN characters ch ON ch.id = cds.character_id";
+                command.Prepare();
+                using (var sqliteReader = command.ExecuteReader())
+                using (var reader = new SQLiteWrapperReader(sqliteReader))
+                {
+                    while (reader.Read())
+                    {
+                        var skillId = (uint)reader.GetInt32("skill_id", 0);
+                        if (skillId == 0 || !_defaultSkills.ContainsKey(skillId))
+                            continue;
+                        var key = ((byte)reader.GetInt32("char_race_id", 0), (byte)reader.GetInt32("char_gender_id", 0));
+                        _raceAssignedDefaultSkillIds.Add(skillId);
+                        if (!_defaultSkillIdsByRaceGender.TryGetValue(key, out var owned))
+                        {
+                            owned = [];
+                            _defaultSkillIdsByRaceGender[key] = owned;
+                        }
+
+                        owned.Add(skillId);
                     }
                 }
             }

--- a/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/CharacterManager.cs
@@ -667,7 +667,7 @@ public class CharacterManager(
         character.Skills = new CharacterSkills(character);
         character.SkillActiveTypes = new CharacterSkillActiveTypes(character);
         character.HeirSkills = new CharacterHeirSkills(character);
-        foreach (var skill in skillManager.GetDefaultSkills())
+        foreach (var skill in skillManager.GetDefaultSkills(character.Race, character.Gender))
         {
             if (!skill.AddToSlot)
                 continue;

--- a/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
@@ -180,7 +180,7 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
             skill = Connection.ActiveChar.AutoAttackTask.Skill;
             skillResult = SkillResult.Success;
         }
-        else if (SkillManager.Instance.IsDefaultSkill(skillId) || SkillManager.Instance.IsCommonSkill(skillId) && skillCaster is not SkillItem)
+        else if (SkillManager.Instance.IsDefaultSkill(skillId, Connection.ActiveChar.Race, Connection.ActiveChar.Gender) || SkillManager.Instance.IsCommonSkill(skillId) && skillCaster is not SkillItem)
         {
             // Is it a common skill?
             skill = new Skill(SkillManager.Instance.GetSkillTemplate(skillId)); // TODO: переделать / rewrite ...

--- a/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
@@ -104,6 +104,16 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
             return;
         }
 
+        // Racial defaults live in character_default_skills. Gate them before the
+        // Zone-authority return so HandleZoneAuthorityCast cannot cast another race's kit.
+        if (!DefaultSkillAssignRules.AllowDefaultCast(
+                SkillManager.Instance.IsDefaultSkill(skillId),
+                SkillManager.Instance.IsDefaultSkill(skillId, activeCharacter.Race, activeCharacter.Gender)))
+        {
+            Logger.Warn("StartSkill rejected other-race default {0} for {1}", skillId, activeCharacter.Name);
+            return;
+        }
+
         var world = Connection.ActiveChar?.ParentWorld ?? WorldManager.Instance.GetWorld(WorldManager.DefaultInstanceId);
 
         Logger.Info($"StartSkill: Id {skillId}, flag {flag}, caster={skillCaster.ObjId}, target={skillCastTarget.ObjId}");

--- a/AAEmu.Game/Models/Game/Skills/DefaultSkillAssignRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/DefaultSkillAssignRules.cs
@@ -22,4 +22,11 @@ public static class DefaultSkillAssignRules
             return true;
         return skillIdsForThisRaceGender != null && skillIdsForThisRaceGender.Contains(skillId);
     }
+
+    /// <summary>
+    /// StartSkill may run a listed default only when it applies to this race/gender.
+    /// Skills that are not defaults (learned, items, mounts) are decided later.
+    /// </summary>
+    public static bool AllowDefaultCast(bool isListedDefault, bool appliesToThisRaceGender) =>
+        !isListedDefault || appliesToThisRaceGender;
 }

--- a/AAEmu.Game/Models/Game/Skills/DefaultSkillAssignRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/DefaultSkillAssignRules.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace AAEmu.Game.Models.Game.Skills;
+
+/// <summary>
+/// Which <c>default_skills</c> a character may receive or cast.
+/// Rows named by <c>character_default_skills</c> belong to one race/gender
+/// template; every other row is shared (basic attack, labor, and the rest).
+/// </summary>
+public static class DefaultSkillAssignRules
+{
+    /// <summary>
+    /// A skill listed on any character template is racial. An unlisted duplicate
+    /// row of the same skill id does not make that skill universal.
+    /// </summary>
+    public static bool AppliesToCharacter(
+        uint skillId,
+        IReadOnlySet<uint> raceAssignedSkillIds,
+        IReadOnlySet<uint> skillIdsForThisRaceGender)
+    {
+        if (raceAssignedSkillIds == null || !raceAssignedSkillIds.Contains(skillId))
+            return true;
+        return skillIdsForThisRaceGender != null && skillIdsForThisRaceGender.Contains(skillId);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Managers/SkillManagerTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Managers/SkillManagerTests.cs
@@ -358,6 +358,36 @@ public class SkillManagerTests
         await Assert.That(result.Count).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task GetDefaultSkills_ForRace_DropsTheOtherRacesRacial()
+    {
+        var manager = new SkillManager(Mock.Of<IAnimationManager>().Object, Mock.Of<IPlotManager>().Object);
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        typeof(SkillManager).GetField("_defaultSkills", flags)?.SetValue(manager, new Dictionary<uint, DefaultSkill>
+        {
+            { 2, new DefaultSkill { Template = new SkillTemplate { Id = 2 }, Slot = 13, AddToSlot = true } },
+            { 35420, new DefaultSkill { Template = new SkillTemplate { Id = 35420 }, Slot = 17, AddToSlot = true } },
+            { 35423, new DefaultSkill { Template = new SkillTemplate { Id = 35423 }, Slot = 17, AddToSlot = true } }
+        });
+        typeof(SkillManager).GetField("_raceAssignedDefaultSkillIds", flags)
+            ?.SetValue(manager, new HashSet<uint> { 35420, 35423 });
+        typeof(SkillManager).GetField("_defaultSkillIdsByRaceGender", flags)?.SetValue(manager,
+            new Dictionary<(byte Race, byte Gender), HashSet<uint>>
+            {
+                { ((byte)Race.Nuian, (byte)Gender.Male), [35420] },
+                { ((byte)Race.Hariharan, (byte)Gender.Male), [35423] }
+            });
+
+        var nuian = manager.GetDefaultSkills(Race.Nuian, Gender.Male);
+        var hariharan = manager.GetDefaultSkills(Race.Hariharan, Gender.Male);
+
+        await Assert.That(nuian.Select(s => s.Template.Id).ToHashSet().SetEquals([2u, 35420u])).IsTrue();
+        await Assert.That(hariharan.Select(s => s.Template.Id).ToHashSet().SetEquals([2u, 35423u])).IsTrue();
+        await Assert.That(manager.IsDefaultSkill(35420, Race.Nuian, Gender.Male)).IsTrue();
+        await Assert.That(manager.IsDefaultSkill(35423, Race.Nuian, Gender.Male)).IsFalse();
+        await Assert.That(manager.IsDefaultSkill(2, Race.Nuian, Gender.Male)).IsTrue();
+    }
+
     #endregion
 
     #region GetModifiersByOwnerId Tests

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/DefaultSkillAssignRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/DefaultSkillAssignRulesTests.cs
@@ -1,0 +1,52 @@
+using AAEmu.Game.Models.Game.Skills;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills;
+
+public class DefaultSkillAssignRulesTests
+{
+    // Compact character_default_skills: Nuian 35420/35418, Hariharan 35423/35424.
+    private static readonly HashSet<uint> RaceAssigned =
+    [
+        35418, 35420, 35421, 35422, 35423, 35424, 35425, 35426, 35427, 35428, 33984, 33985
+    ];
+
+    private static readonly HashSet<uint> Nuian = [35420, 35418];
+    private static readonly HashSet<uint> Hariharan = [35423, 35424];
+
+    [Test]
+    public async Task SharedSkill_AppliesToEveryRace()
+    {
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(2, RaceAssigned, Nuian)).IsTrue();
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(2, RaceAssigned, Hariharan)).IsTrue();
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(2, RaceAssigned, new HashSet<uint>())).IsTrue();
+    }
+
+    [Test]
+    public async Task RacialSkill_StaysOnItsOwnRace()
+    {
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(35420, RaceAssigned, Nuian)).IsTrue();
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(35418, RaceAssigned, Nuian)).IsTrue();
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(35423, RaceAssigned, Nuian)).IsFalse();
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(35420, RaceAssigned, Hariharan)).IsFalse();
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(35423, RaceAssigned, Hariharan)).IsTrue();
+    }
+
+    [Test]
+    public async Task RaceWithoutTemplateRows_KeepsOnlySharedSkills()
+    {
+        // Fairy / Returned have no character_default_skills rows in compact.
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(2, RaceAssigned, null)).IsTrue();
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(35420, RaceAssigned, null)).IsFalse();
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(35420, RaceAssigned, new HashSet<uint>())).IsFalse();
+    }
+
+    [Test]
+    public async Task UnlistedDuplicateRow_DoesNotMakeARacialSkillUniversal()
+    {
+        // default_skills id 157 is 33984 with no character_default_skills row;
+        // id 156 is the same skill on Warborn. Assignment is by skill id.
+        var warborn = new HashSet<uint> { 33984, 35428 };
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(33984, RaceAssigned, warborn)).IsTrue();
+        await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(33984, RaceAssigned, Nuian)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/DefaultSkillAssignRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/DefaultSkillAssignRulesTests.cs
@@ -49,4 +49,20 @@ public class DefaultSkillAssignRulesTests
         await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(33984, RaceAssigned, warborn)).IsTrue();
         await Assert.That(DefaultSkillAssignRules.AppliesToCharacter(33984, RaceAssigned, Nuian)).IsFalse();
     }
+
+    [Test]
+    public async Task AllowDefaultCast_RejectsAnotherRacesRacialOnBothPaths()
+    {
+        await Assert.That(DefaultSkillAssignRules.AllowDefaultCast(false, false)).IsTrue();
+        await Assert.That(DefaultSkillAssignRules.AllowDefaultCast(true, true)).IsTrue();
+        await Assert.That(DefaultSkillAssignRules.AllowDefaultCast(
+            isListedDefault: true,
+            appliesToThisRaceGender: DefaultSkillAssignRules.AppliesToCharacter(35423, RaceAssigned, Nuian))).IsFalse();
+        await Assert.That(DefaultSkillAssignRules.AllowDefaultCast(
+            isListedDefault: true,
+            appliesToThisRaceGender: DefaultSkillAssignRules.AppliesToCharacter(2, RaceAssigned, Nuian))).IsTrue();
+        await Assert.That(DefaultSkillAssignRules.AllowDefaultCast(
+            isListedDefault: true,
+            appliesToThisRaceGender: DefaultSkillAssignRules.AppliesToCharacter(35420, RaceAssigned, null))).IsFalse();
+    }
 }


### PR DESCRIPTION
## Summary
- `character_default_skills` maps racial rows onto a race/gender character template. Shared rows (basic attack, labor) stay on every new character.
- Create no longer dumps every `default_skills` row onto the hotbar, so slots 17/18 are not overwritten by the last race in the table.
- `CSStartSkill` uses the same race/gender check. Fairy and Returned have no racial rows in the shipped compact and are not invented here.

## Test plan
- [ ] Create a Nuian and an Elf. Each should only get that race's racial defaults plus the shared skills.
- [ ] Existing characters keep saved slots; this is create-time only.
- [ ] `dotnet test AAEmu.UnitTests --treenode-filter "/*/*/*DefaultSkillAssignRulesTests/*"`
- [ ] `dotnet test AAEmu.UnitTests --treenode-filter "/*/*/*SkillManagerTests/*"`
