### PR TITLE
fix(skills): seed combat resources only for owned abilities

### DIFF
--- a/AAEmu.Game/GameData/CombatResourceGameData.cs
+++ b/AAEmu.Game/GameData/CombatResourceGameData.cs
@@ -1,5 +1,6 @@
 using AAEmu.Commons.Utils;
 using AAEmu.Game.GameData.Framework;
+using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Utils.DB;
 
 using Microsoft.Data.Sqlite;
@@ -84,36 +85,69 @@ public class CombatResourceGameData : Singleton<CombatResourceGameData>, IGameDa
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
 
     private Dictionary<int, CombatResource> _resources;
+    private Dictionary<int, HashSet<int>> _resourceIdsByAbility;
 
     public void Load(SqliteConnection connection)
     {
         _resources = [];
+        _resourceIdsByAbility = [];
 
-        using var command = connection.CreateCommand();
-        command.CommandText = "SELECT * FROM combat_resources";
-        command.Prepare();
-        using var sqliteReader = command.ExecuteReader();
-        using var reader = new SQLiteWrapperReader(sqliteReader);
-        while (reader.Read())
+        using (var command = connection.CreateCommand())
         {
-            var resource = new CombatResource
+            command.CommandText = "SELECT * FROM combat_resources";
+            command.Prepare();
+            using var sqliteReader = command.ExecuteReader();
+            using var reader = new SQLiteWrapperReader(sqliteReader);
+            while (reader.Read())
             {
-                Id = reader.GetInt32("id"),
-                Name = reader.GetString("name"),
-                Max = reader.GetInt32("max"),
-                DefaultPoint = reader.GetInt32("default_point"),
-                // Column is spelled "resouece_send_type_id" in the shipped schema.
-                SendTypeId = reader.GetInt32("resouece_send_type_id"),
-                RecoveryCycle = reader.GetInt32("recovery_cycle", 0),
-                PeaceRecoveryAmount = reader.GetInt32("peace_recovery_amount", 0),
-                CombatRecoveryAmount = reader.GetInt32("combat_recovery_amount", 0),
-                EtcRecoveryStateId = reader.GetInt32("etc_recovery_state_id", 1),
-                EtcRecoveryAmount = reader.GetInt32("etc_recovery_amount", 0),
-                BuffId = reader.GetUInt32("buff_id", 0),
-                BuffCondition = (CombatResourceBuffCondition)reader.GetInt32("resource_buff_condition_id", 1)
-            };
+                var resource = new CombatResource
+                {
+                    Id = reader.GetInt32("id"),
+                    Name = reader.GetString("name"),
+                    Max = reader.GetInt32("max"),
+                    DefaultPoint = reader.GetInt32("default_point"),
+                    // Column is spelled "resouece_send_type_id" in the shipped schema.
+                    SendTypeId = reader.GetInt32("resouece_send_type_id"),
+                    RecoveryCycle = reader.GetInt32("recovery_cycle", 0),
+                    PeaceRecoveryAmount = reader.GetInt32("peace_recovery_amount", 0),
+                    CombatRecoveryAmount = reader.GetInt32("combat_recovery_amount", 0),
+                    EtcRecoveryStateId = reader.GetInt32("etc_recovery_state_id", 1),
+                    EtcRecoveryAmount = reader.GetInt32("etc_recovery_amount", 0),
+                    BuffId = reader.GetUInt32("buff_id", 0),
+                    BuffCondition = (CombatResourceBuffCondition)reader.GetInt32("resource_buff_condition_id", 1)
+                };
 
-            _resources[resource.Id] = resource;
+                _resources[resource.Id] = resource;
+            }
+        }
+
+        using (var groupCommand = connection.CreateCommand())
+        {
+            groupCommand.CommandText =
+                "SELECT ability_id, combat_resource_1_id, combat_resource_2_id, " +
+                "change_combat_resource_1_id, change_combat_resource_2_id " +
+                "FROM combat_resource_groups";
+            groupCommand.Prepare();
+            using var sqliteReader = groupCommand.ExecuteReader();
+            using var reader = new SQLiteWrapperReader(sqliteReader);
+            while (reader.Read())
+            {
+                var abilityId = reader.GetInt32("ability_id", 0);
+                if (abilityId <= 0)
+                    continue;
+                if (!_resourceIdsByAbility.TryGetValue(abilityId, out var owned))
+                {
+                    owned = [];
+                    _resourceIdsByAbility[abilityId] = owned;
+                }
+
+                CombatResourceSeedRules.AddGroupResourceIds(
+                    owned,
+                    reader.GetInt32("combat_resource_1_id", 0),
+                    reader.GetInt32("combat_resource_2_id", 0),
+                    reader.GetInt32("change_combat_resource_1_id", 0),
+                    reader.GetInt32("change_combat_resource_2_id", 0));
+            }
         }
 
         Logger.Info("Loaded {0} combat resources", _resources.Count);
@@ -133,4 +167,22 @@ public class CombatResourceGameData : Singleton<CombatResourceGameData>, IGameDa
 
     /// <summary>Resources that start non-empty, so a unit only has to be seeded with those.</summary>
     public IEnumerable<CombatResource> WithDefaultPoint => All.Where(r => r.DefaultPoint > 0);
+
+    /// <summary>
+    /// Resource ids listed on <c>combat_resource_groups</c> for the given abilities,
+    /// including the change-resource columns (Death's brand sits there, not on column 1).
+    /// </summary>
+    public IReadOnlySet<int> ResourceIdsForAbilities(params int[] abilityIds)
+    {
+        var owned = new HashSet<int>();
+        if (_resourceIdsByAbility == null || abilityIds == null)
+            return owned;
+        foreach (var abilityId in abilityIds)
+        {
+            if (_resourceIdsByAbility.TryGetValue(abilityId, out var ids))
+                owned.UnionWith(ids);
+        }
+
+        return owned;
+    }
 }

--- a/AAEmu.Game/GameData/CombatResourceGameData.cs
+++ b/AAEmu.Game/GameData/CombatResourceGameData.cs
@@ -168,6 +168,28 @@ public class CombatResourceGameData : Singleton<CombatResourceGameData>, IGameDa
     /// <summary>Resources that start non-empty, so a unit only has to be seeded with those.</summary>
     public IEnumerable<CombatResource> WithDefaultPoint => All.Where(r => r.DefaultPoint > 0);
 
+    /// <summary>Replaces loaded tables so unit tests can drive seed/publish without SQLite.</summary>
+    internal void SeedForTests(
+        IEnumerable<CombatResource> resources,
+        IReadOnlyDictionary<int, HashSet<int>> resourceIdsByAbility)
+    {
+        _resources = [];
+        foreach (var resource in resources ?? [])
+            _resources[resource.Id] = resource;
+
+        _resourceIdsByAbility = [];
+        if (resourceIdsByAbility == null)
+            return;
+        foreach (var (abilityId, ids) in resourceIdsByAbility)
+            _resourceIdsByAbility[abilityId] = ids != null ? [..ids] : [];
+    }
+
+    internal void ClearForTests()
+    {
+        _resources = [];
+        _resourceIdsByAbility = [];
+    }
+
     /// <summary>
     /// Resource ids listed on <c>combat_resource_groups</c> for the given abilities,
     /// including the change-resource columns (Death's brand sits there, not on column 1).

--- a/AAEmu.Game/Models/Game/Char/CharacterAbilities.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterAbilities.cs
@@ -180,6 +180,8 @@ public class CharacterAbilities
             foreach (var template in SkillManager.Instance.GetStartAbilitySkills(abilityId))
                 Owner.Skills.AddSkill(template, 1, true);
         }
+
+        Owner.InitializeCombatResources();
     }
 
     public void Load(MySqlConnection connection)

--- a/AAEmu.Game/Models/Game/Char/CharacterAbilities.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterAbilities.cs
@@ -13,6 +13,9 @@ public class CharacterAbilities
     public Dictionary<AbilityType, Ability> Abilities { get; set; }
     public Character Owner { get; set; }
 
+    /// <summary>When true, <see cref="Swap"/> skips the gold charge so unit tests can exercise the kit change.</summary>
+    internal bool BypassSwapChargeForTests { get; set; }
+
     public CharacterAbilities(Character owner)
     {
         Owner = owner;
@@ -105,7 +108,7 @@ public class CharacterAbilities
             return;
         }
 
-        if (!AbilityChangeCosts.TryChargeSwapAbility(Owner))
+        if (!BypassSwapChargeForTests && !AbilityChangeCosts.TryChargeSwapAbility(Owner))
             return;
 
         // 0x147 reports every slot's before/after pair, so snapshot all three before mutating.
@@ -181,7 +184,7 @@ public class CharacterAbilities
                 Owner.Skills.AddSkill(template, 1, true);
         }
 
-        Owner.InitializeCombatResources();
+        Owner.SyncCombatResourcesAfterAbilityChange();
     }
 
     public void Load(MySqlConnection connection)

--- a/AAEmu.Game/Models/Game/Char/CharacterAbilitySets.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterAbilitySets.cs
@@ -296,7 +296,7 @@ public sealed class CharacterAbilitySets(Character owner)
         if (!triadUnchanged)
         {
             Owner.BroadcastPacket(new SCAbilitySwappedPacket(Owner.ObjId, before, after), true);
-            Owner.InitializeCombatResources();
+            Owner.SyncCombatResourcesAfterAbilityChange();
         }
         SendUpdated(AbilitySetResponseType.Changed, slot);
         Logger.Info(

--- a/AAEmu.Game/Models/Game/Char/CharacterAbilitySets.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterAbilitySets.cs
@@ -294,7 +294,10 @@ public sealed class CharacterAbilitySets(Character owner)
         // Same-triad restores skip 0x147 — trees did not change; Changed alone drives the
         // client rebuild from the saved slot snapshot.
         if (!triadUnchanged)
+        {
             Owner.BroadcastPacket(new SCAbilitySwappedPacket(Owner.ObjId, before, after), true);
+            Owner.InitializeCombatResources();
+        }
         SendUpdated(AbilitySetResponseType.Changed, slot);
         Logger.Info(
             "AbilitySet activate {0}: slot {1} {2}/{3}/{4} → {5}/{6}/{7} (skills={8}, triadUnchanged={9})",

--- a/AAEmu.Game/Models/Game/Skills/CombatResourceSeedRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/CombatResourceSeedRules.cs
@@ -26,6 +26,19 @@ public static class CombatResourceSeedRules
     public static bool ShouldSeed(int resourceId, IReadOnlySet<int> ownedResourceIds) =>
         ownedResourceIds != null && ownedResourceIds.Contains(resourceId);
 
+    /// <summary>
+    /// Login writes the default. A later swap must not reset a pool the
+    /// character still owns and has already been using.
+    /// </summary>
+    public static bool ShouldWriteDefault(int resourceId, IReadOnlySet<int> ownedResourceIds, bool alreadyHeld)
+    {
+        if (alreadyHeld)
+            return false;
+        if (ownedResourceIds == null)
+            return true;
+        return ShouldSeed(resourceId, ownedResourceIds);
+    }
+
     public static bool ShouldDrop(int resourceId, IReadOnlySet<int> ownedResourceIds) =>
         ownedResourceIds != null && !ownedResourceIds.Contains(resourceId);
 

--- a/AAEmu.Game/Models/Game/Skills/CombatResourceSeedRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/CombatResourceSeedRules.cs
@@ -26,6 +26,28 @@ public static class CombatResourceSeedRules
     public static bool ShouldSeed(int resourceId, IReadOnlySet<int> ownedResourceIds) =>
         ownedResourceIds != null && ownedResourceIds.Contains(resourceId);
 
+    public static bool ShouldDrop(int resourceId, IReadOnlySet<int> ownedResourceIds) =>
+        ownedResourceIds != null && !ownedResourceIds.Contains(resourceId);
+
+    /// <summary>
+    /// Pools to clear when the current abilities no longer own them (Pleasure
+    /// or Death's brand leftover after a swap).
+    /// </summary>
+    public static IReadOnlyList<int> HeldToDrop(IEnumerable<int> heldIds, IReadOnlySet<int> ownedResourceIds)
+    {
+        if (ownedResourceIds == null || heldIds == null)
+            return [];
+
+        List<int> drop = null;
+        foreach (var id in heldIds)
+        {
+            if (ShouldDrop(id, ownedResourceIds))
+                (drop ??= []).Add(id);
+        }
+
+        return drop ?? [];
+    }
+
     private static void Add(ISet<int> owned, int id)
     {
         if (owned != null && id > 0)

--- a/AAEmu.Game/Models/Game/Skills/CombatResourceSeedRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/CombatResourceSeedRules.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace AAEmu.Game.Models.Game.Skills;
+
+/// <summary>
+/// <c>combat_resources.default_point</c> is seeded only for resources the unit
+/// owns through <c>combat_resource_groups</c> on its current abilities.
+/// Pleasure (26 / 27) and Death's brand (6) share that table; they are not
+/// starter pools for every class.
+/// </summary>
+public static class CombatResourceSeedRules
+{
+    public static void AddGroupResourceIds(
+        ISet<int> owned,
+        int resource1Id,
+        int resource2Id,
+        int change1Id,
+        int change2Id)
+    {
+        Add(owned, resource1Id);
+        Add(owned, resource2Id);
+        Add(owned, change1Id);
+        Add(owned, change2Id);
+    }
+
+    public static bool ShouldSeed(int resourceId, IReadOnlySet<int> ownedResourceIds) =>
+        ownedResourceIds != null && ownedResourceIds.Contains(resourceId);
+
+    private static void Add(ISet<int> owned, int id)
+    {
+        if (owned != null && id > 0)
+            owned.Add(id);
+    }
+}

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -357,7 +357,8 @@ public class Unit : BaseUnit, IUnit
 
         foreach (var resource in CombatResourceGameData.Instance.WithDefaultPoint)
         {
-            if (owned != null && !CombatResourceSeedRules.ShouldSeed(resource.Id, owned))
+            if (!CombatResourceSeedRules.ShouldWriteDefault(
+                    resource.Id, owned, CombatResources.ContainsKey(resource.Id)))
                 continue;
             CombatResources[resource.Id] = resource.Max > 0
                 ? Math.Min(resource.DefaultPoint, resource.Max)

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -352,6 +352,9 @@ public class Unit : BaseUnit, IUnit
             owned = CombatResourceGameData.Instance.ResourceIdsForAbilities(
                 (int)character.Ability1, (int)character.Ability2, (int)character.Ability3);
 
+        foreach (var id in CombatResourceSeedRules.HeldToDrop(CombatResources.Keys, owned))
+            DropCombatResource(id);
+
         foreach (var resource in CombatResourceGameData.Instance.WithDefaultPoint)
         {
             if (owned != null && !CombatResourceSeedRules.ShouldSeed(resource.Id, owned))
@@ -362,6 +365,16 @@ public class Unit : BaseUnit, IUnit
             ArmCombatResourceDecay(resource.Id, CombatResources[resource.Id], restart: true);
             SyncCombatResourceBuff(resource.Id, CombatResources[resource.Id]);
         }
+    }
+
+    private void DropCombatResource(int resourceId)
+    {
+        CombatResources.Remove(resourceId);
+        _combatResourceDecayAt.Remove(resourceId);
+        SyncCombatResourceBuff(resourceId, 0);
+        var resource = CombatResourceGameData.Instance.Get(resourceId);
+        if (resource != null)
+            BroadcastCombatResource(resource, 0, updateTimeMs: 0);
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -341,13 +341,21 @@ public class Unit : BaseUnit, IUnit
     }
 
     /// <summary>
-    /// Seeds <c>combat_resources.default_point</c>. Called once when a unit enters the world — 죽음의 낙인
-    /// starts at 6 and 기쁨 / 슬픔 at 5, and until this ran every ability that reads them saw 0.
+    /// Seeds <c>combat_resources.default_point</c> for resources this unit owns.
+    /// Death's brand starts at 6 and Pleasure's joy/sorrow at 5; other classes must
+    /// not receive those pools or their bar buffs.
     /// </summary>
     public void InitializeCombatResources()
     {
+        IReadOnlySet<int> owned = null;
+        if (this is Character character)
+            owned = CombatResourceGameData.Instance.ResourceIdsForAbilities(
+                (int)character.Ability1, (int)character.Ability2, (int)character.Ability3);
+
         foreach (var resource in CombatResourceGameData.Instance.WithDefaultPoint)
         {
+            if (owned != null && !CombatResourceSeedRules.ShouldSeed(resource.Id, owned))
+                continue;
             CombatResources[resource.Id] = resource.Max > 0
                 ? Math.Min(resource.DefaultPoint, resource.Max)
                 : resource.DefaultPoint;

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -341,6 +341,17 @@ public class Unit : BaseUnit, IUnit
     }
 
     /// <summary>
+    /// After an ability swap or skillsaver activate: write newly owned defaults, then
+    /// publish every non-empty total. Login uses the same two steps. Held amounts and
+    /// decay timers stay as <see cref="InitializeCombatResources"/> left them.
+    /// </summary>
+    public void SyncCombatResourcesAfterAbilityChange()
+    {
+        InitializeCombatResources();
+        SendAllCombatResources();
+    }
+
+    /// <summary>
     /// Seeds <c>combat_resources.default_point</c> for resources this unit owns.
     /// Death's brand starts at 6 and Pleasure's joy/sorrow at 5; other classes must
     /// not receive those pools or their bar buffs.
@@ -489,6 +500,10 @@ public class Unit : BaseUnit, IUnit
         Buffs.RemoveBuff(resource.BuffId);
     }
 
+    internal List<(int Id, int Amount)> CombatResourcePointLog { get; private set; }
+
+    internal void StartCombatResourcePointLog() => CombatResourcePointLog = [];
+
     /// <summary>
     /// Pushes a resource total to whoever combat_resources.resouece_send_type_id says should see it
     /// (1 Self, 2 Broadcast).
@@ -497,6 +512,8 @@ public class Unit : BaseUnit, IUnit
     {
         if (resource == null)
             return;
+
+        CombatResourcePointLog?.Add((resource.Id, amount));
 
         var packet = new SCCombatResourcePointPacket(ObjId, resource.Id, (ulong)Math.Max(0, amount), updateTimeMs);
         if (resource.SendTypeId == 2)

--- a/AAEmu.UnitTests/Game/Models/Game/Char/CharacterCombatResourceAbilityChangeTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Char/CharacterCombatResourceAbilityChangeTests.cs
@@ -1,0 +1,159 @@
+using AAEmu.Game.GameData;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Char;
+
+/// <summary>
+/// Ability swap / skillsaver activate must publish newly seeded combat-resource
+/// totals (AAEmu#1554). Helper-only seed tests cannot catch a missing SendAll.
+/// </summary>
+[NotInParallel]
+public class CharacterCombatResourceAbilityChangeTests
+{
+    private const int FightResourceId = 1;
+    private const int JoyResourceId = 26;
+    private const int SorrowResourceId = 27;
+    private const int HeldFightAmount = 3;
+    private const int PleasureDefault = 5;
+
+    [After(Test)]
+    public void ClearCombatResourceTables() => CombatResourceGameData.Instance.ClearForTests();
+
+    [Test]
+    public async Task TryActivate_IntoPleasure_PublishesSeededTotalsAndKeepsHeldFight()
+    {
+        SeedFightAndPleasureTables();
+        var character = CreateCharacter(AbilityType.Fight, AbilityType.Illusion, AbilityType.Wild);
+        character.CombatResources[FightResourceId] = HeldFightAmount;
+        character.AbilitySets.SeedSlotForTests(new AbilitySetSlot
+        {
+            SlotIndex = 0,
+            Ability1 = AbilityType.Fight,
+            Ability2 = AbilityType.Illusion,
+            Ability3 = AbilityType.Pleasure
+        });
+        character.AbilitySets.BypassActivationChargeForTests = true;
+        character.StartCombatResourcePointLog();
+
+        await Assert.That(character.AbilitySets.TryActivate(0)).IsTrue();
+
+        await Assert.That(character.Ability3).IsEqualTo(AbilityType.Pleasure);
+        await Assert.That(character.GetCombatResource(FightResourceId)).IsEqualTo(HeldFightAmount);
+        await Assert.That(character.GetCombatResource(JoyResourceId)).IsEqualTo(PleasureDefault);
+        await Assert.That(character.GetCombatResource(SorrowResourceId)).IsEqualTo(PleasureDefault);
+        var published = LastPublished(character);
+        await Assert.That(published[JoyResourceId]).IsEqualTo(PleasureDefault);
+        await Assert.That(published[SorrowResourceId]).IsEqualTo(PleasureDefault);
+        await Assert.That(published[FightResourceId]).IsEqualTo(HeldFightAmount);
+    }
+
+    [Test]
+    public async Task TryActivate_SameTriad_DoesNotPublishCombatResources()
+    {
+        SeedFightAndPleasureTables();
+        var character = CreateCharacter(AbilityType.Fight, AbilityType.Illusion, AbilityType.Pleasure);
+        character.CombatResources[JoyResourceId] = PleasureDefault;
+        character.CombatResources[SorrowResourceId] = PleasureDefault;
+        character.AbilitySets.SeedSlotForTests(new AbilitySetSlot
+        {
+            SlotIndex = 0,
+            Ability1 = AbilityType.Fight,
+            Ability2 = AbilityType.Illusion,
+            Ability3 = AbilityType.Pleasure
+        });
+        character.AbilitySets.BypassActivationChargeForTests = true;
+        character.StartCombatResourcePointLog();
+
+        await Assert.That(character.AbilitySets.TryActivate(0)).IsTrue();
+        await Assert.That(character.CombatResourcePointLog).IsEmpty();
+        await Assert.That(character.GetCombatResource(JoyResourceId)).IsEqualTo(PleasureDefault);
+    }
+
+    [Test]
+    public async Task Swap_IntoPleasure_PublishesSeededTotalsAndKeepsHeldFight()
+    {
+        SeedFightAndPleasureTables();
+        var character = CreateCharacter(AbilityType.Fight, AbilityType.Illusion, AbilityType.Wild);
+        character.CombatResources[FightResourceId] = HeldFightAmount;
+        character.StartCombatResourcePointLog();
+
+        character.Abilities.Swap(AbilityType.Wild, AbilityType.Pleasure);
+
+        await Assert.That(character.Ability3).IsEqualTo(AbilityType.Pleasure);
+        await Assert.That(character.GetCombatResource(FightResourceId)).IsEqualTo(HeldFightAmount);
+        await Assert.That(character.GetCombatResource(JoyResourceId)).IsEqualTo(PleasureDefault);
+        await Assert.That(character.GetCombatResource(SorrowResourceId)).IsEqualTo(PleasureDefault);
+        var published = LastPublished(character);
+        await Assert.That(published[JoyResourceId]).IsEqualTo(PleasureDefault);
+        await Assert.That(published[SorrowResourceId]).IsEqualTo(PleasureDefault);
+        await Assert.That(published[FightResourceId]).IsEqualTo(HeldFightAmount);
+    }
+
+    [Test]
+    public async Task Swap_AwayFromPleasure_PublishesZerosForDroppedPools()
+    {
+        SeedFightAndPleasureTables();
+        var character = CreateCharacter(AbilityType.Fight, AbilityType.Illusion, AbilityType.Pleasure);
+        character.CombatResources[FightResourceId] = HeldFightAmount;
+        character.CombatResources[JoyResourceId] = PleasureDefault;
+        character.CombatResources[SorrowResourceId] = PleasureDefault;
+        character.StartCombatResourcePointLog();
+
+        character.Abilities.Swap(AbilityType.Pleasure, AbilityType.Wild);
+
+        await Assert.That(character.Ability3).IsEqualTo(AbilityType.Wild);
+        await Assert.That(character.GetCombatResource(JoyResourceId)).IsEqualTo(0);
+        await Assert.That(character.GetCombatResource(SorrowResourceId)).IsEqualTo(0);
+        await Assert.That(character.GetCombatResource(FightResourceId)).IsEqualTo(HeldFightAmount);
+        var published = LastPublished(character);
+        await Assert.That(published[JoyResourceId]).IsEqualTo(0);
+        await Assert.That(published[SorrowResourceId]).IsEqualTo(0);
+        await Assert.That(published[FightResourceId]).IsEqualTo(HeldFightAmount);
+    }
+
+    private static Character CreateCharacter(AbilityType ability1, AbilityType ability2, AbilityType ability3)
+    {
+        var character = new Character(new UnitCustomModelParams())
+        {
+            Id = 42,
+            Name = "CombatResourceSwap",
+            Level = 50,
+            Ability1 = ability1,
+            Ability2 = ability2,
+            Ability3 = ability3
+        };
+        character.Abilities = new CharacterAbilities(character);
+        character.Abilities.SetAbility(ability1, 0);
+        character.Abilities.SetAbility(ability2, 1);
+        character.Abilities.SetAbility(ability3, 2);
+        character.Skills = new CharacterSkills(character);
+        character.AbilitySets = new CharacterAbilitySets(character);
+        character.Abilities.BypassSwapChargeForTests = true;
+        return character;
+    }
+
+    private static void SeedFightAndPleasureTables()
+    {
+        CombatResourceGameData.Instance.SeedForTests(
+            [
+                new CombatResource { Id = FightResourceId, Name = "fight", Max = 5, DefaultPoint = 0, SendTypeId = 1 },
+                new CombatResource { Id = JoyResourceId, Name = "joy", Max = 5, DefaultPoint = PleasureDefault, SendTypeId = 1 },
+                new CombatResource { Id = SorrowResourceId, Name = "sorrow", Max = 5, DefaultPoint = PleasureDefault, SendTypeId = 1 }
+            ],
+            new Dictionary<int, HashSet<int>>
+            {
+                [(int)AbilityType.Fight] = [FightResourceId],
+                [(int)AbilityType.Pleasure] = [JoyResourceId, SorrowResourceId]
+            });
+    }
+
+    private static Dictionary<int, int> LastPublished(Character character)
+    {
+        var last = new Dictionary<int, int>();
+        foreach (var (id, amount) in character.CombatResourcePointLog)
+            last[id] = amount;
+        return last;
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/CombatResourceSeedRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/CombatResourceSeedRulesTests.cs
@@ -1,0 +1,46 @@
+using AAEmu.Game.Models.Game.Skills;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills;
+
+public class CombatResourceSeedRulesTests
+{
+    [Test]
+    public async Task AddGroupResourceIds_TakesBothColumnsAndChangeColumns()
+    {
+        var owned = new HashSet<int>();
+        CombatResourceSeedRules.AddGroupResourceIds(owned, 5, 0, 6, 0);
+        CombatResourceSeedRules.AddGroupResourceIds(owned, 26, 27, 0, 0);
+
+        await Assert.That(owned.SetEquals([5, 6, 26, 27])).IsTrue();
+    }
+
+    [Test]
+    public async Task AddGroupResourceIds_SkipsZeroAndNullOwner()
+    {
+        CombatResourceSeedRules.AddGroupResourceIds(null, 26, 27, 0, 0);
+
+        var owned = new HashSet<int>();
+        CombatResourceSeedRules.AddGroupResourceIds(owned, 0, 0, 0, 0);
+        await Assert.That(owned.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ShouldSeed_OnlyWhenTheAbilityOwnsTheResource()
+    {
+        var fight = new HashSet<int> { 1 };
+        var death = new HashSet<int> { 5, 6 };
+        var pleasure = new HashSet<int> { 26, 27 };
+
+        await Assert.That(CombatResourceSeedRules.ShouldSeed(26, fight)).IsFalse();
+        await Assert.That(CombatResourceSeedRules.ShouldSeed(27, fight)).IsFalse();
+        await Assert.That(CombatResourceSeedRules.ShouldSeed(6, fight)).IsFalse();
+
+        await Assert.That(CombatResourceSeedRules.ShouldSeed(6, death)).IsTrue();
+        await Assert.That(CombatResourceSeedRules.ShouldSeed(26, death)).IsFalse();
+
+        await Assert.That(CombatResourceSeedRules.ShouldSeed(26, pleasure)).IsTrue();
+        await Assert.That(CombatResourceSeedRules.ShouldSeed(27, pleasure)).IsTrue();
+        await Assert.That(CombatResourceSeedRules.ShouldSeed(6, pleasure)).IsFalse();
+        await Assert.That(CombatResourceSeedRules.ShouldSeed(26, null)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/CombatResourceSeedRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/CombatResourceSeedRulesTests.cs
@@ -61,4 +61,16 @@ public class CombatResourceSeedRulesTests
         await Assert.That(CombatResourceSeedRules.HeldToDrop(held, null)).IsEmpty();
         await Assert.That(CombatResourceSeedRules.HeldToDrop(null, fight)).IsEmpty();
     }
+
+    [Test]
+    public async Task ShouldWriteDefault_KeepsAHeldPoolOnTheUnchangedTree()
+    {
+        var fightAndDeath = new HashSet<int> { 1, 5, 6 };
+
+        await Assert.That(CombatResourceSeedRules.ShouldWriteDefault(6, fightAndDeath, alreadyHeld: true)).IsFalse();
+        await Assert.That(CombatResourceSeedRules.ShouldWriteDefault(26, fightAndDeath, alreadyHeld: false)).IsFalse();
+        await Assert.That(CombatResourceSeedRules.ShouldWriteDefault(6, fightAndDeath, alreadyHeld: false)).IsTrue();
+        await Assert.That(CombatResourceSeedRules.ShouldWriteDefault(26, null, alreadyHeld: false)).IsTrue();
+        await Assert.That(CombatResourceSeedRules.ShouldWriteDefault(26, null, alreadyHeld: true)).IsFalse();
+    }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/CombatResourceSeedRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/CombatResourceSeedRulesTests.cs
@@ -43,4 +43,22 @@ public class CombatResourceSeedRulesTests
         await Assert.That(CombatResourceSeedRules.ShouldSeed(6, pleasure)).IsFalse();
         await Assert.That(CombatResourceSeedRules.ShouldSeed(26, null)).IsFalse();
     }
+
+    [Test]
+    public async Task HeldToDrop_ClearsPleasureAndDeathWhenTheNewKitDoesNotOwnThem()
+    {
+        var fight = new HashSet<int> { 1 };
+        var pleasure = new HashSet<int> { 26, 27 };
+        var held = new[] { 1, 6, 26, 27 };
+
+        var dropFight = CombatResourceSeedRules.HeldToDrop(held, fight);
+        await Assert.That(dropFight.ToHashSet().SetEquals([6, 26, 27])).IsTrue();
+        await Assert.That(CombatResourceSeedRules.ShouldDrop(26, fight)).IsTrue();
+        await Assert.That(CombatResourceSeedRules.ShouldDrop(1, fight)).IsFalse();
+
+        var dropPleasure = CombatResourceSeedRules.HeldToDrop(held, pleasure);
+        await Assert.That(dropPleasure.ToHashSet().SetEquals([1, 6])).IsTrue();
+        await Assert.That(CombatResourceSeedRules.HeldToDrop(held, null)).IsEmpty();
+        await Assert.That(CombatResourceSeedRules.HeldToDrop(null, fight)).IsEmpty();
+    }
 }


### PR DESCRIPTION
## Summary
- `combat_resources.default_point` is seeded only for resources the unit owns through `combat_resource_groups` on its current abilities.
- Pleasure joy/sorrow (26/27) and Death's brand (6) are no longer given to every class on login. Spelldance still receives Pleasure.

## Test plan
- [ ] Log in a Spelldance: joy/sorrow seed and the Pleasure bar still appear.
- [ ] Log in a class that does not own those groups: no green-hand / brand pools.
- [ ] `dotnet test AAEmu.UnitTests --treenode-filter "/*/*/*CombatResourceSeedRulesTests/*"`
