### PR TITLE
fix(doodads): allow timer hops to revisit a looping phase

### DIFF
--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -770,13 +770,10 @@ public class Doodad : BaseUnit
         if (WorldIntegration.ZoneAuthority)
             WorldIntegration.RelayDoodadPhaseToZone?.Invoke(ObjId, FuncGroupId, Data);
 
-        if (!ListGroupId.Contains((uint)nextPhase))
+        if (!DoodadPhaseWalk.TryVisit(ListGroupId, (uint)nextPhase))
         {
-            ListGroupId.Add((uint)nextPhase); // to check CheckPhase()
-        }
-        else
-        {
-            // Cycle detected: always abort. (Previously empty funcs fell through and infinite-looped.)
+            // Same-walk cycle only. Timer hops begin a new walk in DoChangePhase so
+            // sit→fly→empty→land→sit can run again (town mailbox owl).
             if (caster is Character)
             {
                 Logger.Debug($"DoPhase: Finished execution with recurse: TemplateId {TemplateId}, Using phase {FuncGroupId}");
@@ -786,7 +783,6 @@ public class Doodad : BaseUnit
                 Logger.Trace($"DoPhase: Finished execution with recurse: TemplateId {TemplateId}, Using phase {FuncGroupId}");
             }
 
-            ListGroupId.Clear();
             return true;
         }
 
@@ -882,12 +878,21 @@ public class Doodad : BaseUnit
             Logger.Trace($"DoChangePhase: TemplateId {TemplateId}, ObjId {ObjId}, nextPhase {nextPhase}");
         }
 
-        var stop = DoPhaseFuncs(caster, ref nextPhase);
+        DoodadPhaseWalk.Begin(ListGroupId);
+        try
+        {
+            var stop = DoPhaseFuncs(caster, ref nextPhase);
 
-        // the phase change packet call must be after the phase functions to have the correct FuncGroupId in the packet
-        BroadcastPacket(new SCDoodadPhaseChangedPacket(this), true); // change the phase to display doodad
+            // the phase change packet call must be after the phase functions to have the correct FuncGroupId in the packet
+            BroadcastPacket(new SCDoodadPhaseChangedPacket(this), true); // change the phase to display doodad
 
-        return stop; // if true, it did not pass the check for the quest (it must be aborted)
+            return stop; // if true, it did not pass the check for the quest (it must be aborted)
+        }
+        finally
+        {
+            DoodadPhaseWalk.Begin(ListGroupId);
+            _phaseDepth = 0;
+        }
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -878,19 +878,21 @@ public class Doodad : BaseUnit
             Logger.Trace($"DoChangePhase: TemplateId {TemplateId}, ObjId {ObjId}, nextPhase {nextPhase}");
         }
 
-        DoodadPhaseWalk.Begin(ListGroupId);
+        var phase = nextPhase;
         try
         {
-            var stop = DoPhaseFuncs(caster, ref nextPhase);
+            return DoodadPhaseWalk.Run(ListGroupId, () =>
+            {
+                var stop = DoPhaseFuncs(caster, ref phase);
 
-            // the phase change packet call must be after the phase functions to have the correct FuncGroupId in the packet
-            BroadcastPacket(new SCDoodadPhaseChangedPacket(this), true); // change the phase to display doodad
+                // the phase change packet call must be after the phase functions to have the correct FuncGroupId in the packet
+                BroadcastPacket(new SCDoodadPhaseChangedPacket(this), true); // change the phase to display doodad
 
-            return stop; // if true, it did not pass the check for the quest (it must be aborted)
+                return stop; // if true, it did not pass the check for the quest (it must be aborted)
+            });
         }
         finally
         {
-            DoodadPhaseWalk.Begin(ListGroupId);
             _phaseDepth = 0;
         }
     }

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadPhaseWalk.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadPhaseWalk.cs
@@ -13,6 +13,23 @@ public static class DoodadPhaseWalk
         visited.Clear();
     }
 
+    /// <summary>
+    /// One <see cref="Doodad.DoChangePhase"/> walk: clear, run the hop, clear again
+    /// so the next timer hop can revisit a looping phase.
+    /// </summary>
+    public static T Run<T>(ICollection<uint> visited, Func<T> body)
+    {
+        Begin(visited);
+        try
+        {
+            return body();
+        }
+        finally
+        {
+            Begin(visited);
+        }
+    }
+
     /// <returns>
     /// <c>false</c> if <paramref name="phase"/> was already visited on this walk
     /// (caller must stop; the set is cleared).

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadPhaseWalk.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadPhaseWalk.cs
@@ -1,0 +1,31 @@
+namespace AAEmu.Game.Models.Game.DoodadObj;
+
+/// <summary>
+/// Visit set for one <see cref="Doodad.DoChangePhase"/> walk.
+/// Phase graphs may loop (town mailbox owl sit → fly → empty → land → sit).
+/// Cycle detection applies only inside that walk; a later timer hop is a new walk
+/// and may revisit a phase.
+/// </summary>
+public static class DoodadPhaseWalk
+{
+    public static void Begin(ICollection<uint> visited)
+    {
+        visited.Clear();
+    }
+
+    /// <returns>
+    /// <c>false</c> if <paramref name="phase"/> was already visited on this walk
+    /// (caller must stop; the set is cleared).
+    /// </returns>
+    public static bool TryVisit(ICollection<uint> visited, uint phase)
+    {
+        if (visited.Contains(phase))
+        {
+            visited.Clear();
+            return false;
+        }
+
+        visited.Add(phase);
+        return true;
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadPhaseWalkTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadPhaseWalkTests.cs
@@ -1,0 +1,49 @@
+using AAEmu.Game.Models.Game.DoodadObj;
+
+namespace AAEmu.UnitTests.Game.Models.Game.DoodadObj;
+
+public class DoodadPhaseWalkTests
+{
+    // Town mailbox doodad_almighties 320 (7496 is the same loop on 20492/20495/20498/20497).
+    private const uint Sit = 107;
+    private const uint FlyAway = 10991;
+    private const uint Empty = 10993;
+    private const uint Land = 10992;
+
+    [Test]
+    public async Task MailboxOwl_EachTimerHop_MayRevisitFlyAway()
+    {
+        var visited = new List<uint>();
+
+        foreach (var phase in new[] { Sit, FlyAway, Empty, Land, Sit })
+        {
+            DoodadPhaseWalk.Begin(visited);
+            await Assert.That(DoodadPhaseWalk.TryVisit(visited, phase)).IsTrue();
+        }
+
+        DoodadPhaseWalk.Begin(visited);
+        await Assert.That(DoodadPhaseWalk.TryVisit(visited, FlyAway)).IsTrue();
+    }
+
+    [Test]
+    public async Task MailboxOwl_PersistedVisitSet_BlocksSecondTakeoff()
+    {
+        var visited = new List<uint>();
+        DoodadPhaseWalk.Begin(visited);
+        await Assert.That(DoodadPhaseWalk.TryVisit(visited, Sit)).IsTrue();
+        DoodadPhaseWalk.Begin(visited);
+
+        foreach (var phase in new[] { FlyAway, Empty, Land, Sit })
+            await Assert.That(DoodadPhaseWalk.TryVisit(visited, phase)).IsTrue();
+
+        await Assert.That(DoodadPhaseWalk.TryVisit(visited, FlyAway)).IsFalse();
+    }
+
+    [Test]
+    public async Task SameWalk_RevisitAbortsAndClears()
+    {
+        var visited = new List<uint> { Sit };
+        await Assert.That(DoodadPhaseWalk.TryVisit(visited, Sit)).IsFalse();
+        await Assert.That(visited.Count).IsEqualTo(0);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadPhaseWalkTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadPhaseWalkTests.cs
@@ -11,18 +11,38 @@ public class DoodadPhaseWalkTests
     private const uint Land = 10992;
 
     [Test]
-    public async Task MailboxOwl_EachTimerHop_MayRevisitFlyAway()
+    public async Task ChangePhaseWalk_EachTimerHop_MayRevisitFlyAway()
     {
-        var visited = new List<uint>();
+        var visited = new List<uint> { Sit };
 
         foreach (var phase in new[] { Sit, FlyAway, Empty, Land, Sit })
         {
-            DoodadPhaseWalk.Begin(visited);
-            await Assert.That(DoodadPhaseWalk.TryVisit(visited, phase)).IsTrue();
+            var accepted = DoodadPhaseWalk.Run(visited, () => DoodadPhaseWalk.TryVisit(visited, phase));
+            await Assert.That(accepted).IsTrue();
+            await Assert.That(visited.Count).IsEqualTo(0);
         }
 
-        DoodadPhaseWalk.Begin(visited);
-        await Assert.That(DoodadPhaseWalk.TryVisit(visited, FlyAway)).IsTrue();
+        var again = DoodadPhaseWalk.Run(visited, () => DoodadPhaseWalk.TryVisit(visited, FlyAway));
+        await Assert.That(again).IsTrue();
+        await Assert.That(visited.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ChangePhaseWalk_ClearsEvenWhenTheHopThrows()
+    {
+        var visited = new List<uint> { Sit };
+        try
+        {
+            DoodadPhaseWalk.Run<int>(visited, () => throw new InvalidOperationException("hop"));
+            throw new Exception("expected hop throw");
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        await Assert.That(visited.Count).IsEqualTo(0);
+        var again = DoodadPhaseWalk.Run(visited, () => DoodadPhaseWalk.TryVisit(visited, FlyAway));
+        await Assert.That(again).IsTrue();
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Doodad phase cycle detection is per `DoChangePhase` walk instead of a lifetime visit set.
- Looping timer graphs (town mailbox owl sit → fly → empty → land → sit) can take off again. A revisit inside one walk still stops.

## Test plan
- [ ] Use a town mailbox and wait through at least two owl flights.
- [ ] `dotnet test AAEmu.UnitTests --treenode-filter "/*/*/*DoodadPhaseWalkTests/*"`
