### PR TITLE
fix(game): persist character UI settings

### DIFF
--- a/AAEmu.Commons/Utils/DB/MySQL.cs
+++ b/AAEmu.Commons/Utils/DB/MySQL.cs
@@ -49,7 +49,7 @@ public static class MySQL
             MinimumPoolSize = 0,
             MaximumPoolSize = 10,
             ConnectionLifeTime = 600,
-            CharacterSet = "utf8",
+            CharacterSet = "utf8mb4",
             AllowZeroDateTime = true,
             ConvertZeroDateTime = true,
             DefaultCommandTimeout = 180,

--- a/AAEmu.Game/Core/Packets/C2G/CSRequestUIDataPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRequestUIDataPacket.cs
@@ -1,6 +1,7 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -8,12 +9,23 @@ public class CSRequestUIDataPacket() : GamePacket(CSOffsets.CSRequestUIDataPacke
 {
     public override void Read(PacketStream stream)
     {
-        var uiDataType = stream.ReadUInt16();
-        var id = stream.ReadUInt32();
+        if (stream.LeftBytes != 10)
+        {
+            Logger.Warn("Rejected UI request: remainingBytes={0}", stream.LeftBytes);
+            return;
+        }
 
-        if (Connection.Characters.TryGetValue(id, out var value))
-            Connection.SendPacket(
-                new SCResponseUIDataPacket(id, uiDataType, value.GetOption(uiDataType))
-            );
+        var uiDataType = stream.ReadUInt16();
+        var id = stream.ReadUInt64();
+        if (!UiData.IsSupported(uiDataType) || id > uint.MaxValue ||
+            !Connection.Characters.TryGetValue((uint)id, out var character))
+        {
+            Logger.Warn("Rejected UI request: characterId={0}, type={1}", id, uiDataType);
+            return;
+        }
+
+        Logger.Debug("UI request: characterId={0}, type={1}, remainingBytes={2}",
+            id, uiDataType, stream.LeftBytes);
+        Connection.SendPacket(new SCResponseUIDataPacket((uint)id, uiDataType, character.GetOption(uiDataType)));
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSSaveUIDataPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSaveUIDataPacket.cs
@@ -1,5 +1,6 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Char;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -7,10 +8,33 @@ public class CSSaveUIDataPacket() : GamePacket(CSOffsets.CSSaveUIDataPacket, 1)
 {
     public override void Read(PacketStream stream)
     {
-        var uiDataType = stream.ReadUInt16();
-        var id = stream.ReadUInt32();
-        var data = stream.ReadString();
+        if (stream.LeftBytes < 12)
+        {
+            Logger.Warn("Rejected truncated UI save: remainingBytes={0}", stream.LeftBytes);
+            return;
+        }
 
-        Connection.ActiveChar.SetOption(uiDataType, data);
+        var uiDataType = stream.ReadUInt16();
+        var id = stream.ReadUInt64();
+        var length = stream.ReadUInt16();
+        if (!UiData.IsSupported(uiDataType) || id > uint.MaxValue ||
+            length > UiData.MaximumBytes || stream.LeftBytes != length ||
+            !Connection.Characters.TryGetValue((uint)id, out var character))
+        {
+            Logger.Warn("Rejected UI save: characterId={0}, type={1}, bytes={2}, remainingBytes={3}",
+                id, uiDataType, length, stream.LeftBytes);
+            return;
+        }
+
+        if (!UiData.TryDecode(stream.ReadBytes(length), out var data))
+        {
+            Logger.Warn("Rejected UI save text: characterId={0}, type={1}, bytes={2}",
+                id, uiDataType, length);
+            return;
+        }
+
+        var saved = character.TrySaveUiData(uiDataType, data);
+        Logger.Debug("UI save: characterId={0}, type={1}, bytes={2}, remainingBytes={3}, persisted={4}",
+            id, uiDataType, length, stream.LeftBytes, saved);
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCResponseUIDataPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCResponseUIDataPacket.cs
@@ -1,5 +1,6 @@
 using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Char;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
@@ -8,11 +9,23 @@ public class SCResponseUIDataPacket(uint characterId, ushort uiDataType, string 
 {
     public override PacketStream Write(PacketStream stream)
     {
-        // type(i64 charId) | uiDataType(u16) | uiData(length-prefixed string) | size(u32).
+        if (!UiData.IsSupported(uiDataType))
+            throw new ArgumentOutOfRangeException(nameof(uiDataType));
+
+        if (!UiData.TryEncode(uiData, out var bytes))
+        {
+            // Keep invalid persisted data intact; only send a safe empty response.
+            Logger.Warn("Invalid stored UI data: characterId={0}, type={1}; sending empty data",
+                characterId, uiDataType);
+        }
+
         stream.Write((ulong)characterId);
         stream.Write(uiDataType);
-        stream.Write(uiData);
-        stream.Write(uiData.Length + 1);
+        stream.Write((ushort)bytes.Length);
+        stream.Write(bytes, false);
+        stream.Write((uint)bytes.Length);
+        Logger.Debug("UI response: characterId={0}, type={1}, bytes={2}",
+            characterId, uiDataType, bytes.Length);
         return stream;
     }
 }

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -581,6 +581,9 @@ public partial class Character : Unit, ICharacter
     public uint CurrentPhysTime => PhysTimeAnchor + (uint)(Environment.TickCount64 - PhysTimeAnchorTick);
 
     private readonly Dictionary<ushort, string> _options;
+    private readonly object _optionsLock = new();
+    private readonly object _uiDataSaveLock = new();
+    private readonly ICharacterOptionStore _optionStore;
 
     public List<IDisposable> Subscribers { get; set; }
     public override CharacterEvents Events { get; } = new();
@@ -2084,9 +2087,10 @@ public partial class Character : Unit, ICharacter
     /// </summary>
     public DateTime LastPacketActivityTime { get; set; } = DateTime.UtcNow;
 
-    public Character(UnitCustomModelParams modelParams)
+    public Character(UnitCustomModelParams modelParams, ICharacterOptionStore optionStore = null)
     {
         _options = [];
+        _optionStore = optionStore ?? new CharacterOptionStore();
         _hostilePlayers = new ConcurrentDictionary<uint, DateTime>();
         Breath = LungCapacity;
         ModelParams = modelParams;
@@ -2952,14 +2956,44 @@ public partial class Character : Unit, ICharacter
 
     public void SetOption(ushort key, string value)
     {
-        _options[key] = value;
+        lock (_optionsLock)
+            _options[key] = value;
     }
 
     public string GetOption(ushort key)
     {
-        if (_options.TryGetValue(key, out var option))
-            return option;
-        return "";
+        lock (_optionsLock)
+            return _options.GetValueOrDefault(key, "");
+    }
+
+    public bool TrySaveUiData(ushort key, string value)
+    {
+        if (!UiData.IsSupported(key) || !UiData.TryEncode(value, out _))
+            return false;
+
+        // Order UI commits without blocking bulk snapshots while waiting for a database connection.
+        lock (_uiDataSaveLock)
+        {
+            try
+            {
+                _optionStore.Save(Id, key, value);
+                lock (_optionsLock)
+                    _options[key] = value;
+                return true;
+            }
+            catch (Exception exception)
+            {
+                Logger.Error(exception, "Failed to persist UI data: characterId={0}, type={1}", Id, key);
+                return false;
+            }
+        }
+    }
+
+    internal KeyValuePair<ushort, string>[] GetOptionsForSave()
+    {
+        // UI sections are committed independently; bulk saves must not replay stale snapshots.
+        lock (_optionsLock)
+            return _options.Where(pair => !UiData.IsSupported(pair.Key)).ToArray();
     }
 
     public void PushSubscriber(IDisposable disposable)
@@ -3818,7 +3852,7 @@ public partial class Character : Unit, ICharacter
                 command.Connection = connection;
                 command.Transaction = transaction;
 
-                foreach (var pair in _options)
+                foreach (var pair in GetOptionsForSave())
                 {
                     command.CommandText =
                         "REPLACE INTO `options` (`key`,`value`,`owner`) VALUES (@key,@value,@owner)";

--- a/AAEmu.Game/Models/Game/Char/CharacterOptionStore.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterOptionStore.cs
@@ -1,0 +1,24 @@
+using AAEmu.Commons.Utils.DB;
+
+namespace AAEmu.Game.Models.Game.Char;
+
+public interface ICharacterOptionStore
+{
+    void Save(uint characterId, ushort key, string value);
+}
+
+public sealed class CharacterOptionStore : ICharacterOptionStore
+{
+    public void Save(uint characterId, ushort key, string value)
+    {
+        using var connection = MySQL.CreateConnection();
+        using var command = connection.CreateCommand();
+        command.CommandText =
+            "INSERT INTO `options` (`owner`, `key`, `value`) VALUES (@owner, @key, @value) " +
+            "ON DUPLICATE KEY UPDATE `value` = @value";
+        command.Parameters.AddWithValue("@owner", characterId);
+        command.Parameters.AddWithValue("@key", key);
+        command.Parameters.AddWithValue("@value", value);
+        command.ExecuteNonQuery();
+    }
+}

--- a/AAEmu.Game/Models/Game/Char/UiData.cs
+++ b/AAEmu.Game/Models/Game/Char/UiData.cs
@@ -1,0 +1,48 @@
+using System.Text;
+
+namespace AAEmu.Game.Models.Game.Char;
+
+public static class UiData
+{
+    public const int MaximumBytes = 8191;
+
+    private static readonly UTF8Encoding Encoding = new(false, true);
+
+    public static bool IsSupported(ushort type) => type is >= 1 and <= 7 or 20;
+
+    public static bool TryDecode(byte[] bytes, out string value)
+    {
+        value = null;
+        if (bytes.Length > MaximumBytes || bytes.Contains((byte)0))
+            return false;
+
+        try
+        {
+            value = Encoding.GetString(bytes);
+            return true;
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+    }
+
+    public static bool TryEncode(string value, out byte[] bytes)
+    {
+        bytes = [];
+        if (value == null || value.Length > MaximumBytes || value.Contains('\0'))
+            return false;
+
+        try
+        {
+            if (Encoding.GetByteCount(value) > MaximumBytes)
+                return false;
+            bytes = Encoding.GetBytes(value);
+            return true;
+        }
+        catch (EncoderFallbackException)
+        {
+            return false;
+        }
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Packets/C2G/CSRequestUIDataPacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/C2G/CSRequestUIDataPacketTests.cs
@@ -1,0 +1,233 @@
+using System.Text;
+using AAEmu.Commons.Network;
+using AAEmu.Commons.Network.Core;
+using AAEmu.Game.Core.Network.Connections;
+using AAEmu.Game.Core.Packets.C2G;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Core.Packets.C2G;
+
+public class CSRequestUIDataPacketTests
+{
+    private readonly UiDataPacketTestStore _store = new();
+    private readonly List<byte[]> _sentPackets = [];
+    private readonly GameConnection _connection;
+    private readonly Character _character;
+    private readonly CSRequestUIDataPacket _packet;
+
+    public CSRequestUIDataPacketTests()
+    {
+        var session = Mock.Of<ISession>();
+        session.SendPacket(Any<byte[]>()).Callback((byte[] bytes) => _sentPackets.Add(bytes));
+        _connection = new GameConnection(session.Object);
+        _character = new Character(new UnitCustomModelParams(), _store) { Id = 42 };
+        _character.SetOption(7, "stored-value");
+        _connection.Characters.Add(_character.Id, _character);
+        _packet = new CSRequestUIDataPacket { Connection = _connection };
+    }
+
+    [Test]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    [Arguments(4)]
+    [Arguments(5)]
+    [Arguments(6)]
+    [Arguments(7)]
+    [Arguments(20)]
+    public async Task Read_UsesOwnedPacketCharacterWithNullActiveCharacter(int type)
+    {
+        var key = (ushort)type;
+        const string data = " \t{ \"unknown_test_field\" : \"\U0001F642\" }\r\n ";
+        _character.SetOption(key, data);
+        var stream = CreateBody(key, _character.Id);
+
+        _packet.Read(stream);
+
+        await Assert.That(_connection.ActiveChar).IsNull();
+        await Assert.That(stream.Count).IsEqualTo(10);
+        await Assert.That(stream.LeftBytes).IsEqualTo(0);
+        await AssertResponse(_character.Id, key, data);
+        await Assert.That(_character.GetOption(key)).IsEqualTo(data);
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Read_UsesOwnedNonactiveCharacterInsteadOfActiveCharacter()
+    {
+        var active = new Character(new UnitCustomModelParams(), _store) { Id = 43 };
+        active.SetOption(7, "active-value");
+        _connection.Characters.Add(active.Id, active);
+        _connection.ActiveChar = active;
+
+        _packet.Read(CreateBody(7, _character.Id));
+
+        await AssertResponse(_character.Id, 7, "stored-value");
+        await Assert.That(active.GetOption(7)).IsEqualTo("active-value");
+        await Assert.That(_character.GetOption(7)).IsEqualTo("stored-value");
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Read_IgnoresUnknownCharacterId()
+    {
+        _connection.ActiveChar = _character;
+
+        _packet.Read(CreateBody(7, 999));
+
+        await Assert.That(_sentPackets.Count).IsEqualTo(0);
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo("stored-value");
+    }
+
+    [Test]
+    public async Task Read_RejectsActiveCharacterAbsentFromOwnedCharacters()
+    {
+        _connection.ActiveChar = _character;
+        _connection.Characters.Clear();
+
+        _packet.Read(CreateBody(7, _character.Id));
+
+        await Assert.That(_sentPackets.Count).IsEqualTo(0);
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo("stored-value");
+    }
+
+    [Test]
+    [Arguments(4294967338UL)]
+    [Arguments(ulong.MaxValue)]
+    public async Task Read_Rejects64BitIdEvenWhenLowBitsAreOwned(ulong id)
+    {
+        _connection.Characters.Clear();
+        _character.Id = unchecked((uint)id);
+        _connection.Characters.Add(_character.Id, _character);
+        _connection.ActiveChar = _character;
+
+        _packet.Read(CreateBody(7, id));
+
+        await Assert.That(_sentPackets.Count).IsEqualTo(0);
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo("stored-value");
+    }
+
+    [Test]
+    public async Task Read_AcceptsUInt32MaxValueIn64BitIdField()
+    {
+        _connection.Characters.Clear();
+        _character.Id = uint.MaxValue;
+        _connection.Characters.Add(_character.Id, _character);
+
+        _packet.Read(CreateBody(7, _character.Id));
+
+        await AssertResponse(uint.MaxValue, 7, "stored-value");
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(8)]
+    [Arguments(19)]
+    [Arguments(21)]
+    [Arguments(65535)]
+    public async Task Read_RejectsUnsupportedType(int type)
+    {
+        var key = (ushort)type;
+        _character.SetOption(key, "unsupported-value");
+
+        _packet.Read(CreateBody(key, _character.Id));
+
+        await Assert.That(_sentPackets.Count).IsEqualTo(0);
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(key)).IsEqualTo("unsupported-value");
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(5)]
+    [Arguments(6)]
+    [Arguments(9)]
+    [Arguments(11)]
+    [Arguments(12)]
+    public async Task Read_RejectsTruncatedAndTrailingBodies(int length)
+    {
+        var bytes = CreateBody(7, _character.Id).GetBytes();
+        Array.Resize(ref bytes, length);
+
+        _packet.Read(new PacketStream(bytes));
+
+        await Assert.That(_sentPackets.Count).IsEqualTo(0);
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo("stored-value");
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Read_ReturnsEmptyForMissingOrEmptyOption(bool seedEmpty)
+    {
+        if (seedEmpty)
+            _character.SetOption(20, "");
+
+        _packet.Read(CreateBody(20, _character.Id));
+
+        await AssertResponse(_character.Id, 20, "");
+        await Assert.That(_character.GetOption(7)).IsEqualTo("stored-value");
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    [Arguments("nul")]
+    [Arguments("high-surrogate")]
+    [Arguments("low-surrogate")]
+    [Arguments("ascii-overflow")]
+    [Arguments("utf8-overflow")]
+    [Arguments("null")]
+    public async Task Read_ReturnsEmptyForInvalidPersistedDataWithoutChangingMemory(string kind)
+    {
+        var data = kind switch
+        {
+            "nul" => "before\0after",
+            "high-surrogate" => "before\uD800after",
+            "low-surrogate" => "before\uDC00after",
+            "ascii-overflow" => new string('x', 8192),
+            "utf8-overflow" => new string('x', 8188) + "\U0001F642",
+            "null" => null,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind))
+        };
+        _character.SetOption(7, data);
+
+        _packet.Read(CreateBody(7, _character.Id));
+
+        await AssertResponse(_character.Id, 7, "");
+        await Assert.That(_character.GetOption(7)).IsEqualTo(data);
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+    }
+
+    private static PacketStream CreateBody(ushort type, ulong id) =>
+        new PacketStream().Write(type).Write(id);
+
+    private async Task AssertResponse(uint id, ushort type, string data)
+    {
+        await Assert.That(_sentPackets.Count).IsEqualTo(1);
+        var stream = new PacketStream(_sentPackets[0]);
+        var bytes = Encoding.UTF8.GetBytes(data);
+        // Consume the current unencrypted GamePacket envelope before checking the UI body.
+        await Assert.That(stream.ReadUInt16()).IsEqualTo((ushort)(stream.Count - 2));
+        stream.ReadByte(); // Signature belongs to the transport, not the UI body.
+        await Assert.That(stream.ReadByte()).IsEqualTo((byte)1);
+        stream.ReadByte(); // Unused checksum.
+        stream.ReadByte(); // Unused counter.
+        await Assert.That(stream.ReadUInt16()).IsEqualTo(SCOffsets.SCResponseUIDataPacket);
+        await Assert.That(stream.LeftBytes).IsEqualTo(16 + bytes.Length);
+        await Assert.That(stream.ReadUInt64()).IsEqualTo((ulong)id);
+        await Assert.That(stream.ReadUInt16()).IsEqualTo(type);
+        await Assert.That(stream.ReadUInt16()).IsEqualTo((ushort)bytes.Length);
+        await Assert.That(stream.ReadBytes(bytes.Length).SequenceEqual(bytes)).IsTrue();
+        await Assert.That(stream.ReadUInt32()).IsEqualTo((uint)bytes.Length);
+        await Assert.That(stream.LeftBytes).IsEqualTo(0);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Packets/C2G/CSSaveUIDataPacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/C2G/CSSaveUIDataPacketTests.cs
@@ -1,0 +1,253 @@
+using System.Text;
+using AAEmu.Commons.Network;
+using AAEmu.Commons.Network.Core;
+using AAEmu.Game.Core.Network.Connections;
+using AAEmu.Game.Core.Packets.C2G;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Core.Packets.C2G;
+
+public class CSSaveUIDataPacketTests
+{
+    private readonly UiDataPacketTestStore _store = new();
+    private readonly GameConnection _connection = new(Mock.Of<ISession>().Object);
+    private readonly Character _character;
+    private readonly CSSaveUIDataPacket _packet;
+
+    public CSSaveUIDataPacketTests()
+    {
+        _character = new Character(new UnitCustomModelParams(), _store) { Id = 42 };
+        _character.SetOption(7, "original-value");
+        _connection.Characters.Add(_character.Id, _character);
+        _packet = new CSSaveUIDataPacket { Connection = _connection };
+    }
+
+    [Test]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    [Arguments(4)]
+    [Arguments(5)]
+    [Arguments(6)]
+    [Arguments(7)]
+    [Arguments(20)]
+    public async Task Read_UsesPacketCharacterWhenActiveCharacterIsNull(int type)
+    {
+        var key = (ushort)type;
+        var stream = CreateBody(key, _character.Id, Encoding.UTF8.GetBytes("saved-value"));
+
+        _packet.Read(stream);
+
+        await Assert.That(_connection.ActiveChar).IsNull();
+        await Assert.That(_character.GetOption(key)).IsEqualTo("saved-value");
+        await Assert.That(_store.Saves.Count).IsEqualTo(1);
+        await Assert.That(_store.Saves[0]).IsEqualTo((_character.Id, key, "saved-value"));
+        await Assert.That(stream.LeftBytes).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Read_UsesOwnedNonactiveCharacterInsteadOfActiveCharacter()
+    {
+        var active = new Character(new UnitCustomModelParams(), _store) { Id = 43 };
+        active.SetOption(7, "active-value");
+        _connection.Characters.Add(active.Id, active);
+        _connection.ActiveChar = active;
+
+        _packet.Read(CreateBody(7, _character.Id, Encoding.UTF8.GetBytes("saved-value")));
+
+        await Assert.That(_character.GetOption(7)).IsEqualTo("saved-value");
+        await Assert.That(active.GetOption(7)).IsEqualTo("active-value");
+        await Assert.That(_store.Saves.Count).IsEqualTo(1);
+        await Assert.That(_store.Saves[0]).IsEqualTo((_character.Id, (ushort)7, "saved-value"));
+    }
+
+    [Test]
+    public async Task Read_IgnoresUnknownCharacterId()
+    {
+        _connection.ActiveChar = _character;
+
+        _packet.Read(CreateBody(7, 999, Encoding.UTF8.GetBytes("saved-value")));
+
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo("original-value");
+    }
+
+    [Test]
+    public async Task Read_RejectsActiveCharacterAbsentFromOwnedCharacters()
+    {
+        _connection.ActiveChar = _character;
+        _connection.Characters.Clear();
+
+        _packet.Read(CreateBody(7, _character.Id, Encoding.UTF8.GetBytes("saved-value")));
+
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo("original-value");
+    }
+
+    [Test]
+    [Arguments(4294967338UL)]
+    [Arguments(ulong.MaxValue)]
+    public async Task Read_Rejects64BitIdEvenWhenLowBitsAreOwned(ulong id)
+    {
+        _connection.Characters.Clear();
+        _character.Id = unchecked((uint)id);
+        _connection.Characters.Add(_character.Id, _character);
+        _connection.ActiveChar = _character;
+
+        _packet.Read(CreateBody(7, id, Encoding.UTF8.GetBytes("saved-value")));
+
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo("original-value");
+    }
+
+    [Test]
+    public async Task Read_AcceptsUInt32MaxValueIn64BitIdField()
+    {
+        _connection.Characters.Clear();
+        _character.Id = uint.MaxValue;
+        _connection.Characters.Add(_character.Id, _character);
+
+        _packet.Read(CreateBody(7, _character.Id, Encoding.UTF8.GetBytes("saved-value")));
+
+        await Assert.That(_character.GetOption(7)).IsEqualTo("saved-value");
+        await Assert.That(_store.Saves.Count).IsEqualTo(1);
+        await Assert.That(_store.Saves[0]).IsEqualTo((uint.MaxValue, (ushort)7, "saved-value"));
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(8)]
+    [Arguments(19)]
+    [Arguments(21)]
+    [Arguments(65535)]
+    public async Task Read_RejectsUnsupportedTypeWithoutPersistence(int type)
+    {
+        var key = (ushort)type;
+        _character.SetOption(key, "unsupported-original");
+
+        _packet.Read(CreateBody(key, _character.Id, Encoding.UTF8.GetBytes("saved-value")));
+
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(key)).IsEqualTo("unsupported-original");
+        await Assert.That(_character.GetOption(7)).IsEqualTo("original-value");
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(5)]
+    [Arguments(6)]
+    [Arguments(9)]
+    [Arguments(10)]
+    [Arguments(11)]
+    public async Task Read_RejectsTruncatedHeaderWithoutPersistence(int length)
+    {
+        var body = CreateBody(7, _character.Id, []).GetBytes();
+
+        _packet.Read(new PacketStream(body[..length]));
+
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo("original-value");
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(2)]
+    [Arguments(3)]
+    [Arguments(5)]
+    [Arguments(65535)]
+    public async Task Read_RejectsLengthMismatchIncludingUtf16LengthAndTrailingBytes(int declaredLength)
+    {
+        // One supplementary character is two UTF-16 code units but four UTF-8 bytes.
+        var bytes = Encoding.UTF8.GetBytes("\U0001F642");
+
+        _packet.Read(CreateBody(7, _character.Id, bytes, (ushort)declaredLength));
+
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo("original-value");
+    }
+
+    [Test]
+    public async Task Read_Rejects32BitIdLayoutWithoutPersistence()
+    {
+        var stream = new PacketStream();
+        stream.Write((ushort)7);
+        stream.Write(_character.Id);
+        stream.Write((ushort)5);
+        stream.Write(Encoding.UTF8.GetBytes("value"), false);
+
+        _packet.Read(stream);
+
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo("original-value");
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments(" \t{ \"unknown_test_field\" : [ 9, \"opaque\" ] }\r\n ")]
+    [Arguments("a\u00E9\u4E2D\U0001F642z")]
+    public async Task Read_PreservesOpaqueTextAndEmptyValues(string data)
+    {
+        var bytes = Encoding.UTF8.GetBytes(data);
+        var stream = CreateBody(7, _character.Id, bytes);
+
+        _packet.Read(stream);
+
+        await Assert.That(stream.Count).IsEqualTo(12 + bytes.Length);
+        await Assert.That(stream.LeftBytes).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo(data);
+        await Assert.That(_store.Saves.Count).IsEqualTo(1);
+        await Assert.That(_store.Saves[0]).IsEqualTo((_character.Id, (ushort)7, data));
+    }
+
+    [Test]
+    [Arguments(8191, false)]
+    [Arguments(8191, true)]
+    [Arguments(8192, false)]
+    [Arguments(8192, true)]
+    public async Task Read_EnforcesByteLimitRatherThanCharacterLimit(int byteLength, bool supplementary)
+    {
+        var data = supplementary ? new string('x', byteLength - 4) + "\U0001F642" : new string('x', byteLength);
+        var bytes = Encoding.UTF8.GetBytes(data);
+
+        _packet.Read(CreateBody(7, _character.Id, bytes));
+
+        await Assert.That(bytes.Length).IsEqualTo(byteLength);
+        await Assert.That(_store.Saves.Count).IsEqualTo(byteLength == 8191 ? 1 : 0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo(byteLength == 8191 ? data : "original-value");
+        if (byteLength == 8191)
+            await Assert.That(_store.Saves[0]).IsEqualTo((_character.Id, (ushort)7, data));
+    }
+
+    [Test]
+    [Arguments("80")]
+    [Arguments("C0AF")]
+    [Arguments("E282")]
+    [Arguments("EDA080")]
+    [Arguments("F4908080")]
+    [Arguments("F09F99")]
+    [Arguments("00")]
+    [Arguments("0061")]
+    [Arguments("610062")]
+    [Arguments("6100")]
+    public async Task Read_RejectsInvalidUtf8AndNulWithoutPersistence(string hex)
+    {
+        _packet.Read(CreateBody(7, _character.Id, Convert.FromHexString(hex)));
+
+        await Assert.That(_store.Saves.Count).IsEqualTo(0);
+        await Assert.That(_character.GetOption(7)).IsEqualTo("original-value");
+    }
+
+    private static PacketStream CreateBody(ushort uiDataType, ulong characterId, byte[] data, ushort? declaredLength = null)
+    {
+        var stream = new PacketStream();
+        stream.Write(uiDataType);
+        stream.Write(characterId);
+        stream.Write(declaredLength ?? (ushort)data.Length);
+        stream.Write(data, false);
+        stream.Rollback();
+        return stream;
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Packets/G2C/SCResponseUIDataPacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/G2C/SCResponseUIDataPacketTests.cs
@@ -1,0 +1,109 @@
+using System.Text;
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Packets.G2C;
+
+namespace AAEmu.UnitTests.Game.Core.Packets.G2C;
+
+public class SCResponseUIDataPacketTests
+{
+    [Test]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    [Arguments(4)]
+    [Arguments(5)]
+    [Arguments(6)]
+    [Arguments(7)]
+    [Arguments(20)]
+    public async Task Write_SupportedTypesUse64BitIdAndMatchingByteLengths(int type)
+    {
+        const string data = "a\u00E9\u4E2D\U0001F642z";
+        var key = (ushort)type;
+        var stream = new SCResponseUIDataPacket(uint.MaxValue, key, data).Write(new PacketStream());
+
+        await AssertBody(stream, uint.MaxValue, key, Encoding.UTF8.GetBytes(data));
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments(" \t{ \"unknown_test_field\" : [ 9, \"opaque\" ] }\r\n ")]
+    [Arguments("not a parsed document: \U0001F642\r\n")]
+    public async Task Write_PreservesOpaqueBytesWhitespaceAndEmptyValues(string data)
+    {
+        var stream = new SCResponseUIDataPacket(42, 7, data).Write(new PacketStream());
+
+        await AssertBody(stream, 42, 7, Encoding.UTF8.GetBytes(data));
+    }
+
+    [Test]
+    [Arguments(8191, false)]
+    [Arguments(8191, true)]
+    [Arguments(8192, false)]
+    [Arguments(8192, true)]
+    public async Task Write_EnforcesByteLimitRatherThanCharacterLimit(int byteLength, bool supplementary)
+    {
+        var data = supplementary ? new string('x', byteLength - 4) + "\U0001F642" : new string('x', byteLength);
+        var bytes = Encoding.UTF8.GetBytes(data);
+
+        var stream = new SCResponseUIDataPacket(42, 20, data).Write(new PacketStream());
+
+        await Assert.That(bytes.Length).IsEqualTo(byteLength);
+        await AssertBody(stream, 42, 20, byteLength == 8191 ? bytes : []);
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("\0")]
+    [Arguments("\0value")]
+    [Arguments("before\0after")]
+    [Arguments("value\0")]
+    public async Task Write_InvalidStoredTextProducesExactlyEmptyBody(string data)
+    {
+        var stream = new SCResponseUIDataPacket(42, 7, data).Write(new PacketStream());
+
+        await AssertBody(stream, 42, 7, []);
+    }
+
+    [Test]
+    [Arguments(0xD800)]
+    [Arguments(0xDBFF)]
+    [Arguments(0xDC00)]
+    [Arguments(0xDFFF)]
+    public async Task Write_InvalidUtf16ProducesEmptyRatherThanReplacementBytes(int codeUnit)
+    {
+        // Construct unpaired surrogates at runtime, not in attribute metadata.
+        var data = "before" + (char)codeUnit + "after";
+
+        var stream = new SCResponseUIDataPacket(42, 7, data).Write(new PacketStream());
+
+        await AssertBody(stream, 42, 7, []);
+    }
+
+    [Test]
+    [Arguments(0)]
+    [Arguments(8)]
+    [Arguments(19)]
+    [Arguments(21)]
+    [Arguments(65535)]
+    public async Task Write_UnsupportedTypeThrowsBeforeWriting(int type)
+    {
+        var stream = new PacketStream();
+        var packet = new SCResponseUIDataPacket(42, (ushort)type, "opaque");
+
+        await Assert.That(() => packet.Write(stream)).Throws<ArgumentOutOfRangeException>();
+
+        await Assert.That(stream.Count).IsEqualTo(0);
+    }
+
+    private static async Task AssertBody(PacketStream stream, uint id, ushort type, byte[] bytes)
+    {
+        stream.Rollback();
+        await Assert.That(stream.Count).IsEqualTo(16 + bytes.Length);
+        await Assert.That(stream.ReadUInt64()).IsEqualTo((ulong)id);
+        await Assert.That(stream.ReadUInt16()).IsEqualTo(type);
+        await Assert.That(stream.ReadUInt16()).IsEqualTo((ushort)bytes.Length);
+        await Assert.That(stream.ReadBytes(bytes.Length).SequenceEqual(bytes)).IsTrue();
+        await Assert.That(stream.ReadUInt32()).IsEqualTo((uint)bytes.Length);
+        await Assert.That(stream.LeftBytes).IsEqualTo(0);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Packets/UiDataPacketTestStore.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/UiDataPacketTestStore.cs
@@ -1,0 +1,11 @@
+using AAEmu.Game.Models.Game.Char;
+
+namespace AAEmu.UnitTests.Game.Core.Packets;
+
+internal sealed class UiDataPacketTestStore : ICharacterOptionStore
+{
+    public List<(uint CharacterId, ushort Key, string Value)> Saves { get; } = [];
+
+    public void Save(uint characterId, ushort key, string value) =>
+        Saves.Add((characterId, key, value));
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Char/CharacterUiDataTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Char/CharacterUiDataTests.cs
@@ -1,0 +1,375 @@
+using System.Collections.Concurrent;
+
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Char;
+
+public class CharacterUiDataTests
+{
+    private static readonly TimeSpan CoordinationTimeout = TimeSpan.FromSeconds(15);
+    private static readonly ushort[] SupportedSections = [1, 2, 3, 4, 5, 6, 7, 20];
+
+    [Test]
+    [Arguments(1)]
+    [Arguments(2)]
+    [Arguments(3)]
+    [Arguments(4)]
+    [Arguments(5)]
+    [Arguments(6)]
+    [Arguments(7)]
+    [Arguments(20)]
+    public async Task TrySaveUiData_FailurePreservesOldValue_IdenticalRetryCommits(int section)
+    {
+        var key = (ushort)section;
+        var store = new FakeOptionStore();
+        var character = new Character(new UnitCustomModelParams(), store) { Id = 42 };
+        character.SetOption(key, "old");
+        var valuesDuringSave = new List<string>();
+        store.BeforeSave = (_, _, _) =>
+        {
+            // The callback is reentrant: memory must still contain the old value at commit time.
+            valuesDuringSave.Add(character.GetOption(key));
+            if (valuesDuringSave.Count == 1)
+                throw new InvalidOperationException("Synthetic persistence failure");
+        };
+
+        await Assert.That(character.TrySaveUiData(key, "replacement")).IsFalse();
+        await Assert.That(character.GetOption(key)).IsEqualTo("old");
+        await Assert.That(store.Saved).IsEmpty();
+
+        await Assert.That(character.TrySaveUiData(key, "replacement")).IsTrue();
+        await Assert.That(character.GetOption(key)).IsEqualTo("replacement");
+        await Assert.That(valuesDuringSave.SequenceEqual(new[] { "old", "old" })).IsTrue();
+        await Assert.That(store.Attempts.Count).IsEqualTo(2);
+        await Assert.That(store.Attempts.All(write => write == (42u, key, "replacement"))).IsTrue();
+        await Assert.That(store.Saved.Single()).IsEqualTo((42u, key, "replacement"));
+    }
+
+    [Test]
+    public async Task TrySaveUiData_InactiveCharacterNeedsNoConnection_LeavesUnknownFieldsUntouched()
+    {
+        const string payload = "  {\"syntheticVersion\":73,\"unknownFutureField\":{\"x\":[3,null,\"a\\\\b\"]}}\r\n";
+        var store = new FakeOptionStore();
+        var character = new Character(new UnitCustomModelParams(), store) { Id = 42 };
+
+        await Assert.That(character.Connection).IsNull();
+        await Assert.That(character.IsOnline).IsFalse();
+        await Assert.That(character.TrySaveUiData(20, payload)).IsTrue();
+
+        await Assert.That(character.GetOption(20)).IsEqualTo(payload);
+        await Assert.That(store.Saved.Single()).IsEqualTo((42u, (ushort)20, payload));
+        await Assert.That(character.Connection).IsNull();
+        await Assert.That(character.IsOnline).IsFalse();
+    }
+
+    [Test]
+    public async Task TrySaveUiData_IsolatesCharactersAndSections()
+    {
+        var store = new FakeOptionStore();
+        var first = new Character(new UnitCustomModelParams(), store) { Id = 42 };
+        var second = new Character(new UnitCustomModelParams(), store) { Id = 43 };
+
+        await Assert.That(first.GetOption(1)).IsEqualTo("");
+        await Assert.That(second.GetOption(1)).IsEqualTo("");
+        foreach (var key in SupportedSections)
+        {
+            await Assert.That(first.TrySaveUiData(key, $"first-{key}")).IsTrue();
+            await Assert.That(second.TrySaveUiData(key, $"second-{key}")).IsTrue();
+        }
+        await Assert.That(first.TrySaveUiData(1, "updated")).IsTrue();
+
+        foreach (var key in SupportedSections)
+        {
+            var expected = key == 1 ? "updated" : $"first-{key}";
+            await Assert.That(first.GetOption(key)).IsEqualTo(expected);
+            await Assert.That(second.GetOption(key)).IsEqualTo($"second-{key}");
+            await Assert.That(store.Saved.Last(write => write.CharacterId == 42 && write.Key == key).Value)
+                .IsEqualTo(expected);
+            await Assert.That(store.Saved.Single(write => write.CharacterId == 43 && write.Key == key).Value)
+                .IsEqualTo($"second-{key}");
+        }
+        await Assert.That(store.Saved.Count).IsEqualTo(17);
+    }
+
+    [Test]
+    public async Task TrySaveUiData_UnsupportedSectionsNeverReachStoreOrChangeMemory()
+    {
+        var store = new FakeOptionStore();
+        var character = new Character(new UnitCustomModelParams(), store) { Id = 42 };
+        ushort[] unsupported = [0, 8, 19, 21, 0xE400, 0xE4FF, ushort.MaxValue];
+
+        foreach (var key in unsupported)
+        {
+            character.SetOption(key, "old");
+            await Assert.That(character.TrySaveUiData(key, "replacement")).IsFalse();
+            await Assert.That(character.GetOption(key)).IsEqualTo("old");
+        }
+        await Assert.That(store.Attempts).IsEmpty();
+    }
+
+    [Test]
+    public async Task TrySaveUiData_InvalidTextNeverReachesStoreOrChangesMemory()
+    {
+        var store = new FakeOptionStore();
+        var character = new Character(new UnitCustomModelParams(), store) { Id = 42 };
+        character.SetOption(1, "old");
+        string[] invalid =
+        [
+            null, "embedded\0nul", "\uD800", "\uDC00", "\uD800x",
+            new string('a', 8192), new string('\u00E9', 4096),
+            string.Concat(Enumerable.Repeat("\uD83D\uDE00", 2048))
+        ];
+
+        foreach (var payload in invalid)
+        {
+            await Assert.That(character.TrySaveUiData(1, payload)).IsFalse();
+            await Assert.That(character.GetOption(1)).IsEqualTo("old");
+        }
+        await Assert.That(store.Attempts).IsEmpty();
+    }
+
+    [Test]
+    public async Task TrySaveUiData_AcceptsEmptyAndStrictUtf8At8191ByteBoundary()
+    {
+        var store = new FakeOptionStore();
+        var character = new Character(new UnitCustomModelParams(), store) { Id = 42 };
+        string[] valid =
+        [
+            "", new string('a', 8191), new string('\u00E9', 4095) + "a",
+            string.Concat(Enumerable.Repeat("\uD83D\uDE00", 2047)) + "abc"
+        ];
+
+        foreach (var payload in valid)
+        {
+            await Assert.That(character.TrySaveUiData(1, payload)).IsTrue();
+            await Assert.That(character.GetOption(1)).IsEqualTo(payload);
+        }
+        await Assert.That(store.Saved.Select(write => write.Value).SequenceEqual(valid)).IsTrue();
+    }
+
+    [Test]
+    public async Task TrySaveUiData_ConsecutiveSavesCommitInOrder_IncludingRepeatedAndEmptyPayloads()
+    {
+        var store = new FakeOptionStore();
+        var character = new Character(new UnitCustomModelParams(), store) { Id = 42 };
+        character.SetOption(1, "seed");
+        var observed = new List<string>();
+        store.BeforeSave = (_, key, _) => observed.Add(character.GetOption(key));
+        string[] payloads = ["first", "second", "second", ""];
+
+        foreach (var payload in payloads)
+        {
+            await Assert.That(character.TrySaveUiData(1, payload)).IsTrue();
+            await Assert.That(character.GetOption(1)).IsEqualTo(payload);
+        }
+
+        await Assert.That(observed.SequenceEqual(new[] { "seed", "first", "second", "second" })).IsTrue();
+        await Assert.That(store.Saved.Select(write => write.Value).SequenceEqual(payloads)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetOptionsForSave_ExcludesEveryUiSection_PreservesAllContentToggleKeys()
+    {
+        var store = new FakeOptionStore();
+        var character = new Character(new UnitCustomModelParams(), store) { Id = 42 };
+        foreach (var key in SupportedSections)
+            character.SetOption(key, $"ui-{key}");
+
+        var expected = new Dictionary<ushort, string>();
+        for (var content = 0; content <= byte.MaxValue; content++)
+            expected[(ushort)(0xE400 + content)] = content % 2 == 0 ? "0" : "1";
+        foreach (ushort key in new ushort[] { 0, 8, 19, 21, ushort.MaxValue })
+            expected[key] = $"non-ui-{key}";
+        foreach (var pair in expected)
+            character.SetOption(pair.Key, pair.Value);
+
+        var snapshot = character.GetOptionsForSave();
+
+        await Assert.That(snapshot.OrderBy(pair => pair.Key).SequenceEqual(expected.OrderBy(pair => pair.Key))).IsTrue();
+        foreach (var key in SupportedSections)
+            await Assert.That(character.GetOption(key)).IsEqualTo($"ui-{key}");
+        await Assert.That(store.Attempts).IsEmpty();
+    }
+
+    [Test]
+    public async Task GetOptionsForSave_SnapshotsAreIndependentOfLaterSavesAndMutations()
+    {
+        var store = new FakeOptionStore();
+        var character = new Character(new UnitCustomModelParams(), store) { Id = 42 };
+        character.SetOption(1, "old-ui");
+        character.SetOption(0xE400, "0");
+        var first = character.GetOptionsForSave();
+        var second = character.GetOptionsForSave();
+
+        character.SetOption(0xE400, "1");
+        character.SetOption(0xE401, "added");
+        await Assert.That(character.TrySaveUiData(1, "new-ui")).IsTrue();
+
+        await Assert.That(first).HasSingleItem();
+        await Assert.That(first[0]).IsEqualTo(new KeyValuePair<ushort, string>(0xE400, "0"));
+        first[0] = new KeyValuePair<ushort, string>(1, "snapshot-only");
+
+        await Assert.That(second).HasSingleItem();
+        await Assert.That(second[0]).IsEqualTo(new KeyValuePair<ushort, string>(0xE400, "0"));
+        await Assert.That(character.GetOption(1)).IsEqualTo("new-ui");
+        await Assert.That(character.GetOption(0xE400)).IsEqualTo("1");
+        var latest = character.GetOptionsForSave().ToDictionary(pair => pair.Key, pair => pair.Value);
+        await Assert.That(latest.Count).IsEqualTo(2);
+        await Assert.That(latest[0xE400]).IsEqualTo("1");
+        await Assert.That(latest[0xE401]).IsEqualTo("added");
+        await Assert.That(store.Saved.Single()).IsEqualTo((42u, (ushort)1, "new-ui"));
+    }
+
+    [Test]
+    [Arguments(1)]
+    [Arguments(2)]
+    public async Task PendingSave_SerializesWriters_WithoutBlockingOtherCharacters(int section)
+    {
+        var secondKey = (ushort)section;
+        using var entered = new ManualResetEventSlim();
+        using var release = new ManualResetEventSlim();
+        var store = new FakeOptionStore();
+        var character = new Character(new UnitCustomModelParams(), store) { Id = 42 };
+        var otherCharacter = new Character(new UnitCustomModelParams(), store) { Id = 43 };
+        character.SetOption(1, "old");
+        character.SetOption(0xE400, "toggle");
+        store.BeforeSave = (characterId, _, value) =>
+        {
+            if (characterId != 42 || value != "first")
+                return;
+            entered.Set();
+            if (!release.Wait(CoordinationTimeout * 3))
+                throw new TimeoutException("Test did not release the pending save");
+        };
+
+        var first = Task.Factory.StartNew(() => character.TrySaveUiData(1, "first"),
+            CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var worker = new Thread(() =>
+        {
+            try
+            {
+                started.SetResult();
+                completed.SetResult(character.TrySaveUiData(secondKey, "second"));
+            }
+            catch (Exception exception)
+            {
+                completed.SetException(exception);
+            }
+        }) { IsBackground = true };
+        var workerStarted = false;
+
+        try
+        {
+            await Assert.That(entered.Wait(CoordinationTimeout)).IsTrue();
+            worker.Start();
+            workerStarted = true;
+            await started.Task.WaitAsync(CoordinationTimeout);
+
+            // This worker can only wait on the writer lock. Observe contention, not elapsed time.
+            var settled = SpinWait.SpinUntil(() => completed.Task.IsCompleted ||
+                (worker.ThreadState & ThreadState.WaitSleepJoin) != 0, CoordinationTimeout);
+            await Assert.That(settled).IsTrue();
+            await Assert.That(completed.Task.IsCompleted).IsFalse();
+            await Assert.That(store.Attempts.Count).IsEqualTo(1);
+            await Assert.That(store.Saved).IsEmpty();
+
+            var otherSave = Task.Run(() => otherCharacter.TrySaveUiData(1, "independent"));
+            await Assert.That(await otherSave.WaitAsync(CoordinationTimeout)).IsTrue();
+            await Assert.That(otherCharacter.GetOption(1)).IsEqualTo("independent");
+            await Assert.That(store.Saved.Single()).IsEqualTo((43u, (ushort)1, "independent"));
+        }
+        finally
+        {
+            release.Set();
+            await first.WaitAsync(CoordinationTimeout);
+            if (workerStarted)
+                await completed.Task.WaitAsync(CoordinationTimeout);
+        }
+
+        await Assert.That(await first).IsTrue();
+        await Assert.That(await completed.Task).IsTrue();
+        await Assert.That(character.GetOption(1)).IsEqualTo(secondKey == 1 ? "second" : "first");
+        await Assert.That(character.GetOption(secondKey)).IsEqualTo("second");
+        var writes = store.Saved.Where(write => write.CharacterId == 42).ToArray();
+        await Assert.That(writes.Length).IsEqualTo(2);
+        await Assert.That(writes[0]).IsEqualTo((42u, (ushort)1, "first"));
+        await Assert.That(writes[1]).IsEqualTo((42u, secondKey, "second"));
+    }
+
+    [Test]
+    public async Task AutosaveHoldingLastPooledConnection_CanReadSeedAndSnapshotWhileUiSaveWaits()
+    {
+        using var pool = new SemaphoreSlim(1, 1);
+        using var acquiringConnection = new ManualResetEventSlim();
+        var store = new FakeOptionStore();
+        var character = new Character(new UnitCustomModelParams(), store) { Id = 42 };
+        character.SetOption(1, "old-ui");
+        character.SetOption(0xE400, "0");
+        store.BeforeSave = (_, _, _) =>
+        {
+            acquiringConnection.Set();
+            if (!pool.Wait(CoordinationTimeout * 3))
+                throw new TimeoutException("Autosave did not release the simulated connection");
+            pool.Release();
+        };
+
+        // Autosave owns the last connection before the UI writer tries to acquire one.
+        await Assert.That(await pool.WaitAsync(CoordinationTimeout)).IsTrue();
+        var writer = Task.Factory.StartNew(() => character.TrySaveUiData(1, "new-ui"),
+            CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        Task cacheAccess = Task.CompletedTask;
+        try
+        {
+            await Assert.That(acquiringConnection.Wait(CoordinationTimeout)).IsTrue();
+            var autosave = Task.Factory.StartNew(() =>
+            {
+                var before = character.GetOption(1);
+                character.SetOption(2, "loaded-ui");
+                character.SetOption(0xE400, "1");
+                return (Before: before, After: character.GetOption(1), Seeded: character.GetOption(2),
+                    Snapshot: character.GetOptionsForSave());
+            }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            cacheAccess = autosave;
+
+            // These operations must finish while autosave still holds the permit, not after I/O.
+            var result = await autosave.WaitAsync(CoordinationTimeout);
+            await Assert.That(result.Before).IsEqualTo("old-ui");
+            await Assert.That(result.After).IsEqualTo("old-ui");
+            await Assert.That(result.Seeded).IsEqualTo("loaded-ui");
+            await Assert.That(result.Snapshot).HasSingleItem();
+            await Assert.That(result.Snapshot[0]).IsEqualTo(new KeyValuePair<ushort, string>(0xE400, "1"));
+            await Assert.That(writer.IsCompleted).IsFalse();
+            await Assert.That(store.Attempts.Single()).IsEqualTo((42u, (ushort)1, "new-ui"));
+            await Assert.That(store.Saved).IsEmpty();
+        }
+        finally
+        {
+            // Also break the simulated inversion on failure so no worker is left blocked.
+            pool.Release();
+            await Task.WhenAll(writer, cacheAccess).WaitAsync(CoordinationTimeout);
+        }
+
+        await Assert.That(await writer).IsTrue();
+        await Assert.That(character.GetOption(1)).IsEqualTo("new-ui");
+        await Assert.That(character.GetOption(2)).IsEqualTo("loaded-ui");
+        await Assert.That(character.GetOption(0xE400)).IsEqualTo("1");
+        await Assert.That(store.Saved.Single()).IsEqualTo((42u, (ushort)1, "new-ui"));
+    }
+
+    private sealed class FakeOptionStore : ICharacterOptionStore
+    {
+        public ConcurrentQueue<(uint CharacterId, ushort Key, string Value)> Attempts { get; } = new();
+        public ConcurrentQueue<(uint CharacterId, ushort Key, string Value)> Saved { get; } = new();
+        public Action<uint, ushort, string> BeforeSave { get; set; }
+
+        public void Save(uint characterId, ushort key, string value)
+        {
+            Attempts.Enqueue((characterId, key, value));
+            BeforeSave?.Invoke(characterId, key, value);
+            Saved.Enqueue((characterId, key, value));
+        }
+    }
+}

--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -483,7 +483,7 @@ CREATE TABLE IF NOT EXISTS `mates` (
 
 CREATE TABLE IF NOT EXISTS `options` (
   `key` varchar(100) NOT NULL,
-  `value` text NOT NULL,
+  `value` text CHARACTER SET utf8mb4 NOT NULL,
   `owner` int unsigned NOT NULL,
   PRIMARY KEY (`key`,`owner`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Settings that the client stores on the server';

--- a/SQL/updates/2026-09-05_aaemu_game_options_utf8mb4.sql
+++ b/SQL/updates/2026-09-05_aaemu_game_options_utf8mb4.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `options`
+    MODIFY `value` TEXT CHARACTER SET utf8mb4 NOT NULL;


### PR DESCRIPTION
## Summary

Fixes server-side persistence and restoration of character UI data, including keybinds, camera mode, viewing angle, camera distance, zoom sensitivity, and other settings contained in supported UI-data sections.

The client sends each section as an opaque serialized payload. The server now stores and returns the complete payload without interpreting or whitelisting individual settings.

## Changes

- Corrected UI save and request packets to read the client's 64-bit character ID.
- Validates character ID range and ownership before processing data.
- Supports UI-data sections `1` through `7` and `20`.
- Added strict UTF-8 decoding and an 8,191-byte payload limit.
- Rejects malformed packets, unsupported sections, invalid UTF-8, embedded NULs, and identifier aliases.
- Corrected response lengths to use encoded UTF-8 byte counts.
- Added immediate options-only SQL persistence, including saves made before a character becomes active.
- Prevents bulk autosaves from overwriting newer UI settings with stale values.
- Preserves unknown and future fields within supported sections.
- Updated the options value column and MySQL connection encoding to `utf8mb4`.
- Added a database migration for existing installations.
- Added tests covering packet validation, ownership, Unicode, persistence failures, concurrent saves, and character/section isolation.