### PR TITLE
feat(game): quest flow, world-level accept, and combat death

### DIFF
--- a/AAEmu.Game/Core/Managers/FormulaManager.cs
+++ b/AAEmu.Game/Core/Managers/FormulaManager.cs
@@ -24,7 +24,8 @@ public class FormulaManager : Singleton<FormulaManager>, IFormulaManager
 
     public UnitFormula GetUnitFormula(FormulaOwnerType owner, UnitFormulaKind kind)
     {
-        if (_unitFormulas.TryGetValue(owner, out var value)
+        if (_unitFormulas != null
+            && _unitFormulas.TryGetValue(owner, out var value)
             && value.TryGetValue(kind, out var kindFound))
             return kindFound;
 

--- a/AAEmu.Game/Core/Managers/IPortalManager.cs
+++ b/AAEmu.Game/Core/Managers/IPortalManager.cs
@@ -14,6 +14,7 @@ public interface IPortalManager : ILoadable
     Portal GetRespawnById(uint id);
     Portal GetWorldGatesBySubZoneId(uint subZoneId);
     Portal GetWorldGatesById(uint id);
+    Portal GetReturnPoint(uint returnPointId);
     uint GetDistrictReturnPoint(uint districtId);
     uint GetDistrictReturnPoint(uint districtId, FactionsEnum factionId);
     uint GetDistrictIdByReturnPoint(uint returnPointId, FactionsEnum factionId);

--- a/AAEmu.Game/Core/Managers/IQuestManager.cs
+++ b/AAEmu.Game/Core/Managers/IQuestManager.cs
@@ -16,6 +16,8 @@ public interface IQuestManager : ILoadable
     List<uint> GetGroupItems(uint groupId);
     QuestSupplies GetSupplies(byte level);
     QuestTemplate GetTemplate(uint id);
+    bool IsQuestTalkNpc(uint npcTemplateId);
+    IReadOnlyCollection<uint> GetQuestTalkDoodadIds();
     void EnqueueEvaluation(Quest quest);
     int RemoveQuestTimer(uint ownerId, uint questId);
 }

--- a/AAEmu.Game/Core/Managers/PortalManager.cs
+++ b/AAEmu.Game/Core/Managers/PortalManager.cs
@@ -13,6 +13,7 @@ using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.OpenPortal;
 using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.Teleport;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World.Transform;
@@ -37,6 +38,7 @@ public class PortalManager(ILocalizationManager localizationManager, IWorldManag
     private Dictionary<uint, uint> _respawnsKey;
     private Dictionary<uint, Portal> _worldGates;
     private Dictionary<uint, uint> _worldGatesKey;
+    private Dictionary<uint, Portal> _levelReturns;
 
     private Dictionary<uint, OpenPortalReagents> _openPortalInlandReagents;
     private Dictionary<uint, OpenPortalReagents> _openPortalOutlandReagents;
@@ -82,6 +84,23 @@ public class PortalManager(ILocalizationManager localizationManager, IWorldManag
     {
         return _worldGatesKey != null && _worldGatesKey.TryGetValue(id, out var key)
             ? _worldGates.GetValueOrDefault(key)
+            : null;
+    }
+
+    /// <summary>
+    /// Destination for SpecialEffect Return value1 = return_points.id.
+    /// Worldgate and recall JSON win; otherwise the level <c>return_point.g</c> row.
+    /// </summary>
+    public Portal GetReturnPoint(uint returnPointId)
+    {
+        var gate = GetWorldGatesById(returnPointId);
+        if (gate != null)
+            return gate;
+        var recall = GetRecallById(returnPointId);
+        if (recall != null)
+            return recall;
+        return _levelReturns != null && _levelReturns.TryGetValue(returnPointId, out var level)
+            ? level
             : null;
     }
 
@@ -137,6 +156,7 @@ public class PortalManager(ILocalizationManager localizationManager, IWorldManag
         _recalls = [];
         _respawns = [];
         _worldGates = [];
+        _levelReturns = [];
         _recallsKey = [];
         _respawnsKey = [];
         _worldGatesKey = [];
@@ -291,9 +311,98 @@ public class PortalManager(ILocalizationManager localizationManager, IWorldManag
                     _districtReturnPoints.TryAdd(template.Id, template);
                 }
             }
+
+            var editorNameToId = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT id, editor_name FROM return_points";
+                command.Prepare();
+                using var reader = new SQLiteWrapperReader(command.ExecuteReader());
+                while (reader.Read())
+                {
+                    var editorName = reader.GetString("editor_name", string.Empty);
+                    if (string.IsNullOrWhiteSpace(editorName))
+                        continue;
+                    editorNameToId.TryAdd(editorName, reader.GetUInt32("id"));
+                }
+            }
+
+            LoadLevelReturnPoints(editorNameToId);
         }
         Logger.Info("Loaded Portal Info");
         #endregion
+    }
+
+    private void LoadLevelReturnPoints(IReadOnlyDictionary<string, uint> editorNameToId)
+    {
+        var roots = EnumerateZoneGameDataRoots();
+        if (roots.Count == 0)
+        {
+            Logger.Warn(
+                "ZoneGameDataRoot is not configured — return_point.g destinations are not loaded");
+            return;
+        }
+
+        var added = 0;
+        foreach (var local in ReturnPointGCatalog.LoadFromRoots(roots))
+        {
+            if (!ReturnPointFileRules.TryGetReturnPointId(editorNameToId, local.EditorName, out var id))
+                continue;
+            var haveGate = _worldGatesKey.ContainsKey(id);
+            var haveRecall = _recallsKey.ContainsKey(id);
+            if (!ReturnPointFileRules.ShouldUseLevelFile(haveGate, haveRecall))
+                continue;
+            var worldTemplate = worldManager.GetWorldTemplateByZoneKey(local.ZoneKey);
+            if (worldTemplate?.XmlWorldZones == null || !worldTemplate.XmlWorldZones.ContainsKey(local.ZoneKey))
+            {
+                Logger.Warn("return_point.g {0} zone {1} is not loaded", local.EditorName, local.ZoneKey);
+                continue;
+            }
+
+            var world = zoneManager.ConvertToWorldCoordinates(
+                local.ZoneKey,
+                new Vector3(local.X, local.Y, local.Z));
+            var portal = new Portal
+            {
+                Id = id,
+                Type = id,
+                Name = localizationManager.Get("return_points", "name", id, local.EditorName),
+                ZoneId = local.ZoneKey,
+                X = world.X,
+                Y = world.Y,
+                Z = world.Z,
+                ZRot = local.ZRotRadians,
+                Yaw = ReturnPointFileRules.YawDegreesFromZRot(local.ZRotRadians)
+            };
+            if (_levelReturns.TryAdd(id, portal))
+                added++;
+        }
+
+        Logger.Info("Loaded {0} return_point.g destinations", added);
+    }
+
+    private static List<string> EnumerateZoneGameDataRoots()
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        void Offer(string candidate)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+                return;
+            try
+            {
+                var full = Path.GetFullPath(candidate.Trim());
+                if (Directory.Exists(full))
+                    seen.Add(full);
+            }
+            catch (Exception)
+            {
+                // bad path
+            }
+        }
+
+        Offer(Environment.GetEnvironmentVariable("AAEMU_ZONE_GAME_DATA_ROOT"));
+        Offer(AppConfiguration.Instance.ZoneGameDataRoot);
+        return [.. seen];
     }
 
     public static bool CheckItemAndRemove(Character owner, uint itemId, int amount)

--- a/AAEmu.Game/Core/Managers/QuestManager.cs
+++ b/AAEmu.Game/Core/Managers/QuestManager.cs
@@ -8,6 +8,7 @@ using AAEmu.Game.Models.Game.Quests.Acts;
 using AAEmu.Game.Models.Game.Quests.Static;
 using AAEmu.Game.Models.Game.Quests.Templates;
 using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Units.Static;
 using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Models.StaticValues;
 using AAEmu.Game.Models.Tasks.Quests;
@@ -27,6 +28,8 @@ public partial class QuestManager(ITaskManager taskManager, IZoneManager zoneMan
     private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
     private bool _loaded;
     private readonly Dictionary<uint, QuestTemplate> _questTemplates = [];
+    private readonly HashSet<uint> _talkNpcIds = [];
+    private readonly HashSet<uint> _talkDoodadIds = [];
     private readonly Dictionary<byte, QuestSupplies> _supplies = [];
 
     /// <summary>
@@ -56,6 +59,13 @@ public partial class QuestManager(ITaskManager taskManager, IZoneManager zoneMan
     {
         return _questTemplates.GetValueOrDefault(id);
     }
+
+    public bool IsQuestTalkNpc(uint npcTemplateId)
+    {
+        return QuestTalkNpcRules.IsTalkNpc(_talkNpcIds, npcTemplateId);
+    }
+
+    public IReadOnlyCollection<uint> GetQuestTalkDoodadIds() => _talkDoodadIds;
 
     /// <summary>
     /// Gets the calculated Quest Supplies for a given character Level
@@ -201,36 +211,52 @@ public partial class QuestManager(ITaskManager taskManager, IZoneManager zoneMan
     {
         foreach (var questTemplate in _questTemplates.Values)
         {
-            byte actIndex = 0;
+            var progressComponentIndex = 0;
             byte selectiveRewardIndex = 0;
-            var lastKey = QuestComponentKind.None;
-            foreach (var (questComponentKey, questComponentValue) in questTemplate.Components)
+            foreach (var (questComponentKey, questComponent) in questTemplate.Components)
             {
-                if (questComponentValue.KindId != lastKey)
-                {
-                    actIndex = 0;
-                    lastKey = questComponentValue.KindId;
-                }
-
                 var questActs = GetActsInComponent(questComponentKey);
-                if (questActs.Count <= 0)
+                if (questComponent.KindId == QuestComponentKind.Progress)
+                {
+                    var progressSlot = QuestObjectiveSlotRules.SlotForProgressComponent(
+                        progressComponentIndex,
+                        QuestObjectiveSlotRules.MaxSlots);
+                    foreach (var questAct in questActs)
+                    {
+                        questAct.ThisComponentObjectiveIndex = questAct.CountsAsAnObjective
+                            ? progressSlot
+                            : QuestObjectiveSlotRules.NoSlot;
+                        questAct.ParentQuestTemplate = questTemplate;
+                        if (questAct is QuestActSupplySelectiveItem)
+                        {
+                            selectiveRewardIndex++;
+                            questAct.ThisSelectiveIndex = selectiveRewardIndex;
+                        }
+                    }
+
+                    progressComponentIndex++;
+                }
+            }
+
+            var otherIndex = (byte)Math.Min(progressComponentIndex, QuestObjectiveSlotRules.MaxSlots);
+            foreach (var (questComponentKey, questComponent) in questTemplate.Components)
+            {
+                if (questComponent.KindId == QuestComponentKind.Progress)
                     continue;
 
-                // Assign references to parents
+                var questActs = GetActsInComponent(questComponentKey);
                 foreach (var questAct in questActs)
                 {
-                    questAct.ThisComponentObjectiveIndex = questAct.CountsAsAnObjective ? actIndex : (byte)0xFF;
+                    questAct.ThisComponentObjectiveIndex = QuestObjectiveSlotRules.NextIndex(
+                        ref otherIndex,
+                        questAct.CountsAsAnObjective,
+                        QuestObjectiveSlotRules.MaxSlots);
                     questAct.ParentQuestTemplate = questTemplate;
-
-                    // For selective rewards
                     if (questAct is QuestActSupplySelectiveItem)
                     {
                         selectiveRewardIndex++;
                         questAct.ThisSelectiveIndex = selectiveRewardIndex;
                     }
-
-                    if (questAct.CountsAsAnObjective)
-                        actIndex++;
                 }
             }
         }
@@ -265,7 +291,20 @@ public partial class QuestManager(ITaskManager taskManager, IZoneManager zoneMan
 
             UpdateQuestComponentActs();
         }
-        Logger.Info($"Loaded {_questTemplates.Count} quests");
+
+        _talkNpcIds.Clear();
+        _talkDoodadIds.Clear();
+        foreach (var template in _questTemplates.Values)
+        {
+            QuestTalkNpcRules.AddTalkNpcs(template, _talkNpcIds);
+            QuestTalkDoodadRules.AddTalkDoodads(template, _talkDoodadIds);
+        }
+
+        Logger.Info(
+            "Loaded {0} quests ({1} talk NPCs, {2} talk doodads)",
+            _questTemplates.Count,
+            _talkNpcIds.Count,
+            _talkDoodadIds.Count);
         _loaded = true;
 
         // Calendar quest resets use TaskManager's DateTime.UtcNow (GMT). Host local TZ is ignored.

--- a/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
+++ b/AAEmu.Game/Core/Managers/UnitManagers/DoodadManager.cs
@@ -19,6 +19,7 @@ using AAEmu.Game.Models.Game.Housing;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
 using AAEmu.Game.Models.Game.Items.Templates;
+using AAEmu.Game.Models.Game.Quests;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
@@ -1928,6 +1929,30 @@ public class DoodadManager(INonUnitObjectIdManager objectIdManager, IDoodadIdMan
                 }
             }
 
+            // doodad_func_quest_reacts
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT * FROM doodad_func_quest_reacts";
+                command.Prepare();
+                using (var reader = new SQLiteWrapperReader(command.ExecuteReader()))
+                {
+                    while (reader.Read())
+                    {
+                        var func = new DoodadFuncQuestReact
+                        {
+                            Id = reader.GetUInt32("id"),
+                            QuestId = reader.GetUInt32("quest_id", 0),
+                            QuestStatusId = reader.GetUInt32("quest_status_id", 0),
+                            NextPhase = reader.GetInt32("next_phase", -1),
+                            QuestComponentId = reader.GetUInt32("quest_component_id", 0),
+                            BubbleOnce = reader.GetBoolean("bubble_once", true),
+                            BubbleId = reader.GetUInt32("bubble_id", 0)
+                        };
+                        _phaseFuncTemplates["DoodadFuncQuestReact"].Add(func.Id, func);
+                    }
+                }
+            }
+
             // doodad_func_respawns
             using (var command = connection.CreateCommand())
             {
@@ -2298,6 +2323,7 @@ public class DoodadManager(INonUnitObjectIdManager objectIdManager, IDoodadIdMan
                         template.MaxTime = reader.GetInt32("max_time", 0);
                         template.ModelKindId = reader.GetUInt32("model_kind_id");
                         template.Model = reader.GetString("model", "") ?? "";
+                        template.ClientDoodad = reader.GetBoolean("client_doodad", true);
                         template.LoadModelFromWorld = reader.GetBoolean("load_model_from_world", false);
                         template.SystemDoodad = reader.GetBoolean("system_doodad", false);
                         template.UseCreatorFaction = reader.GetBoolean("use_creator_faction", true);
@@ -2758,6 +2784,52 @@ public class DoodadManager(INonUnitObjectIdManager objectIdManager, IDoodadIdMan
         }
 
         return funcs.GetValueOrDefault(funcId);
+    }
+
+    public void AddQuestFuncTemplateIds(ISet<uint> dest)
+    {
+        if (dest == null || _templates == null)
+            return;
+
+        foreach (var template in _templates.Values)
+        {
+            foreach (var group in template.FuncGroups)
+            {
+                foreach (var func in GetFuncsForGroup(group.Id))
+                {
+                    if (func.FuncType != nameof(DoodadFuncQuest))
+                        continue;
+                    dest.Add(template.Id);
+                    goto NextTemplate;
+                }
+            }
+
+            NextTemplate: ;
+        }
+    }
+
+    public void AddNpcTypeTemplateIds(ISet<uint> dest)
+    {
+        if (dest == null || _templates == null)
+            return;
+
+        foreach (var template in _templates.Values)
+        {
+            if (QuestTalkDoodadRules.TryParseNpcTypeModel(template.Model, out _))
+                dest.Add(template.Id);
+        }
+    }
+
+    public void AddClientDoodadTemplateIds(ISet<uint> dest)
+    {
+        if (dest == null || _templates == null)
+            return;
+
+        foreach (var template in _templates.Values)
+        {
+            if (template.ClientDoodad)
+                dest.Add(template.Id);
+        }
     }
 
     public bool OffersQuest(uint doodadTemplateId, uint questId)

--- a/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
@@ -248,7 +248,10 @@ public class EnterWorldManager(
 
             // A cinema that never ended must not take its quest effect with it: the step is
             // already saved, so apply the pending cinema-end buffs before the save below.
-            activeChar.Quests.FlushPendingCinemaEndEffects();
+            // Only a session that reached the world can deliver them — leaving from select
+            // (a refused zone entry, say) keeps the queue, and the save rewrites its row.
+            if (activeChar.WorldEntryCompleted)
+                activeChar.Quests.FlushPendingCinemaEndEffects();
 
             // Despawn and unmount everybody from owned Mates
             activeChar.ParentWorld.MateManager.RemoveAndDespawnAllActiveOwnedMates(activeChar);

--- a/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
@@ -1,4 +1,4 @@
-using AAEmu.Commons.Cryptography;
+﻿using AAEmu.Commons.Cryptography;
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Connections;
@@ -245,6 +245,10 @@ public class EnterWorldManager(
 
             // Remove all remaining quest timer tasks
             questManager.RemoveQuestTimer(activeChar.Id, 0);
+
+            // A cinema that never ended must not take its quest effect with it: the step is
+            // already saved, so apply the pending cinema-end buffs before the save below.
+            activeChar.Quests.FlushPendingCinemaEndEffects();;
 
             // Despawn and unmount everybody from owned Mates
             activeChar.ParentWorld.MateManager.RemoveAndDespawnAllActiveOwnedMates(activeChar);

--- a/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/EnterWorldManager.cs
@@ -248,7 +248,7 @@ public class EnterWorldManager(
 
             // A cinema that never ended must not take its quest effect with it: the step is
             // already saved, so apply the pending cinema-end buffs before the save below.
-            activeChar.Quests.FlushPendingCinemaEndEffects();;
+            activeChar.Quests.FlushPendingCinemaEndEffects();
 
             // Despawn and unmount everybody from owned Mates
             activeChar.ParentWorld.MateManager.RemoveAndDespawnAllActiveOwnedMates(activeChar);

--- a/AAEmu.Game/Core/Managers/World/SphereQuestManager.cs
+++ b/AAEmu.Game/Core/Managers/World/SphereQuestManager.cs
@@ -601,10 +601,34 @@ public class SphereQuestManager(WorldInstance parent) : ISphereQuestManager
     public static List<SphereQuest> GetSpheresForQuest(uint questSphereQuestId)
     {
         var res = new List<SphereQuest>();
+        if (_sphereQuests == null)
+            return res;
 
         foreach (var questSpheres in _sphereQuests.Values)
             res.AddRange(questSpheres.Where(x => x.QuestId == questSphereQuestId).ToList());
 
         return res;
+    }
+
+    /// <summary>
+    /// <c>quest_area_sphere.g</c> volume whose <c>stype</c> is <paramref name="sphereId"/>
+    /// and that contains <paramref name="worldPos"/>.
+    /// </summary>
+    public static SphereQuest FindContainingQuestAreaSphere(uint sphereId, Vector3 worldPos)
+    {
+        if (sphereId == 0)
+            return null;
+
+        var grid = _questAreaSphereGrid;
+        if (grid == null || !grid.TryGetValue(SphereGridCellOf(worldPos.X, worldPos.Y), out var candidates))
+            return null;
+
+        foreach (var sphere in candidates)
+        {
+            if (sphere.SphereId == sphereId && sphere.Contains(worldPos))
+                return sphere;
+        }
+
+        return null;
     }
 }

--- a/AAEmu.Game/Core/Managers/World/WorldManager.cs
+++ b/AAEmu.Game/Core/Managers/World/WorldManager.cs
@@ -1285,36 +1285,44 @@ public class WorldManager(
             familyManager.Value.OnCharacterLogin(character);
         }
 
-        // Ensure nearby NPCs/doodads are streamed after world entry (Phase 2 visibility).
-        ResendVisibleObjectsToCharacter(character);
+        // Region enter already painted. Only fill gaps — do not duplicate UnitState.
+        ResendVisibleObjectsToCharacter(character, clientDroppedVisibility: false);
     }
 
-    public static void ResendVisibleObjectsToCharacter(Character character)
+    public static void ResendVisibleObjectsToCharacter(Character character, bool clientDroppedVisibility)
     {
-        // Re-send visible flags to character getting out of cinema
         var stuffs = GetNeighborRegionsObjs<GameObject>(character);
         var doodads = new List<Doodad>();
         foreach (var stuff in stuffs)
         {
             if (stuff is Doodad d)
-                doodads.Add(d);
-            else
             {
-                // Mirror SCUnitState often lands mid-intro cinema; the client drops those units, but
-                // MirrorNpcStatesSentIds still blocks a second send — so Resend was a no-op and
-                // Elf starters saw an empty world until they walked far enough for new AOI entries.
-                if (stuff is Npc npc && npc.IsZoneMirror)
-                    character.ReleaseMirrorNpcSlot(npc.ObjId);
-                if (stuff is Slave slave)
-                {
-                    // Keeps exit-band eligibility for a hull already streamed (230 m after a
-                    // cinema must repaint, not wait for a fresh 225 m entry).
-                    slave.ResendVisibleObject(character);
-                    continue;
-                }
-                stuff.AddVisibleObject(character);
+                doodads.Add(d);
+                continue;
             }
+
+            if (stuff is Npc npc && npc.IsZoneMirror)
+            {
+                var alreadyStreamed = character.MirrorNpcStatesSentIds.ContainsKey(npc.ObjId);
+                if (!VisibleObjectResendRules.ShouldRepaintMirror(alreadyStreamed, clientDroppedVisibility))
+                    continue;
+                if (clientDroppedVisibility)
+                    character.ReleaseMirrorNpcSlot(npc.ObjId);
+            }
+
+            if (stuff is Slave slave)
+            {
+                // Keeps exit-band eligibility for a hull already streamed (230 m after a
+                // cinema must repaint, not wait for a fresh 225 m entry).
+                slave.ResendVisibleObject(character);
+                continue;
+            }
+
+            stuff.AddVisibleObject(character);
         }
+
+        if (!VisibleObjectResendRules.ShouldResendDoodadCreates(clientDroppedVisibility))
+            return;
 
         for (var i = 0; i < doodads.Count; i += SCDoodadsCreatedPacket.MaxCountPerPacket)
         {

--- a/AAEmu.Game/Core/Packets/C2G/CSCompletedCinemaPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSCompletedCinemaPacket.cs
@@ -16,7 +16,7 @@ public class CSCompletedCinemaPacket() : GamePacket(CSOffsets.CSCompletedCinemaP
             character.CurrentlyPlayingCinemaId = cinemaId;
         Logger.Warn("CompletedCinema cinema={0}", cinemaId);
         character.Quests.ApplyCinemaEndEffects(cinemaId);
-        WorldManager.ResendVisibleObjectsToCharacter(character);
+        WorldManager.ResendVisibleObjectsToCharacter(character, clientDroppedVisibility: true);
         character.Events.OnCinemaEnded(character, new OnCinemaEndedArgs { CinemaId = cinemaId });
         if (character.CurrentlyPlayingCinemaId == cinemaId)
             character.CurrentlyPlayingCinemaId = 0;

--- a/AAEmu.Game/Core/Packets/C2G/CSCompletedCinemaPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSCompletedCinemaPacket.cs
@@ -10,9 +10,15 @@ public class CSCompletedCinemaPacket() : GamePacket(CSOffsets.CSCompletedCinemaP
     public override void Read(PacketStream stream)
     {
         // Empty struct
-        Logger.Warn("CompletedCinema");
-
-        WorldManager.ResendVisibleObjectsToCharacter(Connection.ActiveChar);
-        Connection.ActiveChar.Events.OnCinemaEnded(Connection.ActiveChar, new OnCinemaEndedArgs { CinemaId = Connection.ActiveChar.CurrentlyPlayingCinemaId });
+        var character = Connection.ActiveChar;
+        var cinemaId = character.Quests.ResolvePlayingCinemaId(character.CurrentlyPlayingCinemaId);
+        if (cinemaId != 0)
+            character.CurrentlyPlayingCinemaId = cinemaId;
+        Logger.Warn("CompletedCinema cinema={0}", cinemaId);
+        character.Quests.ApplyCinemaEndEffects(cinemaId);
+        WorldManager.ResendVisibleObjectsToCharacter(character);
+        character.Events.OnCinemaEnded(character, new OnCinemaEndedArgs { CinemaId = cinemaId });
+        if (character.CurrentlyPlayingCinemaId == cinemaId)
+            character.CurrentlyPlayingCinemaId = 0;
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSInteractNPCPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSInteractNPCPacket.cs
@@ -1,5 +1,6 @@
 using AAEmu.Commons.Network;
 using AAEmu.Game;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.NPChar;
@@ -34,6 +35,14 @@ public class CSInteractNPCPacket() : GamePacket(CSOffsets.CSInteractNPCPacket, 1
 
         // A zero-entry table is the native representation of no known aggro for this NPC.
         Connection.SendPacket(new SCAiAggroPacket(objId));
+
+        // F-talk only sent this packet. Without the skill list the client opens
+        // a directing window that cannot confirm (no start packet). Same body
+        // as right-click CSStartInteraction, extraInfo=1 / empty pick.
+        var option = NpcInteractionRules.PrimarySkill(
+            npc.Template,
+            QuestManager.Instance.IsQuestTalkNpc(npc.TemplateId));
+        character.SendPacket(new SCNpcInteractionSkillListPacket(objId, 0, 1, 0, 0, 0, [option]));
 
         if (WorldIntegration.ZoneAuthority)
             WorldIntegration.RelayInteractNpcToZone?.Invoke(character.ObjId, objId, false);

--- a/AAEmu.Game/Core/Packets/C2G/CSNotifyInGameCompletedPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSNotifyInGameCompletedPacket.cs
@@ -19,6 +19,9 @@ public class CSNotifyInGameCompletedPacket() : GamePacket(CSOffsets.CSNotifyInGa
         {
             WorldIntegration.SyncTowerDefsToCharacter?.Invoke(Connection.ActiveChar);
             SquadManager.Instance.SyncClientSquadAfterLogin(Connection.ActiveChar);
+            // A cinema the previous session never finished still owes its buff or teleport.
+            // Load only queues it — the effect needs the live connection that entry brings.
+            Connection.ActiveChar.Quests.FlushPendingCinemaEndEffects();
         }
     }
 

--- a/AAEmu.Game/Core/Packets/C2G/CSNotifyInGameCompletedPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSNotifyInGameCompletedPacket.cs
@@ -19,6 +19,7 @@ public class CSNotifyInGameCompletedPacket() : GamePacket(CSOffsets.CSNotifyInGa
         {
             WorldIntegration.SyncTowerDefsToCharacter?.Invoke(Connection.ActiveChar);
             SquadManager.Instance.SyncClientSquadAfterLogin(Connection.ActiveChar);
+            Connection.ActiveChar.WorldEntryCompleted = true;
             // A cinema the previous session never finished still owes its buff or teleport.
             // Load only queues it — the effect needs the live connection that entry brings.
             Connection.ActiveChar.Quests.FlushPendingCinemaEndEffects();

--- a/AAEmu.Game/Core/Packets/C2G/CSNotifyInGamePacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSNotifyInGamePacket.cs
@@ -4,6 +4,8 @@ using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Connections;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.GameData;
+using AAEmu.Game.Models;
 using AAEmu.Game.Models.Game.Chat;
 using AAEmu.Game.Models.Game.Items;
 
@@ -61,6 +63,16 @@ public class CSNotifyInGamePacket() : GamePacket(CSOffsets.CSNotifyInGamePacket,
         // Zone already owns presence when ZoneAuthority + TryEnterZone succeeded above.
         Connection.ActiveChar.Spawn();
 
+        // GetWorldLevel binds to the local player unit created by Spawn. Sending it in the
+        // select burst leaves that unit link null and the HUD provider null-derefs.
+        Connection.ActiveChar.SendPacket(new SCWorldLevelInfoPacket(
+            WorldLevelGameData.Instance.CreateFor(
+                Connection.ActiveChar.Level,
+                AppConfiguration.Instance.World.PlayerLevelCap)));
+
+        // In-world start/complete checks read the journal after the local player exists.
+        Connection.ActiveChar.Quests.SendInitialState();
+
         // DO NOT seed the physics clock from the server's Environment.TickCount64 here. That is the SERVER
         // uptime domain (~tens of millions of ms), NOT the client's physics clock (which starts near 0 at
         // client launch). Seeding it made every self/NPC stand carry a tPhy ~89,000,000 ms in the client's
@@ -104,12 +116,6 @@ public class CSNotifyInGamePacket() : GamePacket(CSOffsets.CSNotifyInGamePacket,
         // client crashes on show without them. The reference server sends this (all-zero, no active events) at
         // world entry — emit it here so the window has data before it renders.
         Connection.ActiveChar.SendPacket(new SCEventInfoCountPacket());
-
-        // World-level state for the GetWorldLevel HUD provider. Must be sent AFTER Spawn() (above): the client's
-        // world-level manager binds this data to the local player unit, so the unit has to exist or its link
-        // (*(ClientPlayer+104)+8) stays null and the provider null-derefs when the player-frame event window shows.
-        // The reference emits 0x038A ~4s after NotifyInGame, never in the select burst.
-        Connection.ActiveChar.SendPacket(new SCWorldLevelInfoPacket());
 
         // Daily schedule: load persisted contracts for today, then reset-count budget.
         TodayAssignmentManager.Instance.OnCharacterEnterWorld(Connection.ActiveChar);

--- a/AAEmu.Game/Core/Packets/C2G/CSRequestPermissionToPlayCinemaForDirectingMode.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRequestPermissionToPlayCinemaForDirectingMode.cs
@@ -1,8 +1,9 @@
 ﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Quests;
-using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -16,20 +17,35 @@ public class CSRequestPermissionToPlayCinemaForDirectingMode()
         var doodadObjId = stream.ReadBc();
 
         var character = Connection.ActiveChar;
+        if (character == null)
+            return;
+
         var component = QuestManager.Instance.GetComponent(packetId);
-        var questId = component?.ParentQuestTemplate?.Id ?? packetId;
-        QuestComponentKind? preferStep = component?.KindId;
-        if (preferStep == null && character?.Quests.ActiveQuests.TryGetValue(questId, out var quest) == true)
-            preferStep = quest.Step;
-        var cinemaId = QuestCinemaRules.CinemaIdForPermission(
-            component,
-            QuestManager.Instance.GetTemplate(questId),
-            preferStep);
-        if (character != null && cinemaId != 0)
+        var questId = component?.ParentQuestTemplate?.Id ?? 0;
+        var cinemaId = QuestCinemaRules.CinemaIdForPermission(component, null);
+        var npc = npcObjId != 0 ? character.ParentWorld?.GetNpc(npcObjId) : null;
+        var doodad = doodadObjId != 0 ? character.ParentWorld?.GetDoodad(doodadObjId) : null;
+        var npcDistance = DistanceTo(character, npc);
+        var doodadDistance = DistanceTo(character, doodad);
+        var questActive = questId != 0 && character.Quests.HasQuest(questId);
+        var allowed = QuestCinemaPermissionRules.CanBind(
+            cinemaId,
+            component != null,
+            questActive,
+            component?.KindId,
+            QuestCinemaPermissionRules.SourceAllowed(npcObjId != 0, npc != null, npcDistance),
+            QuestCinemaPermissionRules.SourceAllowed(doodadObjId != 0, doodad != null, doodadDistance));
+
+        if (allowed)
             character.Quests.BindPlayingCinema(cinemaId);
+        else
+            cinemaId = 0;
 
         Logger.Warn(
-            "CSRequestPermissionToPlayCinemaForDirectingMode id={0} quest={1} npc={2} doodad={3} cinema={4}",
-            packetId, questId, npcObjId, doodadObjId, cinemaId);
+            "CSRequestPermissionToPlayCinemaForDirectingMode id={0} quest={1} npc={2} doodad={3} cinema={4} allowed={5}",
+            packetId, questId, npcObjId, doodadObjId, cinemaId, allowed);
     }
+
+    private static float DistanceTo(Character character, BaseUnit source) =>
+        source == null ? float.MaxValue : character.GetDistanceTo(source, true);
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSRequestPermissionToPlayCinemaForDirectingMode.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSRequestPermissionToPlayCinemaForDirectingMode.cs
@@ -1,5 +1,8 @@
 ﻿using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Static;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -8,10 +11,25 @@ public class CSRequestPermissionToPlayCinemaForDirectingMode()
 {
     public override void Read(PacketStream stream)
     {
-        var questContextId = stream.ReadUInt32();
+        var packetId = stream.ReadUInt32();
         var npcObjId = stream.ReadBc();
         var doodadObjId = stream.ReadBc();
 
-        Logger.Warn("CSRequestPermissionToPlayCinemaForDirectingMode");
+        var character = Connection.ActiveChar;
+        var component = QuestManager.Instance.GetComponent(packetId);
+        var questId = component?.ParentQuestTemplate?.Id ?? packetId;
+        QuestComponentKind? preferStep = component?.KindId;
+        if (preferStep == null && character?.Quests.ActiveQuests.TryGetValue(questId, out var quest) == true)
+            preferStep = quest.Step;
+        var cinemaId = QuestCinemaRules.CinemaIdForPermission(
+            component,
+            QuestManager.Instance.GetTemplate(questId),
+            preferStep);
+        if (character != null && cinemaId != 0)
+            character.Quests.BindPlayingCinema(cinemaId);
+
+        Logger.Warn(
+            "CSRequestPermissionToPlayCinemaForDirectingMode id={0} quest={1} npc={2} doodad={3} cinema={4}",
+            packetId, questId, npcObjId, doodadObjId, cinemaId);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
@@ -1,4 +1,4 @@
-using AAEmu.Commons.Network;
+﻿using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Managers.Id;
 using AAEmu.Game.Core.Managers.UnitManagers;
@@ -41,6 +41,7 @@ public class CSSelectCharacterPacket() : GamePacket(CSOffsets.CSSelectCharacterP
             // the client drops. Reset on select so the inactivity window starts at enter, not at lobby load.
             character.LastPacketActivityTime = DateTime.UtcNow;
             character.ResetMirrorNpcStreaming();
+            character.WorldEntryCompleted = false;
             if (Character.UsedCharacterObjIds.TryGetValue(character.Id, out var oldObjId))
             {
                 Connection.ActiveChar.ObjId = oldObjId;

--- a/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSSelectCharacterPacket.cs
@@ -123,13 +123,12 @@ public class CSSelectCharacterPacket() : GamePacket(CSOffsets.CSSelectCharacterP
             Connection.SendPacket(new SCUpdateAdditionalSkillPointPacket());
 
             foreach (var houseBatch in houses.Chunk(SCHouseDataPacket.MaxEntries))
-            {
                 Connection.SendPacket(new SCHouseDataPacket(houseBatch));
-            }
 
             foreach (var conflict in ZoneManager.Instance.GetConflicts())
             {
-                Connection.SendPacket(new SCConflictZoneStatePacket(conflict.ZoneGroupId, conflict.CurrentZoneState, conflict.NextStateTime));
+                Connection.SendPacket(new SCConflictZoneStatePacket(
+                    conflict.ZoneGroupId, conflict.CurrentZoneState, conflict.NextStateTime));
             }
 
             // 10.0.2.13: SCFactionList (opcode 0x08) was removed; system-faction descriptors are

--- a/AAEmu.Game/Core/Packets/C2G/CSStartInteractionPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartInteractionPacket.cs
@@ -1,6 +1,8 @@
 ﻿using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.StaticValues;
 
@@ -32,29 +34,10 @@ public class CSStartInteractionPacket() : GamePacket(CSOffsets.CSStartInteractio
             // This could later be used to implement some of the anti-cheating
             // 0 is the intended default or else quests go wonky
 
-            uint option = 0;
-            if (npc.Template.Banker)
-                option = SkillsEnum.UseWarehouse; // Open warehouse
-            // TODO: fill in the skills and maybe change the order to what it would show in-game
-            else if (npc.Template.AbilityChanger)
-                option = SkillsEnum.ChangeSkillsets; // Open Skill-Trainer
-            else if (npc.Template.Auctioneer)
-                option = SkillsEnum.UseAuctioneer; // Open Auctioneer
-            else if (npc.Template.Priest)
-                option = SkillsEnum.Blessing; // Open Recover-Exp dialog ?
-            else if (npc.Template.Repairman)
-                option = SkillsEnum.Repair; // Open Repair dialog ?
-            else if (npc.Template.Merchant)
-                option = SkillsEnum.UseStore; // Open Shop dialog ?
-            else if (npc.Template.Stabler)
-                option = SkillsEnum.HealPetSWounds; // Open Pet Recovery dialog ?
-            else if (npc.Template.Expedition)
-                option = SkillsEnum.FormGuild; // Open Repair dialog ?
-            else if (npc.Template.RecrutingBattlefieldId > 0)
-                option = SkillsEnum.WarSupport; // Open Arena dialog ?
-            else if (npc.Template.Blacksmith)
-                option = SkillsEnum.ItemFusion; // Open Item Fuse dialog ?
-
+            // 0 keeps quest talk. Other NPC roles replace that first slot.
+            var option = NpcInteractionRules.PrimarySkill(
+                npc.Template,
+                QuestManager.Instance.IsQuestTalkNpc(npc.TemplateId));
             Connection.ActiveChar.SendPacket(new SCNpcInteractionSkillListPacket(npcObjId, objId, extraInfo,
                 pickId, mouseButton, modifierKeys, [option]));
         }

--- a/AAEmu.Game/Core/Packets/C2G/CSStartQuestContextPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartQuestContextPacket.cs
@@ -17,6 +17,13 @@ public class CSStartQuestContextPacket() : GamePacket(CSOffsets.CSStartQuestCont
         _doodadObjId = stream.ReadBc();        // doodadObjId
         _sphereId = stream.ReadUInt32();       // selected
 
+        Logger.Info(
+            "CSStartQuestContext quest={0} npcObj={1} doodadObj={2} sphere={3}",
+            _questContextId,
+            _npcObjId,
+            _doodadObjId,
+            _sphereId);
+
         if (_npcObjId > 0)
             Connection.ActiveChar.Quests.AddQuestFromNpc(_questContextId, _npcObjId);
         else if (_doodadObjId > 0)

--- a/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSStartSkillPacket.cs
@@ -329,9 +329,12 @@ public class CSStartSkillPacket() : GamePacket(CSOffsets.CSStartSkillPacket, 1)
         if (skillResult != SkillResult.Success)
         {
             // Don't poison the melee hotbar with CooldownTime fails — client auto-retries skill 2/3/4.
-            if (skillId is 2 or 3 or 4 && skillResult == SkillResult.CooldownTime)
+            if (skillResult == SkillResult.CooldownTime &&
+                (skillId is 2 or 3 or 4 ||
+                 template.StartAutoAttack ||
+                 SkillCastOverlapRules.IsInstantComboHit(template.CastingTime, template.CustomGcd)))
             {
-                Logger.Trace("ZoneAuthority basic-attack CooldownTime skillId={0} (suppressed fail packet)", skillId);
+                Logger.Trace("ZoneAuthority hold/combo CooldownTime skillId={0} (suppressed fail packet)", skillId);
                 return;
             }
 

--- a/AAEmu.Game/Core/Packets/C2G/CSTeleportEndedPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSTeleportEndedPacket.cs
@@ -36,6 +36,6 @@ public class CSTeleportEndedPacket() : GamePacket(CSOffsets.CSTeleportEndedPacke
         Logger.Info("TeleportEnded applied {0} -> ({1:0.0},{2:0.0},{3:0.0}) zone={4}",
             me.Name, x, y, z, me.Transform.ZoneId);
 
-        WorldManager.ResendVisibleObjectsToCharacter(me);
+        WorldManager.ResendVisibleObjectsToCharacter(me, clientDroppedVisibility: false);
     }
 }

--- a/AAEmu.Game/Core/Packets/C2G/CSTeleportEndedPacket.cs
+++ b/AAEmu.Game/Core/Packets/C2G/CSTeleportEndedPacket.cs
@@ -2,6 +2,7 @@
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.Teleport;
 
 namespace AAEmu.Game.Core.Packets.C2G;
 
@@ -23,6 +24,12 @@ public class CSTeleportEndedPacket() : GamePacket(CSOffsets.CSTeleportEndedPacke
         // Transform on the old cell, so later GM spawns used dry-land coords
         // while the client was already at the destination.
         me.DisabledSetPosition = false;
+        if (!ReturnTeleportRules.ShouldApplyEndedPosition(x, y, z))
+        {
+            Logger.Warn("TeleportEnded ignored origin for {0} zone={1}", me.Name, me.Transform.ZoneId);
+            return;
+        }
+
         var rot = me.Transform.World.Rotation;
         me.SetPosition(x, y, z, rot.X, rot.Y, rot.Z);
         me.Transform.FinalizeTransform();

--- a/AAEmu.Game/Core/Packets/G2C/SCDoodadCompleteQuestPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDoodadCompleteQuestPacket.cs
@@ -3,19 +3,14 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-/// <summary>
-/// TODO: nothing constructs this packet yet.
-/// </summary>
-/// <remarks>
-/// Field order, widths and names come from the 10.0.2.13 client's serializer, which passes each
-/// value's name alongside the value:
-/// </remarks>
-public class SCDoodadCompleteQuestPacket(uint bc, int @type) : GamePacket(SCOffsets.SCDoodadCompleteQuestPacket, 1)
+public class SCDoodadCompleteQuestPacket(uint doodadObjId, uint questContextId)
+    : GamePacket(SCOffsets.SCDoodadCompleteQuestPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.WriteBc(bc);
-        stream.Write(@type);
+        stream.WriteBc(doodadObjId);
+        stream.Write(questContextId);
+
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCDoodadCreatedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDoodadCreatedPacket.cs
@@ -4,10 +4,15 @@ using AAEmu.Game.Models.Game.DoodadObj;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCDoodadCreatedPacket(Doodad doodad) : GamePacket(SCOffsets.SCDoodadCreatedPacket, 1)
+public class SCDoodadCreatedPacket(Doodad doodad, uint funcGroupId) : GamePacket(SCOffsets.SCDoodadCreatedPacket, 1)
 {
+    public SCDoodadCreatedPacket(Doodad doodad)
+        : this(doodad, doodad.FuncGroupId)
+    {
+    }
+
     public override PacketStream Write(PacketStream stream)
     {
-        return doodad.Write(stream);
+        return doodad.Write(stream, funcGroupId);
     }
 }

--- a/AAEmu.Game/Core/Packets/G2C/SCDoodadPhaseChangedPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCDoodadPhaseChangedPacket.cs
@@ -7,23 +7,29 @@ namespace AAEmu.Game.Core.Packets.G2C;
 public class SCDoodadPhaseChangedPacket : GamePacket
 {
     private readonly Doodad _doodad;
+    private readonly uint _funcGroupId;
 
-    public SCDoodadPhaseChangedPacket(Doodad doodad) : base(SCOffsets.SCDoodadPhaseChangedPacket, 1)
+    public SCDoodadPhaseChangedPacket(Doodad doodad) : this(doodad, doodad.FuncGroupId)
+    {
+    }
+
+    public SCDoodadPhaseChangedPacket(Doodad doodad, uint funcGroupId) : base(SCOffsets.SCDoodadPhaseChangedPacket, 1)
     {
         _doodad = doodad;
-        Logger.Trace("[Doodad] [0] SCDoodadPhaseChangedPacket: TemplateId {0}, ObjId {1},  CurrentPhaseId {2}, TimeLeft {3}", _doodad.TemplateId, _doodad.ObjId, _doodad.FuncGroupId, _doodad.TimeLeft);
+        _funcGroupId = funcGroupId;
+        Logger.Trace("[Doodad] [0] SCDoodadPhaseChangedPacket: TemplateId {0}, ObjId {1},  CurrentPhaseId {2}, TimeLeft {3}", _doodad.TemplateId, _doodad.ObjId, _funcGroupId, _doodad.TimeLeft);
     }
 
     public override PacketStream Write(PacketStream stream)
     {
-        Logger.Debug("[Doodad] [2] SCDoodadPhaseChangedPacket: TemplateId {0}, ObjId {1},  CurrentPhaseId {2}, TimeLeft {3}", _doodad.TemplateId, _doodad.ObjId, _doodad.FuncGroupId, _doodad.TimeLeft);
+        Logger.Debug("[Doodad] [2] SCDoodadPhaseChangedPacket: TemplateId {0}, ObjId {1},  CurrentPhaseId {2}, TimeLeft {3}", _doodad.TemplateId, _doodad.ObjId, _funcGroupId, _doodad.TimeLeft);
 
         // bc objId, u32 newFuncGroupId, u32 data, u32 growing, i32 puzzleGroup, u32 itemTemplateId,
         // bool isGoods (+ optional freshness/type/type when true).
         // Old layout omitted `data` + `isGoods` → client over-read into the next SC packet and/or
         // never applied the open/close model swap (housing door tpl 4566 stayed closed).
         stream.WriteBc(_doodad.ObjId);
-        stream.Write(_doodad.FuncGroupId);
+        stream.Write(_funcGroupId);
         stream.Write(_doodad.Data);
         stream.Write(_doodad.TimeLeft); // growing
         stream.Write(_doodad.PuzzleGroup);

--- a/AAEmu.Game/Core/Packets/G2C/SCServerInfoPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCServerInfoPacket.cs
@@ -1,14 +1,10 @@
 using AAEmu.Commons.Network;
-using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
 public class SCServerInfoPacket(long serverOpenTime) : GamePacket(SCOffsets.SCServerInfoPacket, 1)
 {
-    // emits Value("serverOpenTime", obj+16) via the ISerialize u64 slot (vtbl+0x78). Unix seconds (capture:
-    public SCServerInfoPacket() : this(Helpers.UnixTimeNow()) { }
-
     public override PacketStream Write(PacketStream stream)
     {
         stream.Write(serverOpenTime);

--- a/AAEmu.Game/Core/Packets/G2C/SCWorldLevelInfoPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCWorldLevelInfoPacket.cs
@@ -1,21 +1,23 @@
 using AAEmu.Commons.Network;
 using AAEmu.Game.Core.Network.Game;
+using AAEmu.Game.Models.Game.World;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-// SC_PACKET_WORLD_LEVEL_INFO (906). Carries the world-level state the client's player-frame gauge reads to render
-// the world-level-vs-character-level indicator. Without it the client's world-level data pointer stays null and
-// the gauge provider dereferences it on show. Values mirror the reference world-entry capture.
-public class SCWorldLevelInfoPacket() : GamePacket(SCOffsets.SCWorldLevelInfoPacket, 1)
+/// <summary>
+/// Opcode 0x38A. Six u32 fields the client names worldLevel, serverDays, expModifier,
+/// hardCapLevel, characterLevel, levelDiff.
+/// </summary>
+public class SCWorldLevelInfoPacket(WorldLevelInfoWire info) : GamePacket(SCOffsets.SCWorldLevelInfoPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
     {
-        stream.Write(42u);          // worldLevel
-        stream.Write(6u);           // grade
-        stream.Write(10000u);       // exp
-        stream.Write(0u);           // nextExp
-        stream.Write(1u);           // enabled
-        stream.Write(unchecked((uint)-41)); // bonus
+        stream.Write(info.WorldLevel);
+        stream.Write(info.ServerDays);
+        stream.Write(info.ExpModifier);
+        stream.Write(info.HardCapLevel);
+        stream.Write(info.CharacterLevel);
+        stream.Write(info.LevelDiff);
         return stream;
     }
 }

--- a/AAEmu.Game/Core/Packets/Proxy/FinishStatePacket.cs
+++ b/AAEmu.Game/Core/Packets/Proxy/FinishStatePacket.cs
@@ -28,10 +28,12 @@ public class FinishStatePacket() : GamePacket(PPOffsets.FinishStatePacket, 2)
                     initialConfig.LobbyImmersiveMode));
                 Connection.SendPacket(new SCInitialConfigPacket());
 
-                // Lobby config-burst order verified against a live 10.0.2.13 capture
-                // SCServerInfo then SCWorldContent, then SCAccountInfo. SCWorldContent carries the content-filter
-                // table (sent empty here = no content blocked).
-                Connection.SendPacket(new SCServerInfoPacket());
+                // Lobby config-burst: SCServerInfo, SCWorldContent, then SCAccountInfo.
+                // SCWorldContent carries the content-filter table (empty here = nothing blocked).
+                // serverOpenTime is unix seconds. The client picks world_level_hard_caps
+                // by calendar days since this stamp; "now" is the first band and hides
+                // main-quest Accept. Publish the compact get_quest row instead.
+                Connection.SendPacket(new SCServerInfoPacket(WorldLevelGameData.Instance.ServerOpenUnixTime()));
                 Connection.SendPacket(new SCWorldContentPacket());
 
                 // SCTrionConfig does not exist in the 10.0.2.13 client (its opcode 0x07 now belongs to

--- a/AAEmu.Game/GameData/SphereGameData.cs
+++ b/AAEmu.Game/GameData/SphereGameData.cs
@@ -420,7 +420,7 @@ public class SphereGameData : Singleton<SphereGameData>, IGameDataLoader
     /// <summary>
     /// Checks if a position is inside the given SphereId
     /// </summary>
-    /// <param name="sphereId">Sphere Id as defined in a Quest Act</param>
+    /// <param name="sphereId">Compact <c>spheres.id</c> (quest_area_sphere.g <c>stype</c>)</param>
     /// <param name="value2">Unknown, always one except for skill 13305 (plant unidentified tree)</param>
     /// <param name="worldPosition"></param>
     /// <param name="requiredComponentId"></param>
@@ -430,20 +430,20 @@ public class SphereGameData : Singleton<SphereGameData>, IGameDataLoader
         if (!_spheres.TryGetValue(sphereId, out var dbSphere))
             return null;
 
-        if (dbSphere.SphereDetailType != "SphereQuest")
-            return null;
-
-        if (!_sphereQuests.TryGetValue(dbSphere.SphereDetailId, out var dbSphereQuest))
-            return null;
-
-        var pakDataSpheres = SphereQuestManager.GetSpheresForQuest(dbSphereQuest.QuestId);
-        foreach (var pakDataSphere in pakDataSpheres)
+        var areaAtPosition = SphereQuestManager.FindContainingQuestAreaSphere(sphereId, worldPosition);
+        IEnumerable<SphereQuest> signSpheres = [];
+        if (dbSphere.SphereDetailType == "SphereQuest" &&
+            _sphereQuests.TryGetValue(dbSphere.SphereDetailId, out var dbSphereQuest))
         {
-            if (pakDataSphere.Contains(worldPosition) && (requiredComponentId == 0 || pakDataSphere.ComponentId == requiredComponentId))
-                return pakDataSphere;
+            signSpheres = SphereQuestManager.GetSpheresForQuest(dbSphereQuest.QuestId);
         }
 
-        return null;
+        return AreaSphereHitRules.FindHit(
+            sphereId,
+            worldPosition,
+            requiredComponentId,
+            areaAtPosition == null ? [] : [areaAtPosition],
+            signSpheres);
     }
 
 }

--- a/AAEmu.Game/GameData/TowerDefGameData.cs
+++ b/AAEmu.Game/GameData/TowerDefGameData.cs
@@ -31,6 +31,7 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
     /// Used with boss grade for the 1.5 km event stream — not ambient MAX priority for infantry.
     /// </summary>
     private HashSet<uint> _killQuotaNpcTemplateIds = [];
+    private HashSet<uint> _doodadAlmightyTargetIds = [];
 
     /// <summary>Spawner template id → direct <c>Npc</c> members (portal seed unit ids).</summary>
     private Dictionary<uint, HashSet<uint>> _spawnerMemberNpcs = [];
@@ -49,6 +50,7 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
         _eventSpawnerTemplateIds = [];
         _priorityNpcTemplateIds = [];
         _killQuotaNpcTemplateIds = [];
+        _doodadAlmightyTargetIds = [];
         _spawnerMemberNpcs = [];
 
         using (var command = connection.CreateCommand())
@@ -154,6 +156,9 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
                     };
 
                     towerDefProg.SpawnTargets.Add(template);
+                    if (template.SpawnTargetId != 0 &&
+                        string.Equals(template.SpawnTargetType, "DoodadAlmighty", StringComparison.Ordinal))
+                        _doodadAlmightyTargetIds.Add(template.SpawnTargetId);
                 }
             }
         }
@@ -422,6 +427,8 @@ public class TowerDefGameData : Singleton<TowerDefGameData>, IGameDataLoader
     public TowerDef GetTowerDef(uint id) => _towerDefs.GetValueOrDefault(id);
 
     public IReadOnlyCollection<TowerDef> GetAllTowerDefs() => _towerDefs.Values;
+
+    public IReadOnlySet<uint> GetDoodadAlmightyTargetIds() => _doodadAlmightyTargetIds;
 
     /// <summary>
     /// True when this spawner template is a TowerDef portal or progressive wave arm — schedule

--- a/AAEmu.Game/GameData/WorldLevelGameData.cs
+++ b/AAEmu.Game/GameData/WorldLevelGameData.cs
@@ -1,0 +1,102 @@
+using AAEmu.Commons.Utils;
+using AAEmu.Game.GameData.Framework;
+using AAEmu.Game.Models;
+using AAEmu.Game.Models.Game.World;
+using AAEmu.Game.Utils.DB;
+using Microsoft.Data.Sqlite;
+using NLog;
+
+namespace AAEmu.Game.GameData;
+
+[GameData]
+public class WorldLevelGameData : Singleton<WorldLevelGameData>, IGameDataLoader
+{
+    private static Logger Logger { get; } = LogManager.GetCurrentClassLogger();
+
+    private readonly List<WorldLevelHardCapRow> _hardCaps = [];
+    private readonly List<WorldLevelExpModifierRow> _modifiers = [];
+
+    public void Load(SqliteConnection connection)
+    {
+        _hardCaps.Clear();
+        _modifiers.Clear();
+
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText =
+                """
+                SELECT min_server_days, max_server_days, hard_cap_level, get_quest
+                FROM world_level_hard_caps
+                ORDER BY min_server_days
+                """;
+            command.Prepare();
+            using var sqliteReader = command.ExecuteReader();
+            using var reader = new SQLiteWrapperReader(sqliteReader);
+            while (reader.Read())
+            {
+                _hardCaps.Add(new WorldLevelHardCapRow(
+                    reader.GetInt32("min_server_days"),
+                    reader.GetInt32("max_server_days"),
+                    reader.GetInt32("hard_cap_level"),
+                    reader.GetBoolean("get_quest")));
+            }
+        }
+
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText =
+                """
+                SELECT level_diff_min, level_diff_max, exp_modifier
+                FROM world_level_exp_modifiers
+                ORDER BY level_diff_min
+                """;
+            command.Prepare();
+            using var sqliteReader = command.ExecuteReader();
+            using var reader = new SQLiteWrapperReader(sqliteReader);
+            while (reader.Read())
+            {
+                _modifiers.Add(new WorldLevelExpModifierRow(
+                    reader.GetInt32("level_diff_min"),
+                    reader.GetInt32("level_diff_max"),
+                    (uint)reader.GetDouble("exp_modifier")));
+            }
+        }
+
+        if (_hardCaps.Count == 0)
+            throw new InvalidOperationException("world_level_hard_caps is empty.");
+        if (_modifiers.Count == 0)
+            throw new InvalidOperationException("world_level_exp_modifiers is empty.");
+
+        Logger.Info("Loaded {0} world-level hard caps and {1} exp modifiers", _hardCaps.Count, _modifiers.Count);
+    }
+
+    public void PostLoad()
+    {
+    }
+
+    public WorldLevelInfoWire CreateFor(int characterLevel, int playerLevelCap)
+    {
+        return WorldLevelInfoRules.ForCharacter(characterLevel, playerLevelCap, _hardCaps, _modifiers);
+    }
+
+    public long ServerOpenUnixTime(int playerLevelCap, long nowUnixSeconds)
+    {
+        var unlock = WorldLevelInfoRules.SelectUnlockRow(_hardCaps, playerLevelCap);
+        return WorldLevelInfoRules.ServerOpenUnixTime(nowUnixSeconds, unlock.MinServerDays);
+    }
+
+    public long ServerOpenUnixTime()
+    {
+        return ServerOpenUnixTime(AppConfiguration.Instance.World.PlayerLevelCap, Helpers.UnixTimeNow());
+    }
+
+    public void SetForTest(
+        IReadOnlyList<WorldLevelHardCapRow> hardCaps,
+        IReadOnlyList<WorldLevelExpModifierRow> modifiers)
+    {
+        _hardCaps.Clear();
+        _hardCaps.AddRange(hardCaps);
+        _modifiers.Clear();
+        _modifiers.AddRange(modifiers);
+    }
+}

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -80,6 +80,12 @@ public partial class Character : Unit, ICharacter
     public bool MirrorNpcStreamReady { get; set; }
 
     /// <summary>
+    /// True once this session reached the world. A session that never got in (refused zone
+    /// entry, return to select) must not consume queued quest effects it could not deliver.
+    /// </summary>
+    public bool WorldEntryCompleted { get; set; }
+
+    /// <summary>
     /// Optional delay after Completed before first mirror UnitState (AAEMU_MIRROR_NPC_GRACE_MS).
     /// </summary>
     public long MirrorNpcStreamNotBeforeTick { get; set; }

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -165,10 +165,12 @@ public class CharacterQuests(Character owner)
     }
 
     /// <summary>
-    /// Applies the cinema-end entries a previous session could not finish. The component id
+    /// Queues the cinema-end entries a previous session could not finish. The component id
     /// is the only durable name for the effect, so a component that no longer exists is
     /// dropped with a warning. Production resolves through the quest manager; tests inject
-    /// their own resolver.
+    /// their own resolver. The queued entries are applied by
+    /// <see cref="FlushPendingCinemaEndEffects"/> after world entry or on leave — never
+    /// during load, where the buff packet has no connection.
     /// </summary>
     public void RestorePendingCinemaEndEffects(
         IReadOnlyList<(uint QuestId, uint CinemaId, uint ComponentId)> rows,
@@ -193,8 +195,6 @@ public class CharacterQuests(Character owner)
 
             EnqueueCinemaEndEffects(row.CinemaId, component);
         }
-
-        FlushPendingCinemaEndEffects();
     }
 
     public bool HasQuest(uint questId)
@@ -815,8 +815,9 @@ public class CharacterQuests(Character owner)
         }
 
         // A pending cinema-end effect survives a dropped connection: the client never reports
-        // the film ending and the step is already saved, so apply what the quest still owes.
-        // The rows are cleared once they are restored.
+        // the film ending and the step is already saved. The row is queued here and replayed
+        // after world entry (the buff packet needs the live connection); it is cleared by the
+        // character save that follows, so a failed apply cannot lose it.
         try
         {
             var pendingCinemaEnds = new List<(uint QuestId, uint CinemaId, uint ComponentId)>();
@@ -837,17 +838,7 @@ public class CharacterQuests(Character owner)
                 }
             }
 
-            if (pendingCinemaEnds.Count == 0)
-                return;
-
             RestorePendingCinemaEndEffects(pendingCinemaEnds);
-
-            using (var command = connection.CreateCommand())
-            {
-                command.CommandText = "DELETE FROM character_quest_cinema_end_effects WHERE `owner` = @owner";
-                command.Parameters.AddWithValue("@owner", Owner.Id);
-                command.ExecuteNonQuery();
-            }
         }
         catch (MySqlException ex)
         {

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -17,6 +17,7 @@ using AAEmu.Game.Models.Spheres;
 using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Slaves;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.World;
 using MySql.Data.MySqlClient;
 
@@ -116,10 +117,12 @@ public class CharacterQuests(Character owner)
                 pending.Component.BuffId);
 
             var questId = pending.Component.ParentQuestTemplate?.Id ?? 0;
-            if (questId != 0 && ActiveQuests.TryGetValue(questId, out var quest))
+            if (questId != 0 &&
+                ActiveQuests.TryGetValue(questId, out var quest) &&
+                QuestCinemaBindRules.ShouldApplyCinemaEndEffect(true))
+            {
                 quest.UseSkillAndBuff(pending.Component);
-            else
-                QuestComponentEffectRules.ApplySkillAndBuff(Owner, pending.Component, SkillManager.Instance);
+            }
         }
 
         if (applied == 0)
@@ -282,7 +285,12 @@ public class CharacterQuests(Character owner)
     {
         var doodad = Owner.ParentWorld.GetDoodad(doodadObjId);
         if (doodad != null)
-            return AddQuest(questId, false, QuestAcceptorType.Doodad, doodad.TemplateId);
+        {
+            var started = AddQuest(questId, false, QuestAcceptorType.Doodad, doodad.TemplateId);
+            if (started)
+                doodad.RefreshQuestReactFor(Owner, questId);
+            return started;
+        }
 
         if (!_observedQuestDoodads.TryGetValue(doodadObjId, out var observed) ||
             observed.ZoneId != Owner.Transform.ZoneId ||
@@ -302,6 +310,19 @@ public class CharacterQuests(Character owner)
 
         _observedQuestDoodads[doodadObjId] = new ObservedQuestDoodad(doodadTemplateId, Owner.Transform.ZoneId);
         return true;
+    }
+
+    /// <summary>
+    /// QuestReact rows only live on the current phase. Re-apply nearby after a step
+    /// change so the body flips without a leave/re-enter.
+    /// </summary>
+    public void ApplyNearbyQuestReacts(uint questId)
+    {
+        if (Owner == null || questId == 0)
+            return;
+
+        foreach (var doodad in WorldManager.GetAround<Doodad>(Owner))
+            doodad?.RefreshQuestReactFor(Owner, questId);
     }
 
     /// <summary>
@@ -362,6 +383,7 @@ public class CharacterQuests(Character owner)
         quest.Cleanup();
         quest.Drop(update);
         quest.FinalizeQuestActs();
+        ClearCinemaEndEffects(questId);
         ActiveQuests.Remove(questId);
         _removed.Add(questId);
 
@@ -376,6 +398,18 @@ public class CharacterQuests(Character owner)
         QuestManager.Instance.RemoveQuestTimer(Owner.Id, questId);
 
         QuestIdManager.Instance.ReleaseId((uint)quest.Id);
+    }
+
+    private void ClearCinemaEndEffects(uint questId)
+    {
+        if (questId == 0)
+            return;
+        for (var i = _cinemaEndEffects.Count - 1; i >= 0; i--)
+        {
+            var pendingQuestId = _cinemaEndEffects[i].Component?.ParentQuestTemplate?.Id ?? 0;
+            if (QuestCinemaBindRules.CinemaEndBelongsToQuest(pendingQuestId, questId))
+                _cinemaEndEffects.RemoveAt(i);
+        }
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -15,6 +15,7 @@ using AAEmu.Game.Models.Game.Quests.Static;
 using AAEmu.Game.Models.Game.Quests.Templates;
 using AAEmu.Game.Models.Spheres;
 using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Slaves;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
 using MySql.Data.MySqlClient;
@@ -34,6 +35,101 @@ public class CharacterQuests(Character owner)
     private Character Owner { get; set; } = owner;
     public Dictionary<uint, Quest> ActiveQuests { get; } = [];
     private Dictionary<ushort, CompletedQuest> CompletedQuests { get; } = [];
+    private readonly List<(uint CinemaId, QuestComponentTemplate Component)> _cinemaEndEffects = [];
+
+    public void BindPlayingCinema(uint cinemaId)
+    {
+        if (cinemaId != 0)
+            Owner.CurrentlyPlayingCinemaId = cinemaId;
+    }
+
+    /// <summary>
+    /// Permission / talk may already be playing this cinema before Progress
+    /// initializes. Credit it now so complete + next accept happen during the film.
+    /// </summary>
+    public void BindAndCreditPlayingCinema(uint cinemaId)
+    {
+        if (!QuestCinemaBindRules.ShouldReplacePlaying(Owner.CurrentlyPlayingCinemaId, cinemaId))
+            return;
+
+        var alreadyPlaying = QuestCinemaBindRules.ShouldCreditOnEnterProgress(
+            Owner.CurrentlyPlayingCinemaId, cinemaId);
+        Owner.CurrentlyPlayingCinemaId = cinemaId;
+        if (alreadyPlaying)
+            Owner.Events.OnCinemaStarted(Owner, new OnCinemaStartedArgs { CinemaId = cinemaId });
+    }
+
+    public void EnqueueCinemaEndEffects(uint cinemaId, QuestComponentTemplate component)
+    {
+        if (cinemaId == 0 || component == null)
+            return;
+        _cinemaEndEffects.Add((cinemaId, component));
+        Logger.Info(
+            "Quest component buff deferred until cinema={0} component={1} buff={2}",
+            cinemaId,
+            component.Id,
+            component.BuffId);
+    }
+
+    public IReadOnlyList<uint> DeferredCinemaIds()
+    {
+        if (_cinemaEndEffects.Count == 0)
+            return [];
+        var ids = new uint[_cinemaEndEffects.Count];
+        for (var i = 0; i < _cinemaEndEffects.Count; i++)
+            ids[i] = _cinemaEndEffects[i].CinemaId;
+        return ids;
+    }
+
+    public uint ResolvePlayingCinemaId(uint reported) =>
+        QuestCinemaBindRules.ResolveCompletedCinema(reported, DeferredCinemaIds());
+
+    public void ApplyCinemaEndEffects(uint cinemaId)
+    {
+        if (_cinemaEndEffects.Count == 0)
+            return;
+        cinemaId = ResolvePlayingCinemaId(cinemaId);
+        if (cinemaId == 0)
+        {
+            Logger.Warn(
+                "Quest cinema-end skipped, playing id is 0 with {0} deferred buff(s)",
+                _cinemaEndEffects.Count);
+            return;
+        }
+
+        var applied = 0;
+        for (var i = 0; i < _cinemaEndEffects.Count;)
+        {
+            var pending = _cinemaEndEffects[i];
+            if (pending.CinemaId != cinemaId)
+            {
+                i++;
+                continue;
+            }
+            applied++;
+
+            _cinemaEndEffects.RemoveAt(i);
+            Logger.Info(
+                "Quest cinema-end component buff cinema={0} component={1} buff={2}",
+                cinemaId,
+                pending.Component.Id,
+                pending.Component.BuffId);
+
+            var questId = pending.Component.ParentQuestTemplate?.Id ?? 0;
+            if (questId != 0 && ActiveQuests.TryGetValue(questId, out var quest))
+                quest.UseSkillAndBuff(pending.Component);
+            else
+                QuestComponentEffectRules.ApplySkillAndBuff(Owner, pending.Component, SkillManager.Instance);
+        }
+
+        if (applied == 0)
+        {
+            Logger.Warn(
+                "Quest cinema-end had no buff for cinema={0}, deferred={1}",
+                cinemaId,
+                _cinemaEndEffects.Count);
+        }
+    }
 
     public bool HasQuest(uint questId)
     {
@@ -113,6 +209,11 @@ public class CharacterQuests(Character owner)
                 return false;
             }
         }
+
+        // /quest add does not pass an NPC. Start's AcceptNpc act then stays
+        // false, Progress never arms, and interactables refuse the quest.
+        if (forcibly)
+            QuestAcceptRules.FillUnknownAcceptor(template, ref questAcceptorType, ref acceptorId);
 
         // Create new Quest Object
         var quest = new Quest(template, Owner)
@@ -481,7 +582,22 @@ public class CharacterQuests(Character owner)
         }
     }
 
-    /// <summary>Sends active and completed quest lists at character select.</summary>
+    /// <summary>
+    /// Push one dirty completed-quest bitset block after a turn-in so the client's
+    /// unit_req kind-31 / IsCompleted readers see the finish without waiting for
+    /// the next full <see cref="SendCompleted"/> (login / SendInitialState).
+    /// </summary>
+    public void SendCompletedBlock(CompletedQuest block)
+    {
+        if (block == null)
+            return;
+        Owner.SendPacket(new SCCompletedQuestsPacket([block]));
+    }
+
+    /// <summary>
+    /// Sends active and completed lists. Char-select is not enough: in-world
+    /// start/complete checks read this after the local player exists.
+    /// </summary>
     public void SendInitialState()
     {
         Send();
@@ -1093,12 +1209,17 @@ public class CharacterQuests(Character owner)
                 {
                     if (!slave.Buffs.CheckBuff(buffId))
                     {
+                        var oldMaxHp = slave.MaxHp;
+                        var oldHp = slave.Hp;
                         slave.Buffs.AddBuff(buffId, Owner);
-                        Logger.Info("SphereBuff APPLY slave={0} buff={1} detail={2}", slave.Name, buffId, sphereBuffDetailId);
+                        slave.Hp = SlaveHealthCapRules.AfterMaxHpChanged(oldHp, oldMaxHp, slave.MaxHp);
+                        if (slave.Hp != oldHp)
+                        {
+                            slave.BroadcastPacket(new SCUnitPointsPacket(slave.ObjId, slave.Hp, slave.Mp), false);
+                            slave.ParentWorld?.SlaveManager?.UpdateSlaveRepairPoints(slave);
+                        }
 
-                        // Ezi (13816) raises MaxHp by 10%, so the hull now sits below its cap and
-                        // Moored's HealthRegen (+200/tick) repairs it back up — Slave.RegenTick pushes
-                        // the points as it climbs. Nothing to snap here.
+                        Logger.Info("SphereBuff APPLY slave={0} buff={1} detail={2}", slave.Name, buffId, sphereBuffDetailId);
                     }
                 }
                 else if (slave.Buffs.CheckBuff(buffId))

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -117,12 +117,16 @@ public class CharacterQuests(Character owner)
                 pending.Component.BuffId);
 
             var questId = pending.Component.ParentQuestTemplate?.Id ?? 0;
-            if (questId != 0 &&
-                ActiveQuests.TryGetValue(questId, out var quest) &&
-                QuestCinemaBindRules.ShouldApplyCinemaEndEffect(true))
-            {
+            Quest quest = null;
+            var active = questId != 0 && ActiveQuests.TryGetValue(questId, out quest);
+            var completed = questId != 0 && HasQuestCompleted(questId);
+            if (!QuestCinemaBindRules.ShouldApplyCinemaEndEffect(active, completed))
+                continue;
+
+            if (quest != null)
                 quest.UseSkillAndBuff(pending.Component);
-            }
+            else
+                QuestComponentEffectRules.ApplySkillAndBuff(Owner, pending.Component, SkillManager.Instance);
         }
 
         if (applied == 0)
@@ -383,7 +387,8 @@ public class CharacterQuests(Character owner)
         quest.Cleanup();
         quest.Drop(update);
         quest.FinalizeQuestActs();
-        ClearCinemaEndEffects(questId);
+        if (QuestCinemaBindRules.ShouldClearCinemaEndOnDrop(HasQuestCompleted(questId), forcibly))
+            ClearCinemaEndEffects(questId);
         ActiveQuests.Remove(questId);
         _removed.Add(questId);
 

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -164,6 +164,39 @@ public class CharacterQuests(Character owner)
             ApplyCinemaEndEffects(cinemaId);
     }
 
+    /// <summary>
+    /// Applies the cinema-end entries a previous session could not finish. The component id
+    /// is the only durable name for the effect, so a component that no longer exists is
+    /// dropped with a warning. Production resolves through the quest manager; tests inject
+    /// their own resolver.
+    /// </summary>
+    public void RestorePendingCinemaEndEffects(
+        IReadOnlyList<(uint QuestId, uint CinemaId, uint ComponentId)> rows,
+        Func<uint, QuestComponentTemplate> componentResolver = null)
+    {
+        if (rows == null || rows.Count == 0)
+            return;
+
+        componentResolver ??= QuestManager.Instance.GetComponent;
+
+        foreach (var row in rows)
+        {
+            var component = componentResolver(row.ComponentId);
+            if (component == null)
+            {
+                Logger.Warn(
+                    "Pending cinema-end component {0} for quest {1} no longer exists, dropped",
+                    row.ComponentId,
+                    row.QuestId);
+                continue;
+            }
+
+            EnqueueCinemaEndEffects(row.CinemaId, component);
+        }
+
+        FlushPendingCinemaEndEffects();
+    }
+
     public bool HasQuest(uint questId)
     {
         return ActiveQuests.ContainsKey(questId);
@@ -780,6 +813,50 @@ public class CharacterQuests(Character owner)
                 }
             }
         }
+
+        // A pending cinema-end effect survives a dropped connection: the client never reports
+        // the film ending and the step is already saved, so apply what the quest still owes.
+        // The rows are cleared once they are restored.
+        try
+        {
+            var pendingCinemaEnds = new List<(uint QuestId, uint CinemaId, uint ComponentId)>();
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText =
+                    "SELECT `quest_id`,`cinema_id`,`component_id` FROM character_quest_cinema_end_effects WHERE `owner` = @owner";
+                command.Parameters.AddWithValue("@owner", Owner.Id);
+                using (var reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        pendingCinemaEnds.Add((
+                            reader.GetUInt32("quest_id"),
+                            reader.GetUInt32("cinema_id"),
+                            reader.GetUInt32("component_id")));
+                    }
+                }
+            }
+
+            if (pendingCinemaEnds.Count == 0)
+                return;
+
+            RestorePendingCinemaEndEffects(pendingCinemaEnds);
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "DELETE FROM character_quest_cinema_end_effects WHERE `owner` = @owner";
+                command.Parameters.AddWithValue("@owner", Owner.Id);
+                command.ExecuteNonQuery();
+            }
+        }
+        catch (MySqlException ex)
+        {
+            // A missing table must not block login; the effect is lost exactly as before this change.
+            Logger.Error(
+                ex,
+                "Pending cinema-end restore skipped for {0} — is the character_quest_cinema_end_effects update applied?",
+                Owner.Name);
+        }
     }
 
     /// <summary>
@@ -844,6 +921,52 @@ public class CharacterQuests(Character owner)
 
                 command.Parameters.Clear();
             }
+        }
+
+        // A cinema-end effect the film has not delivered yet belongs to the quest, so it is
+        // saved with it. An abrupt disconnect saves the character without leaving the world,
+        // and that path must not lose the pending buff or teleport.
+        try
+        {
+            using (var command = connection.CreateCommand())
+            {
+                command.Connection = connection;
+                command.Transaction = transaction;
+
+                command.CommandText = "DELETE FROM character_quest_cinema_end_effects WHERE `owner` = @owner";
+                command.Parameters.AddWithValue("@owner", Owner.Id);
+                command.ExecuteNonQuery();
+            }
+
+            if (_cinemaEndEffects.Count > 0)
+            {
+                using var command = connection.CreateCommand();
+                command.Connection = connection;
+                command.Transaction = transaction;
+
+                command.CommandText =
+                    "INSERT INTO character_quest_cinema_end_effects(`owner`,`quest_id`,`cinema_id`,`component_id`) " +
+                    "VALUES(@owner,@quest_id,@cinema_id,@component_id)";
+
+                foreach (var pending in _cinemaEndEffects)
+                {
+                    command.Parameters.AddWithValue("@owner", Owner.Id);
+                    command.Parameters.AddWithValue("@quest_id", pending.Component.ParentQuestTemplate?.Id ?? 0);
+                    command.Parameters.AddWithValue("@cinema_id", pending.CinemaId);
+                    command.Parameters.AddWithValue("@component_id", pending.Component.Id);
+                    command.ExecuteNonQuery();
+
+                    command.Parameters.Clear();
+                }
+            }
+        }
+        catch (MySqlException ex)
+        {
+            // The character save must still succeed when the update has not been applied yet.
+            Logger.Error(
+                ex,
+                "Pending cinema-end save skipped for {0} — is the character_quest_cinema_end_effects update applied?",
+                Owner.Name);
         }
     }
 

--- a/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
+++ b/AAEmu.Game/Models/Game/Char/CharacterQuests.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Concurrent;
 using System.Data;
 using AAEmu.Game.Core.Managers;
@@ -124,9 +124,14 @@ public class CharacterQuests(Character owner)
                 continue;
 
             if (quest != null)
+            {
                 quest.UseSkillAndBuff(pending.Component);
-            else
+            }
+            else if (pending.Component.SkillId > 0 || pending.Component.BuffId > 0)
+            {
+                // Resolve the manager only when the component carries an effect.
                 QuestComponentEffectRules.ApplySkillAndBuff(Owner, pending.Component, SkillManager.Instance);
+            }
         }
 
         if (applied == 0)
@@ -136,6 +141,27 @@ public class CharacterQuests(Character owner)
                 cinemaId,
                 _cinemaEndEffects.Count);
         }
+    }
+
+    /// <summary>
+    /// Leave-world flush. Once the session is gone the client never reports the cinema
+    /// end, and the quest step is already saved, so apply the pending entries now instead
+    /// of dropping the quest's buff or teleport with this in-memory list.
+    /// </summary>
+    public void FlushPendingCinemaEndEffects()
+    {
+        if (_cinemaEndEffects.Count == 0)
+            return;
+
+        var cinemas = new List<uint>();
+        foreach (var pending in _cinemaEndEffects)
+        {
+            if (!cinemas.Contains(pending.CinemaId))
+                cinemas.Add(pending.CinemaId);
+        }
+
+        foreach (var cinemaId in cinemas)
+            ApplyCinemaEndEffects(cinemaId);
     }
 
     public bool HasQuest(uint questId)
@@ -292,7 +318,7 @@ public class CharacterQuests(Character owner)
         {
             var started = AddQuest(questId, false, QuestAcceptorType.Doodad, doodad.TemplateId);
             if (started)
-                doodad.RefreshQuestReactFor(Owner, questId);
+                doodad.RefreshQuestReactFor(Owner);
             return started;
         }
 
@@ -317,8 +343,10 @@ public class CharacterQuests(Character owner)
     }
 
     /// <summary>
-    /// QuestReact rows only live on the current phase. Re-apply nearby after a step
-    /// change so the body flips without a leave/re-enter.
+    /// QuestReact rows only live on the current phase. Re-apply the whole chain nearby
+    /// after a step change so the body flips without a leave/re-enter. The chain is not
+    /// filtered by <paramref name="questId"/>: rows are ordered and an earlier quest can
+    /// still hold the phase.
     /// </summary>
     public void ApplyNearbyQuestReacts(uint questId)
     {
@@ -326,7 +354,7 @@ public class CharacterQuests(Character owner)
             return;
 
         foreach (var doodad in WorldManager.GetAround<Doodad>(Owner))
-            doodad?.RefreshQuestReactFor(Owner, questId);
+            doodad?.RefreshQuestReactFor(Owner);
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -7,6 +7,7 @@ using AAEmu.Game.Core.Managers.UnitManagers;
 using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Network.Game;
 using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.GameData;
 using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.CommonFarm.Static;
@@ -15,6 +16,7 @@ using AAEmu.Game.Models.Game.DoodadObj.Static;
 using AAEmu.Game.Models.Game.DoodadObj.Templates;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.Quests.Static;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
 using AAEmu.Game.Models.Tasks.Doodads;
@@ -498,8 +500,12 @@ public class Doodad : BaseUnit
 
             if (allFuncsForGroup.Count <= 0)
             {
-                // Phase has no funcs
-                return;
+                // Start phases can be phase-func-only gates (QuestReact → talkable group).
+                var phaseBefore = FuncGroupId;
+                var stopOnPhaseGate = DoChangePhase(caster, (int)FuncGroupId);
+                if (stopOnPhaseGate || FuncGroupId == phaseBefore)
+                    return;
+                continue;
             }
 
             if (skillId == 0)
@@ -522,13 +528,23 @@ public class Doodad : BaseUnit
             }
             else
             {
+                if (player != null &&
+                    funcWithSkill != null &&
+                    DoodadManager.Instance.GetFuncTemplate(funcWithSkill.FuncId, funcWithSkill.FuncType)
+                        is DoodadFuncQuest)
+                {
+                    funcWithSkill = SelectQuestFunc(player, allFuncsForGroup);
+                }
+
                 var completesFromClientPacket = funcWithSkill != null &&
                     DoodadManager.Instance.GetFuncTemplate(funcWithSkill.FuncId, funcWithSkill.FuncType)
                         ?.CompletesFromClientPacket == true;
                 if (DoFunc(caster, startedSkillId, funcWithSkill))
                 {
-                    // FuncGroupId will be equal to either the current phase, func.NextPhase, or OverridePhase
-                    if (!completesFromClientPacket)
+                    // Stay-on-phase funcs (quest offer, next_phase -1) leave ToNextPhase false.
+                    // Re-entering the same phase still broadcasts SCDoodadPhaseChanged and
+                    // interrupts the client's directing Accept control.
+                    if (ShouldApplyPhaseAfterSuccessfulFunc(completesFromClientPacket, ToNextPhase))
                         DoChangePhase(caster, (int)FuncGroupId);
                     return;
                 }
@@ -582,6 +598,53 @@ public class Doodad : BaseUnit
 
             skillId = 0;
         }
+    }
+
+    private static DoodadFunc SelectQuestFunc(Character character, List<DoodadFunc> funcs)
+    {
+        return DoodadQuestFuncRules.Select(
+            funcs,
+            func =>
+            {
+                if (DoodadManager.Instance.GetFuncTemplate(func.FuncId, func.FuncType) is DoodadFuncQuest quest)
+                    return quest.QuestKindId;
+                return 0u;
+            },
+            func =>
+            {
+                if (DoodadManager.Instance.GetFuncTemplate(func.FuncId, func.FuncType) is DoodadFuncQuest quest)
+                    return quest.QuestId;
+                return 0u;
+            },
+            character.Quests.HasQuest,
+            character.Quests.HasQuestCompleted,
+            questId => QuestManager.Instance.GetTemplate(questId)?.Repeatable == true,
+            questId => CanStartDoodadQuest(character, questId));
+    }
+
+    private static bool CanStartDoodadQuest(Character character, uint questId)
+    {
+        var template = QuestManager.Instance.GetTemplate(questId);
+        if (template == null || !template.MeetsContextRequirements(character))
+            return false;
+
+        foreach (var component in template.GetComponents(QuestComponentKind.Start))
+        {
+            if (!UnitRequirementsGameData.Instance.CanComponentRun(component, character))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// After a successful <see cref="DoFunc"/>, only walk to the next phase when that func
+    /// actually advanced. A stay (quest offer, <c>next_phase</c> -1) must not rebroadcast
+    /// the current phase.
+    /// </summary>
+    internal static bool ShouldApplyPhaseAfterSuccessfulFunc(bool completesFromClientPacket, bool toNextPhase)
+    {
+        return !completesFromClientPacket && toNextPhase;
     }
 
     /// <summary>
@@ -1094,8 +1157,25 @@ public class Doodad : BaseUnit
     /// <param name="character"></param>
     public override void AddVisibleObject(Character character)
     {
+        TryApplyQuestReact(character);
         character.SendPacket(new SCDoodadCreatedPacket(this));
         base.AddVisibleObject(character);
+    }
+
+    /// <summary>
+    /// QuestReact is character-dependent and skipped at boot. Apply it when a player first
+    /// streams the doodad so the Created packet already carries the talkable phase.
+    /// </summary>
+    private void TryApplyQuestReact(Character character)
+    {
+        if (character == null || FuncGroupId == 0)
+            return;
+
+        var phaseFuncs = DoodadManager.Instance.GetPhaseFunc(FuncGroupId);
+        if (phaseFuncs.Count == 0 || !phaseFuncs.Exists(f => f.FuncType == nameof(DoodadFuncQuestReact)))
+            return;
+
+        DoChangePhase(character, (int)FuncGroupId);
     }
 
     /// <summary>

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game;
@@ -1205,8 +1205,11 @@ public class Doodad : BaseUnit
     /// QuestReact is character-dependent and skipped at boot. Apply it when a player first
     /// streams the doodad, uses it, or a nearby quest step changes, so the talkable phase
     /// is not stuck until they leave and re-enter range.
+    /// The whole ordered chain is walked, never a single quest: each row validates its own
+    /// quest state, so refreshing for one quest would skip an earlier row that still gates
+    /// the phase and reset the viewer instead.
     /// </summary>
-    public void ApplyQuestReact(Character character, uint questId = 0)
+    public void ApplyQuestReact(Character character)
     {
         if (character == null || FuncGroupId == 0)
             return;
@@ -1221,19 +1224,8 @@ public class Doodad : BaseUnit
             if (phaseFunc.FuncType != nameof(DoodadFuncQuestReact))
                 continue;
 
-            if (questId == 0)
-            {
-                hasReact = true;
-                break;
-            }
-
-            if (DoodadManager.Instance.GetPhaseFuncTemplate(phaseFunc.FuncId, phaseFunc.FuncType)
-                    is DoodadFuncQuestReact react &&
-                react.QuestId == questId)
-            {
-                hasReact = true;
-                break;
-            }
+            hasReact = true;
+            break;
         }
 
         if (!hasReact)
@@ -1252,8 +1244,6 @@ public class Doodad : BaseUnit
                     continue;
                 if (DoodadManager.Instance.GetPhaseFuncTemplate(phaseFunc.FuncId, phaseFunc.FuncType)
                         is not DoodadFuncQuestReact react)
-                    continue;
-                if (questId != 0 && react.QuestId != questId)
                     continue;
                 if (!react.TryResolveViewerNext(character, phase, out var next))
                     continue;
@@ -1294,11 +1284,11 @@ public class Doodad : BaseUnit
     /// Re-resolve this viewer's QuestReact phase and unicast it. Does not
     /// change the shared persisted phase.
     /// </summary>
-    public void RefreshQuestReactFor(Character character, uint questId = 0)
+    public void RefreshQuestReactFor(Character character)
     {
         if (character == null)
             return;
-        ApplyQuestReact(character, questId);
+        ApplyQuestReact(character);
         character.SendPacket(new SCDoodadPhaseChangedPacket(this, GetPhaseFor(character)));
     }
 

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -134,6 +134,8 @@ public class Doodad : BaseUnit
         {
             if (value != _funcGroupId)
             {
+                if (DoodadQuestReactRules.ShouldInvalidateViewerPhases(_funcGroupId, value))
+                    _questReactViewerPhases.Clear();
                 _funcGroupId = value;
                 PhaseTime = DateTime.UtcNow; // Save PhaseTime at start of new phase (group)
                 if (IsPersistent)
@@ -331,11 +333,13 @@ public class Doodad : BaseUnit
     public bool ToNextPhase { get; set; }
 
     /// <summary>
-    /// Last <see cref="Use"/> found and ran a func. Interaction quest credit reads this.
+    /// Last <see cref="Use"/> found and ran a func. Only valid inside the Use lock.
+    /// Quest credit reads <see cref="ConsumeUseAppliedFunc"/>.
     /// </summary>
     public bool LastUseAppliedFunc { get; private set; }
 
     private readonly ConcurrentDictionary<uint, uint> _questReactViewerPhases = new();
+    private readonly ConcurrentDictionary<uint, bool> _useAppliedByCaster = new();
 
     /// <summary>
     /// Used for ratio calculations on random triggers
@@ -447,10 +451,28 @@ public class Doodad : BaseUnit
     /// <param name="caster"></param>
     /// <param name="startedSkillId"></param>
     /// <param name="funcGroupId"></param>
-    public void Use(BaseUnit caster, uint startedSkillId = 0, int funcGroupId = 0)
+    public bool Use(BaseUnit caster, uint startedSkillId = 0, int funcGroupId = 0)
     {
         lock (this)
+        {
             UseLocked(caster, startedSkillId, funcGroupId);
+            var applied = LastUseAppliedFunc;
+            if (caster is Character character && character.ObjId != 0)
+                _useAppliedByCaster[character.ObjId] = applied;
+            return applied;
+        }
+    }
+
+    /// <summary>
+    /// Quest credit for this caster's last <see cref="Use"/>. Other players
+    /// writing the shared flag cannot steal or grant this result.
+    /// </summary>
+    public bool ConsumeUseAppliedFunc(uint characterObjId)
+    {
+        if (characterObjId == 0)
+            return false;
+        return _useAppliedByCaster.TryRemove(characterObjId, out var applied) &&
+               DoodadQuestFuncRules.ShouldCountInteraction(applied);
     }
 
     private void UseLocked(BaseUnit caster, uint startedSkillId, int funcGroupId)

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using AAEmu.Commons.Network;
 using AAEmu.Commons.Utils.DB;
 using AAEmu.Game;
@@ -330,6 +331,13 @@ public class Doodad : BaseUnit
     public bool ToNextPhase { get; set; }
 
     /// <summary>
+    /// Last <see cref="Use"/> found and ran a func. Interaction quest credit reads this.
+    /// </summary>
+    public bool LastUseAppliedFunc { get; private set; }
+
+    private readonly ConcurrentDictionary<uint, uint> _questReactViewerPhases = new();
+
+    /// <summary>
     /// Used for ratio calculations on random triggers
     /// </summary>
     public int PhaseRatio { get; private set; }
@@ -447,6 +455,7 @@ public class Doodad : BaseUnit
 
     private void UseLocked(BaseUnit caster, uint startedSkillId, int funcGroupId)
     {
+        LastUseAppliedFunc = false;
         var skillId = startedSkillId;
         var startedSkillTemplate = SkillManager.Instance.GetSkillTemplate(startedSkillId);
         if (caster == null)
@@ -479,27 +488,33 @@ public class Doodad : BaseUnit
         }
 
         var player = caster as Character;
+        if (player != null)
+            ApplyQuestReact(player);
 
         while (true)
         {
+            var usePhase = player != null ? GetPhaseFor(player) : FuncGroupId;
             if (player != null)
             {
-                Logger.Warn($"Use: TemplateId {TemplateId}, Using phase {FuncGroupId} with SkillId {skillId}");
+                Logger.Warn($"Use: TemplateId {TemplateId}, Using phase {usePhase} with SkillId {skillId}");
             }
             else
             {
-                Logger.Trace($"Use: TemplateId {TemplateId}, Using phase {FuncGroupId} with SkillId {skillId}");
+                Logger.Trace($"Use: TemplateId {TemplateId}, Using phase {usePhase} with SkillId {skillId}");
             }
 
             ToNextPhase = false; // по умолчанию не выполняем следующую фазу
             ListGroupId.Clear();
 
             //  first we find the functions, then we execute
-            var funcWithSkill = DoodadManager.Instance.GetFunc(FuncGroupId, skillId); // if skillId > 0
-            var allFuncsForGroup = DoodadManager.Instance.GetFuncsForGroup(FuncGroupId);
+            var funcWithSkill = DoodadManager.Instance.GetFunc(usePhase, skillId); // if skillId > 0
+            var allFuncsForGroup = DoodadManager.Instance.GetFuncsForGroup(usePhase);
 
             if (allFuncsForGroup.Count <= 0)
             {
+                // Overlay already walked QuestReact. Do not hop the shared phase for that gate.
+                if (player != null && usePhase != FuncGroupId)
+                    return;
                 // Start phases can be phase-func-only gates (QuestReact → talkable group).
                 var phaseBefore = FuncGroupId;
                 var stopOnPhaseGate = DoChangePhase(caster, (int)FuncGroupId);
@@ -659,6 +674,7 @@ public class Doodad : BaseUnit
         // if there is no function, complete the cycle
         if (func == null)
         {
+            LastUseAppliedFunc = false;
             if (caster is Character)
             {
                 Logger.Debug($"DoFunc: Finished execution with func = null: TemplateId {TemplateId}, Using phase {FuncGroupId} with SkillId {skillId}");
@@ -671,6 +687,7 @@ public class Doodad : BaseUnit
             return true;
         }
 
+        LastUseAppliedFunc = true;
         // then perform the function
         func.Use(caster, this, skillId, func.NextPhase);
         return CompleteFunc(caster, func, skillId);
@@ -1157,25 +1174,110 @@ public class Doodad : BaseUnit
     /// <param name="character"></param>
     public override void AddVisibleObject(Character character)
     {
-        TryApplyQuestReact(character);
-        character.SendPacket(new SCDoodadCreatedPacket(this));
+        ApplyQuestReact(character);
+        character.SendPacket(new SCDoodadCreatedPacket(this, GetPhaseFor(character)));
         base.AddVisibleObject(character);
     }
 
     /// <summary>
     /// QuestReact is character-dependent and skipped at boot. Apply it when a player first
-    /// streams the doodad so the Created packet already carries the talkable phase.
+    /// streams the doodad, uses it, or a nearby quest step changes, so the talkable phase
+    /// is not stuck until they leave and re-enter range.
     /// </summary>
-    private void TryApplyQuestReact(Character character)
+    public void ApplyQuestReact(Character character, uint questId = 0)
     {
         if (character == null || FuncGroupId == 0)
             return;
 
         var phaseFuncs = DoodadManager.Instance.GetPhaseFunc(FuncGroupId);
-        if (phaseFuncs.Count == 0 || !phaseFuncs.Exists(f => f.FuncType == nameof(DoodadFuncQuestReact)))
+        if (phaseFuncs.Count == 0)
             return;
 
-        DoChangePhase(character, (int)FuncGroupId);
+        var hasReact = false;
+        foreach (var phaseFunc in phaseFuncs)
+        {
+            if (phaseFunc.FuncType != nameof(DoodadFuncQuestReact))
+                continue;
+
+            if (questId == 0)
+            {
+                hasReact = true;
+                break;
+            }
+
+            if (DoodadManager.Instance.GetPhaseFuncTemplate(phaseFunc.FuncId, phaseFunc.FuncType)
+                    is DoodadFuncQuestReact react &&
+                react.QuestId == questId)
+            {
+                hasReact = true;
+                break;
+            }
+        }
+
+        if (!hasReact)
+        {
+            SetQuestReactViewerPhase(character.ObjId, FuncGroupId);
+            return;
+        }
+
+        var phase = FuncGroupId;
+        for (var hop = 0; hop < DoodadQuestReactRules.MaxViewerHops; hop++)
+        {
+            var advanced = false;
+            foreach (var phaseFunc in DoodadManager.Instance.GetPhaseFunc(phase))
+            {
+                if (phaseFunc.FuncType != nameof(DoodadFuncQuestReact))
+                    continue;
+                if (DoodadManager.Instance.GetPhaseFuncTemplate(phaseFunc.FuncId, phaseFunc.FuncType)
+                        is not DoodadFuncQuestReact react)
+                    continue;
+                if (questId != 0 && react.QuestId != questId)
+                    continue;
+                if (!react.TryResolveViewerNext(character, phase, out var next))
+                    continue;
+                phase = next;
+                advanced = true;
+                break;
+            }
+
+            if (!advanced)
+                break;
+        }
+
+        SetQuestReactViewerPhase(character.ObjId, phase);
+    }
+
+    public uint GetPhaseFor(Character character)
+    {
+        if (character != null &&
+            _questReactViewerPhases.TryGetValue(character.ObjId, out var phase) &&
+            DoodadQuestReactRules.ShouldKeepViewerPhase(FuncGroupId, phase))
+            return phase;
+        return FuncGroupId;
+    }
+
+    public void SetQuestReactViewerPhase(uint characterObjId, uint phase)
+    {
+        if (characterObjId == 0 || !DoodadQuestReactRules.ShouldKeepViewerPhase(FuncGroupId, phase))
+        {
+            if (characterObjId != 0)
+                _questReactViewerPhases.TryRemove(characterObjId, out _);
+            return;
+        }
+
+        _questReactViewerPhases[characterObjId] = phase;
+    }
+
+    /// <summary>
+    /// Re-resolve this viewer's QuestReact phase and unicast it. Does not
+    /// change the shared persisted phase.
+    /// </summary>
+    public void RefreshQuestReactFor(Character character, uint questId = 0)
+    {
+        if (character == null)
+            return;
+        ApplyQuestReact(character, questId);
+        character.SendPacket(new SCDoodadPhaseChangedPacket(this, GetPhaseFor(character)));
     }
 
     /// <summary>
@@ -1184,6 +1286,8 @@ public class Doodad : BaseUnit
     /// <param name="character"></param>
     public override void RemoveVisibleObject(Character character)
     {
+        if (character != null)
+            _questReactViewerPhases.TryRemove(character.ObjId, out _);
         base.RemoveVisibleObject(character);
         character.SendPacket(new SCDoodadRemovedPacket(ObjId));
     }
@@ -1216,12 +1320,14 @@ public class Doodad : BaseUnit
     /// The old flat u32-template + bool hasLoot layout misaligned FuncGroupId so the client never
     /// showed F/climb prompts (visuals still worked from Zone mesh / wrong field spill).
     /// </summary>
-    public PacketStream Write(PacketStream stream)
+    public PacketStream Write(PacketStream stream) => Write(stream, FuncGroupId);
+
+    public PacketStream Write(PacketStream stream, uint funcGroupId)
     {
         stream.WriteBc(ObjId);
         // SC pisc: [templateId, funcGroupId → obj+68, backpackItemId → obj+96, ?].
         // keeps 0 for normal props. Same gate on WZCreateDoodad — never ModelKindId.
-        stream.WritePisc(TemplateId, FuncGroupId, 0u, 0u);
+        stream.WritePisc(TemplateId, funcGroupId, 0u, 0u);
 
         // flag bit0 = hasLootItem (gear/loot UI). Exclusive loot-phase only — see CSLootOpenBagPacket.
         var hasLootItem = CurrentFuncs.Count > 0 && CurrentFuncs.All(func => IsFuncDrivenLootFunc(func.FuncType));

--- a/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Doodad.cs
@@ -1309,7 +1309,11 @@ public class Doodad : BaseUnit
     public override void RemoveVisibleObject(Character character)
     {
         if (character != null)
+        {
             _questReactViewerPhases.TryRemove(character.ObjId, out _);
+            _useAppliedByCaster.TryRemove(character.ObjId, out _);
+        }
+
         base.RemoveVisibleObject(character);
         character.SendPacket(new SCDoodadRemovedPacket(ObjId));
     }

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestFuncRules.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestFuncRules.cs
@@ -56,8 +56,12 @@ public static class DoodadQuestFuncRules
 
     /// <summary>
     /// A Use that found no matching func must not credit <c>QuestActObjInteraction</c>.
+    /// Credit is tied to that caster's use, not a shared doodad flag.
     /// </summary>
     public static bool ShouldCountInteraction(bool useAppliedFunc) => useAppliedFunc;
+
+    public static bool ShouldCountInteractionForCaster(uint casterObjId, uint recordedCasterObjId, bool applied) =>
+        casterObjId != 0 && casterObjId == recordedCasterObjId && ShouldCountInteraction(applied);
 
     /// <summary>
     /// Prefer an in-progress report, else the first startable accept.

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestFuncRules.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestFuncRules.cs
@@ -40,6 +40,26 @@ public static class DoodadQuestFuncRules
     }
 
     /// <summary>
+    /// Ready step/status is already past Progress counters (those acts are finalized).
+    /// Count the journal Ready flag, not only leftover objective cells.
+    /// </summary>
+    public static bool ShouldOfferComplete(
+        QuestObjectiveStatus objectiveStatus,
+        bool letItDone,
+        QuestStatus questStatus,
+        QuestComponentKind step)
+    {
+        if (questStatus == QuestStatus.Ready || step == QuestComponentKind.Ready)
+            return true;
+        return ShouldOfferComplete(objectiveStatus, letItDone);
+    }
+
+    /// <summary>
+    /// A Use that found no matching func must not credit <c>QuestActObjInteraction</c>.
+    /// </summary>
+    public static bool ShouldCountInteraction(bool useAppliedFunc) => useAppliedFunc;
+
+    /// <summary>
     /// Prefer an in-progress report, else the first startable accept.
     /// </summary>
     public static T Select<T>(

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestFuncRules.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestFuncRules.cs
@@ -1,0 +1,84 @@
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.Game.Models.Game.DoodadObj;
+
+/// <summary>
+/// Compact <c>doodad_func_quests.quest_kind_id</c>: 1 starts a quest, 2 turns one in.
+/// One doodad phase can list several of each; only the matching row may run.
+/// </summary>
+public static class DoodadQuestFuncRules
+{
+    public const uint AcceptKind = 1;
+    public const uint ReportKind = 2;
+
+    public static bool IsAcceptKind(uint questKindId) => questKindId == AcceptKind;
+
+    public static bool IsReportKind(uint questKindId) => questKindId == ReportKind;
+
+    public static bool ShouldOfferAccept(uint questKindId, bool hasQuest, bool completed, bool repeatable)
+    {
+        if (!IsAcceptKind(questKindId) || hasQuest)
+            return false;
+        return repeatable || !completed;
+    }
+
+    public static bool ShouldReport(uint questKindId, bool hasQuest)
+    {
+        return IsReportKind(questKindId) && hasQuest;
+    }
+
+    /// <summary>
+    /// Ready (or let-it-done early) turn-in. World offers the complete window; the client
+    /// sends <c>CSCompleteQuestContext</c> after the last line.
+    /// </summary>
+    public static bool ShouldOfferComplete(QuestObjectiveStatus status, bool letItDone)
+    {
+        var minimum = letItDone
+            ? QuestObjectiveStatus.CanEarlyComplete
+            : QuestObjectiveStatus.QuestComplete;
+        return status >= minimum;
+    }
+
+    /// <summary>
+    /// Prefer an in-progress report, else the first startable accept.
+    /// </summary>
+    public static T Select<T>(
+        IEnumerable<T> funcs,
+        Func<T, uint> questKindId,
+        Func<T, uint> questId,
+        Func<uint, bool> hasQuest,
+        Func<uint, bool> completed,
+        Func<uint, bool> repeatable,
+        Func<uint, bool> canStart = null)
+    {
+        if (funcs == null || questKindId == null || questId == null || hasQuest == null || completed == null)
+            return default;
+
+        repeatable ??= static _ => false;
+        canStart ??= static _ => true;
+
+        T accept = default;
+        var haveAccept = false;
+        foreach (var func in funcs)
+        {
+            var id = questId(func);
+            if (id == 0)
+                continue;
+
+            var kind = questKindId(func);
+            if (ShouldReport(kind, hasQuest(id)))
+                return func;
+
+            if (haveAccept)
+                continue;
+
+            if (ShouldOfferAccept(kind, hasQuest(id), completed(id), repeatable(id)) && canStart(id))
+            {
+                accept = func;
+                haveAccept = true;
+            }
+        }
+
+        return haveAccept ? accept : default;
+    }
+}

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestFuncRules.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestFuncRules.cs
@@ -1,4 +1,4 @@
-using AAEmu.Game.Models.Game.Quests.Static;
+﻿using AAEmu.Game.Models.Game.Quests.Static;
 
 namespace AAEmu.Game.Models.Game.DoodadObj;
 
@@ -59,9 +59,6 @@ public static class DoodadQuestFuncRules
     /// Credit is tied to that caster's use, not a shared doodad flag.
     /// </summary>
     public static bool ShouldCountInteraction(bool useAppliedFunc) => useAppliedFunc;
-
-    public static bool ShouldCountInteractionForCaster(uint casterObjId, uint recordedCasterObjId, bool applied) =>
-        casterObjId != 0 && casterObjId == recordedCasterObjId && ShouldCountInteraction(applied);
 
     /// <summary>
     /// Prefer an in-progress report, else the first startable accept.

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestReactRules.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestReactRules.cs
@@ -39,6 +39,13 @@ public static class DoodadQuestReactRules
     /// </summary>
     public static bool ShouldMutateSharedPhase() => false;
 
+    /// <summary>
+    /// A timer or normal func that hops the shared phase must drop overlays
+    /// computed against the previous group.
+    /// </summary>
+    public static bool ShouldInvalidateViewerPhases(uint previousSharedPhase, uint nextSharedPhase) =>
+        previousSharedPhase != nextSharedPhase;
+
     public static bool ShouldKeepViewerPhase(uint sharedPhase, uint viewerPhase) =>
         viewerPhase != 0 && viewerPhase != sharedPhase;
 

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestReactRules.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestReactRules.cs
@@ -1,0 +1,36 @@
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.Game.Models.Game.DoodadObj;
+
+/// <summary>
+/// Compact <c>doodad_func_quest_reacts</c> match. A row moves the doodad when that
+/// character's quest status (and optional component) matches.
+/// </summary>
+public static class DoodadQuestReactRules
+{
+    public static bool MatchesStatus(uint requiredStatusId, QuestStatus actualStatus)
+    {
+        return requiredStatusId == (uint)actualStatus;
+    }
+
+    /// <summary>
+    /// <paramref name="requiredComponentId"/> 0 means any component. A Ready-step row may name
+    /// the Ready component even when the live <c>ComponentId</c> was cleared on the last step.
+    /// </summary>
+    public static bool MatchesComponent(
+        uint requiredComponentId,
+        uint activeComponentId,
+        bool readyStepContainsRequiredComponent)
+    {
+        if (requiredComponentId == 0)
+            return true;
+        if (activeComponentId == requiredComponentId)
+            return true;
+        return readyStepContainsRequiredComponent;
+    }
+
+    public static bool ShouldAdvance(int nextPhase, uint currentFuncGroupId)
+    {
+        return nextPhase > 0 && (uint)nextPhase != currentFuncGroupId;
+    }
+}

--- a/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestReactRules.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/DoodadQuestReactRules.cs
@@ -33,4 +33,17 @@ public static class DoodadQuestReactRules
     {
         return nextPhase > 0 && (uint)nextPhase != currentFuncGroupId;
     }
+
+    /// <summary>
+    /// QuestReact is per viewer. The shared persisted phase must not move.
+    /// </summary>
+    public static bool ShouldMutateSharedPhase() => false;
+
+    public static bool ShouldKeepViewerPhase(uint sharedPhase, uint viewerPhase) =>
+        viewerPhase != 0 && viewerPhase != sharedPhase;
+
+    public static uint NextViewerPhase(uint currentPhase, int reactNextPhase) =>
+        ShouldAdvance(reactNextPhase, currentPhase) ? (uint)reactNextPhase : currentPhase;
+
+    public const int MaxViewerHops = 8;
 }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncQuest.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncQuest.cs
@@ -1,6 +1,7 @@
 ﻿using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.DoodadObj.Templates;
 using AAEmu.Game.Models.Game.Units;
 
@@ -18,16 +19,40 @@ public class DoodadFuncQuest : DoodadFuncTemplate
 
         if (caster is Character character)
         {
-            if (!character.Quests.HasQuest(QuestId))
+            character.Quests.ObserveQuestDoodad(owner.ObjId, owner.TemplateId);
+
+            if (character.Quests.ActiveQuests.TryGetValue(QuestId, out var quest)
+                && quest.Template != null
+                && DoodadQuestFuncRules.ShouldOfferComplete(
+                    quest.GetQuestObjectiveStatus(),
+                    quest.Template.LetItDone))
             {
-                if (caster is Character player)
-                    player.SendPacket(new SCDoodadQuestAcceptPacket(owner.ObjId, QuestId));
-                // character.Quests.AddQuestFromDoodad(QuestId, owner.ObjId);
+                Logger.Info(
+                    "DoodadFuncQuest complete-offer tpl={0} obj={1} quest={2}",
+                    owner.TemplateId,
+                    owner.ObjId,
+                    QuestId);
+                character.SendPacket(new SCDoodadCompleteQuestPacket(owner.ObjId, QuestId));
+                return;
             }
-            else
-            {
-                QuestManager.Instance.DoReportEvents(character, QuestId, 0, owner.ObjId, 0);
-            }
+
+            if (character.Quests.HasQuest(QuestId))
+                return;
+
+            var repeatable = QuestManager.Instance.GetTemplate(QuestId)?.Repeatable == true;
+            if (!DoodadQuestFuncRules.ShouldOfferAccept(
+                    QuestKindId,
+                    hasQuest: false,
+                    character.Quests.HasQuestCompleted(QuestId),
+                    repeatable))
+                return;
+
+            Logger.Info(
+                "DoodadFuncQuest offer tpl={0} obj={1} quest={2}",
+                owner.TemplateId,
+                owner.ObjId,
+                QuestId);
+            character.SendPacket(new SCDoodadQuestAcceptPacket(owner.ObjId, QuestId));
         }
     }
 }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncQuest.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncQuest.cs
@@ -25,7 +25,9 @@ public class DoodadFuncQuest : DoodadFuncTemplate
                 && quest.Template != null
                 && DoodadQuestFuncRules.ShouldOfferComplete(
                     quest.GetQuestObjectiveStatus(),
-                    quest.Template.LetItDone))
+                    quest.Template.LetItDone,
+                    quest.Status,
+                    quest.Step))
             {
                 Logger.Info(
                     "DoodadFuncQuest complete-offer tpl={0} obj={1} quest={2}",

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncQuestReact.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncQuestReact.cs
@@ -20,7 +20,26 @@ public class DoodadFuncQuestReact : DoodadPhaseFuncTemplate
 
     public override bool Use(BaseUnit caster, Doodad owner)
     {
-        if (caster is not Character character || owner == null || QuestId == 0)
+        if (caster is not Character character || owner == null)
+            return false;
+
+        if (!TryResolveViewerNext(character, owner.FuncGroupId, out var viewerPhase))
+            return false;
+
+        if (DoodadQuestReactRules.ShouldMutateSharedPhase())
+        {
+            owner.OverridePhase = (int)viewerPhase;
+            return true;
+        }
+
+        owner.SetQuestReactViewerPhase(character.ObjId, viewerPhase);
+        return false;
+    }
+
+    public bool TryResolveViewerNext(Character character, uint currentPhase, out uint viewerPhase)
+    {
+        viewerPhase = currentPhase;
+        if (character == null || QuestId == 0)
             return false;
 
         ReadQuestState(character, QuestId, QuestComponentId, out var actualStatus, out var activeComponentId,
@@ -32,10 +51,10 @@ public class DoodadFuncQuestReact : DoodadPhaseFuncTemplate
             return false;
         }
 
-        if (!DoodadQuestReactRules.ShouldAdvance(NextPhase, owner.FuncGroupId))
+        var next = DoodadQuestReactRules.NextViewerPhase(currentPhase, NextPhase);
+        if (!DoodadQuestReactRules.ShouldKeepViewerPhase(currentPhase, next))
             return false;
-
-        owner.OverridePhase = NextPhase;
+        viewerPhase = next;
         return true;
     }
 

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncQuestReact.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncQuestReact.cs
@@ -1,0 +1,68 @@
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.DoodadObj.Templates;
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Models.Game.DoodadObj.Funcs;
+
+/// <summary>
+/// Phase gate from <c>doodad_func_quest_reacts</c>. Evaluated only for a character — boot
+/// settle with no caster must leave the doodad on its start phase.
+/// </summary>
+public class DoodadFuncQuestReact : DoodadPhaseFuncTemplate
+{
+    public uint QuestId { get; set; }
+    public uint QuestStatusId { get; set; }
+    public int NextPhase { get; set; }
+    public uint QuestComponentId { get; set; }
+    public bool BubbleOnce { get; set; }
+    public uint BubbleId { get; set; }
+
+    public override bool Use(BaseUnit caster, Doodad owner)
+    {
+        if (caster is not Character character || owner == null || QuestId == 0)
+            return false;
+
+        ReadQuestState(character, QuestId, QuestComponentId, out var actualStatus, out var activeComponentId,
+            out var readyStepContainsRequiredComponent);
+
+        if (!DoodadQuestReactRules.MatchesStatus(QuestStatusId, actualStatus) ||
+            !DoodadQuestReactRules.MatchesComponent(QuestComponentId, activeComponentId, readyStepContainsRequiredComponent))
+        {
+            return false;
+        }
+
+        if (!DoodadQuestReactRules.ShouldAdvance(NextPhase, owner.FuncGroupId))
+            return false;
+
+        owner.OverridePhase = NextPhase;
+        return true;
+    }
+
+    private static void ReadQuestState(
+        Character character,
+        uint questId,
+        uint requiredComponentId,
+        out QuestStatus actualStatus,
+        out uint activeComponentId,
+        out bool readyStepContainsRequiredComponent)
+    {
+        readyStepContainsRequiredComponent = false;
+        activeComponentId = 0;
+
+        if (character.Quests.ActiveQuests.TryGetValue(questId, out var quest))
+        {
+            actualStatus = quest.Status;
+            activeComponentId = quest.CurrentComponentId != 0 ? quest.CurrentComponentId : quest.ComponentId;
+            readyStepContainsRequiredComponent = requiredComponentId != 0 &&
+                                                 actualStatus == QuestStatus.Ready &&
+                                                 quest.Step == QuestComponentKind.Ready &&
+                                                 quest.CurrentStep?.Components.ContainsKey(requiredComponentId) == true;
+            return;
+        }
+
+        actualStatus = character.Quests.HasQuestCompleted(questId)
+            ? QuestStatus.Completed
+            : QuestStatus.Invalid;
+    }
+}

--- a/AAEmu.Game/Models/Game/DoodadObj/Templates/DoodadTemplate.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Templates/DoodadTemplate.cs
@@ -16,6 +16,11 @@ public class DoodadTemplate
     public uint ModelKindId { get; set; }
     /// <summary>URI from doodad_almighties.model (cgf://, vegetation://, prefab://, …).</summary>
     public string Model { get; set; } = "";
+    /// <summary>
+    /// <c>doodad_almighties.client_doodad</c>. Level-pack scene bodies (npctype people, some
+    /// interactables) use this; they still need a World entity for F / quests.
+    /// </summary>
+    public bool ClientDoodad { get; set; }
     /// <summary>When true, Zone pulls mesh from world/level instead of packet modelId.</summary>
     public bool LoadModelFromWorld { get; set; }
 

--- a/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
+++ b/AAEmu.Game/Models/Game/Items/Loots/LootPack.cs
@@ -285,15 +285,8 @@ public class LootPack
                             }
                         }
                     }
-                    // Merge quests items in selected items
-                    if (tmpSelectedQuestItemsByGroup.Count > 0)
-                        foreach (var loot in tmpSelectedQuestItemsByGroup[groupNo])
-                        {
-                            // Skip quest item if it was randomly selected
-                            if (selectedItemsByGroup[groupNo].Contains(loot))
-                                continue;
-                            selectedItemsByGroup[groupNo].Add(loot);
-                        }
+                    // Quest items in this group always drop, even when the non-quest roll missed.
+                    LootPackRules.MergeQuestItems(selectedItemsByGroup, tmpSelectedQuestItemsByGroup, groupNo);
                 }
             }
             // No matches found

--- a/AAEmu.Game/Models/Game/Items/Loots/LootPackRules.cs
+++ b/AAEmu.Game/Models/Game/Items/Loots/LootPackRules.cs
@@ -1,0 +1,32 @@
+namespace AAEmu.Game.Models.Game.Items.Loots;
+
+/// <summary>
+/// Quest rows in a rolled loot group always drop. The non-quest roll can miss that
+/// group, so the merge must create the list instead of indexing it.
+/// </summary>
+public static class LootPackRules
+{
+    public static void MergeQuestItems(
+        IDictionary<uint, List<Loot>> selectedItemsByGroup,
+        IReadOnlyDictionary<uint, List<Loot>> questItemsByGroup,
+        uint groupNo)
+    {
+        if (selectedItemsByGroup == null || questItemsByGroup == null)
+            return;
+        if (!questItemsByGroup.TryGetValue(groupNo, out var questLoots) || questLoots == null)
+            return;
+
+        if (!selectedItemsByGroup.TryGetValue(groupNo, out var selected) || selected == null)
+        {
+            selected = [];
+            selectedItemsByGroup[groupNo] = selected;
+        }
+
+        foreach (var loot in questLoots)
+        {
+            if (loot == null || selected.Contains(loot))
+                continue;
+            selected.Add(loot);
+        }
+    }
+}

--- a/AAEmu.Game/Models/Game/NPChar/NpcInteractionRules.cs
+++ b/AAEmu.Game/Models/Game/NPChar/NpcInteractionRules.cs
@@ -1,0 +1,39 @@
+using AAEmu.Game.Models.StaticValues;
+
+namespace AAEmu.Game.Models.Game.NPChar;
+
+/// <summary>
+/// First skill on <c>SCNpcInteractionSkillList</c>.
+/// Quest talk is <see cref="SkillsEnum.NpcTalk"/>; zero never opens start/complete.
+/// </summary>
+public static class NpcInteractionRules
+{
+    public static uint PrimarySkill(NpcTemplate template, bool questTalk = false)
+    {
+        if (template == null)
+            return 0;
+        if (questTalk)
+            return SkillsEnum.NpcTalk;
+        if (template.Banker)
+            return SkillsEnum.UseWarehouse;
+        if (template.AbilityChanger)
+            return SkillsEnum.ChangeSkillsets;
+        if (template.Auctioneer)
+            return SkillsEnum.UseAuctioneer;
+        if (template.Priest)
+            return SkillsEnum.Blessing;
+        if (template.Repairman)
+            return SkillsEnum.Repair;
+        if (template.Merchant)
+            return SkillsEnum.UseStore;
+        if (template.Stabler)
+            return SkillsEnum.HealPetSWounds;
+        if (template.Expedition)
+            return SkillsEnum.FormGuild;
+        if (template.RecrutingBattlefieldId > 0)
+            return SkillsEnum.WarSupport;
+        if (template.Blacksmith)
+            return SkillsEnum.ItemFusion;
+        return 0;
+    }
+}

--- a/AAEmu.Game/Models/Game/NPChar/ZoneMirrorIdRules.cs
+++ b/AAEmu.Game/Models/Game/NPChar/ZoneMirrorIdRules.cs
@@ -1,0 +1,24 @@
+namespace AAEmu.Game.Models.Game.NPChar;
+
+/// <summary>
+/// Process-wide object ids. A recycled id that still names a live unit from
+/// another zone must not be treated as the same mirror.
+/// </summary>
+public static class ZoneMirrorIdRules
+{
+    public static bool IsIdempotentRemirror(
+        uint existingZoneId,
+        uint existingInstanceId,
+        bool existingIsZoneMirror,
+        uint incomingZoneId,
+        uint incomingInstanceId)
+    {
+        return existingIsZoneMirror
+               && existingZoneId != 0
+               && incomingZoneId != 0
+               && existingZoneId == incomingZoneId
+               && existingInstanceId == incomingInstanceId;
+    }
+
+    public static bool ShouldSkipAllocatedId(bool unitStillExists) => unitStillExists;
+}

--- a/AAEmu.Game/Models/Game/NPChar/ZoneMirrorIdRules.cs
+++ b/AAEmu.Game/Models/Game/NPChar/ZoneMirrorIdRules.cs
@@ -19,6 +19,4 @@ public static class ZoneMirrorIdRules
                && existingZoneId == incomingZoneId
                && existingInstanceId == incomingInstanceId;
     }
-
-    public static bool ShouldSkipAllocatedId(bool unitStillExists) => unitStillExists;
 }

--- a/AAEmu.Game/Models/Game/Quests/Acts/QuestActConReportDoodad.cs
+++ b/AAEmu.Game/Models/Game/Quests/Acts/QuestActConReportDoodad.cs
@@ -31,7 +31,7 @@ public class QuestActConReportDoodad(QuestComponentTemplate parentComponent) : Q
 
     public override void FinalizeQuest(Quest quest, QuestAct questAct)
     {
-        quest.Owner.Events.OnReportDoodad += questAct.OnReportDoodad;
+        quest.Owner.Events.OnReportDoodad -= questAct.OnReportDoodad;
         base.FinalizeQuest(quest, questAct);
     }
 
@@ -45,15 +45,21 @@ public class QuestActConReportDoodad(QuestComponentTemplate parentComponent) : Q
         var minimumProgress = questAct.Template.ParentComponent.ParentQuestTemplate.LetItDone
             ? QuestObjectiveStatus.CanEarlyComplete
             : QuestObjectiveStatus.QuestComplete;
-        var isReady = questAct.QuestComponent.Parent.Parent.GetQuestObjectiveStatus() >= minimumProgress;
+        var quest = questAct.QuestComponent.Parent.Parent;
+        var isReady = quest.GetQuestObjectiveStatus() >= minimumProgress;
         // TODO: Check doodad range?
+
+        Logger.Debug(
+            $"QuestActConReportDoodad({DetailId}).OnReportDoodad: Quest: {quest.TemplateId}, Owner {quest.Owner.Name} ({quest.Owner.Id}), DoodadId {args.DoodadId}, Selected {args.Selected}, isReady {isReady}");
 
         if (!isReady)
             return;
 
+        // Same as ReportNpc: CSCompleteQuestContext carries the selective reward pick.
+        quest.SelectedRewardIndex = args.Selected;
         questAct.OverrideObjectiveCompleted = true;
-        if (questAct.QuestComponent.Parent.Parent.Step == QuestComponentKind.Progress)
-            questAct.QuestComponent.Parent.Parent.Step = QuestComponentKind.Ready;
+        if (quest.Step <= QuestComponentKind.Progress)
+            quest.Step = QuestComponentKind.Ready;
         questAct.RequestEvaluation(); // Manual request since this does not use objective counters to trigger
     }
 }

--- a/AAEmu.Game/Models/Game/Quests/Acts/QuestActConReportNpc.cs
+++ b/AAEmu.Game/Models/Game/Quests/Acts/QuestActConReportNpc.cs
@@ -1,4 +1,5 @@
 ﻿using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.Quests;
 using AAEmu.Game.Models.Game.Quests.Static;
 using AAEmu.Game.Models.Game.Quests.Templates;
 using AAEmu.Game.Models.Game.Units;
@@ -21,8 +22,11 @@ public class QuestActConReportNpc(QuestComponentTemplate parentComponent) : Ques
     public override bool RunAct(Quest quest, QuestAct questAct, int currentObjectiveCount)
     {
         Logger.Debug($"{QuestActTemplateName}({DetailId}).RunAct: Quest: {quest.TemplateId}, Owner {quest.Owner.Name} ({quest.Owner.Id}), NpcId {NpcId}");
-        // TODO Verify: Does it actually have to be targeted?
-        return questAct.OverrideObjectiveCompleted || (quest.Owner.CurrentTarget is Npc npc && npc.TemplateId == NpcId);
+        if (questAct.OverrideObjectiveCompleted)
+            return true;
+        if (!CompletesFromCurrentTarget(questAct))
+            return false;
+        return quest.Owner.CurrentTarget is Npc npc && npc.TemplateId == NpcId;
     }
 
     public override void InitializeQuest(Quest quest, QuestAct questAct)
@@ -42,6 +46,17 @@ public class QuestActConReportNpc(QuestComponentTemplate parentComponent) : Ques
         if (questAct.Id != ActId || NpcId != args.NpcId)
             return;
 
+        var kind = questAct.Template.ParentComponent.KindId;
+        if (QuestReportNpcRules.TalkCompletesWithoutProgress(kind))
+        {
+            if (!CompletesFromTalkEvent(questAct))
+                return;
+            Logger.Debug($"QuestActConReportNpc({DetailId}).OnReportNpc: Quest: {questAct.QuestComponent.Parent.Parent.TemplateId}, Owner {questAct.QuestComponent.Parent.Parent.Owner.Name} ({questAct.QuestComponent.Parent.Parent.Owner.Id}), NpcId {args.NpcId}, Selected {args.Selected}, noneStepTalk True");
+            questAct.OverrideObjectiveCompleted = true;
+            questAct.RequestEvaluation();
+            return;
+        }
+
         // This check is needed so that turning in a quest at a NPC doesn't complete all active quests that
         // need to be turned in at the same NPC
         var minimumProgress = questAct.Template.ParentComponent.ParentQuestTemplate.LetItDone
@@ -56,8 +71,26 @@ public class QuestActConReportNpc(QuestComponentTemplate parentComponent) : Ques
 
         questAct.QuestComponent.Parent.Parent.SelectedRewardIndex = args.Selected;
         questAct.OverrideObjectiveCompleted = true;
-        if (questAct.QuestComponent.Parent.Parent.Step <= QuestComponentKind.Progress)
+        if (QuestReportNpcRules.TalkAdvancesToReady(kind)
+            && questAct.QuestComponent.Parent.Parent.Step <= QuestComponentKind.Progress)
             questAct.QuestComponent.Parent.Parent.Step = QuestComponentKind.Ready;
         questAct.RequestEvaluation(); // Manual request since this does not use objective counters to trigger
     }
+
+    private static bool CompletesFromCurrentTarget(QuestAct questAct) =>
+        QuestReportNpcRules.CompletesFromCurrentTarget(
+            questAct.Template.ParentComponent.KindId,
+            questAct.Template.ParentComponent.PlayCinemaBeforeBubble,
+            ProgressCinemaId(questAct));
+
+    private static bool CompletesFromTalkEvent(QuestAct questAct) =>
+        QuestReportNpcRules.CompletesFromTalkEvent(
+            questAct.Template.ParentComponent.KindId,
+            questAct.Template.ParentComponent.PlayCinemaBeforeBubble,
+            ProgressCinemaId(questAct));
+
+    private static uint ProgressCinemaId(QuestAct questAct) =>
+        QuestCinemaRules.FirstCinema(
+            questAct.QuestComponent.Parent.Parent.Template,
+            QuestComponentKind.Progress);
 }

--- a/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjCinema.cs
+++ b/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjCinema.cs
@@ -1,6 +1,7 @@
 ﻿using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Quests.Templates;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Models.Game.Quests;
 
 namespace AAEmu.Game.Models.Game.Quests.Acts;
 
@@ -52,8 +53,12 @@ public class QuestActObjCinema(QuestComponentTemplate parentComponent) : QuestAc
 
         if (sender is not Character player)
             return;
-        // Set currentlyPlayingId
+        if (!QuestCinemaBindRules.ShouldBindStarted(e.CinemaId, CinemaId, player.CurrentlyPlayingCinemaId))
+            return;
+
         player.CurrentlyPlayingCinemaId = CinemaId;
+        if (QuestObjectiveSlotRules.CinemaWatchCounts(questAct.QuestComponent.Parent.Parent.Step))
+            SetObjective(questAct, 1);
     }
 
     /// <summary>
@@ -73,7 +78,8 @@ public class QuestActObjCinema(QuestComponentTemplate parentComponent) : QuestAc
         if (player.CurrentlyPlayingCinemaId != CinemaId)
             return;
 
-        SetObjective(questAct, 1);
+        if (QuestObjectiveSlotRules.CinemaWatchCounts(questAct.QuestComponent.Parent.Parent.Step))
+            SetObjective(questAct, 1);
         player.CurrentlyPlayingCinemaId = 0;
     }
 }

--- a/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjInteraction.cs
+++ b/AAEmu.Game/Models/Game/Quests/Acts/QuestActObjInteraction.cs
@@ -1,4 +1,6 @@
 ﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Static;
 using AAEmu.Game.Models.Game.Quests.Templates;
 using AAEmu.Game.Models.Game.Units;
 using AAEmu.Game.Models.Game.World;
@@ -53,7 +55,16 @@ public class QuestActObjInteraction(QuestComponentTemplate parentComponent) : Qu
         Logger.Debug($"{QuestActTemplateName}({DetailId}).OnInteraction: Quest: {questAct.QuestComponent.Parent.Parent.TemplateId}, Owner {questAct.QuestComponent.Parent.Parent.Owner.Name} ({questAct.QuestComponent.Parent.Parent.Owner.Id}), WorldInteractionId {WorldInteractionId}, DoodadId {DoodadId}, TeamShare {TeamShare}, Phase {Phase}.");
         AddObjective(questAct, 1);
 
-        var player = questAct.QuestComponent.Parent.Parent.Owner;
+        var quest = questAct.QuestComponent.Parent.Parent;
+        var progressCinemaId = QuestCinemaRules.FirstCinema(quest.Template, QuestComponentKind.Progress);
+        if (QuestNoneSceneRules.ShouldStartSceneCinema(
+                questAct.QuestComponent.Template.PlayCinemaBeforeBubble, progressCinemaId))
+        {
+            quest.Owner.Quests.BindPlayingCinema(progressCinemaId);
+            quest.CreditNoneSceneActs();
+        }
+
+        var player = quest.Owner;
         if (player.Id == args.SourcePlayer.Id)
         {
             // Handle interaction that only apply to source player

--- a/AAEmu.Game/Models/Game/Quests/LevelPackDoodadRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/LevelPackDoodadRules.cs
@@ -1,0 +1,27 @@
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// Which level-pack <c>doodad.g</c> rows World should author when
+/// <c>doodad_spawns.json</c> omitted them. Does not invent coordinates.
+/// </summary>
+public static class LevelPackDoodadRules
+{
+    /// <summary>
+    /// Permanent plant: scene bodies and quest talk/func doodads.
+    /// Not tower DoodadAlmighty, not a cell ignore/open list, and not
+    /// <c>game_schedule_doodads</c> (Christmas / weekend / festival — those
+    /// wait for the schedule). Extra fish schools and vegetation stay on json.
+    /// </summary>
+    public static bool ShouldAuthorPermanent(
+        bool clientDoodad,
+        bool npcTypeModel,
+        bool talkOrQuestFunc,
+        bool towerAlmighty,
+        bool ignoredPermanent,
+        bool scheduledEvent)
+    {
+        if (towerAlmighty || ignoredPermanent || scheduledEvent)
+            return false;
+        return clientDoodad || npcTypeModel || talkOrQuestFunc;
+    }
+}

--- a/AAEmu.Game/Models/Game/Quests/NewQuestCode.cs
+++ b/AAEmu.Game/Models/Game/Quests/NewQuestCode.cs
@@ -228,6 +228,7 @@ public partial class Quest
 
         // Trigger OnQuestStepChanged event, even if this step is not available
         Owner?.Events?.OnQuestStepChanged(Owner, new OnQuestStepChangedArgs { QuestId = TemplateId, Step = value });
+        Owner?.Quests?.ApplyNearbyQuestReacts(TemplateId);
         // Owner?.SendMessage($"Quest {TemplateId}, Step {oldValue} => {value}");
         // Logger.Debug($"Player {Owner?.Name ?? "???"}, Quest {TemplateId}, Step => {value}");
         RequestEvaluation();

--- a/AAEmu.Game/Models/Game/Quests/NewQuestCode.cs
+++ b/AAEmu.Game/Models/Game/Quests/NewQuestCode.cs
@@ -1,6 +1,7 @@
 using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.NPChar;
 using AAEmu.Game.Models.Game.Quests.Static;
 using AAEmu.Game.Models.Game.Units;
 
@@ -58,6 +59,13 @@ public partial class Quest
         // right-hand quest window empty despite 0x18C/0x18E flowing.
         if (Status == QuestStatus.Invalid || Status == QuestStatus.Dropped)
             Status = QuestStatus.Progress;
+
+        if (QuestNoneSceneRules.ShouldStartSceneOnAccept(Template))
+        {
+            var cinemaId = QuestCinemaRules.FirstCinema(Template, QuestComponentKind.Progress);
+            Owner?.Quests?.BindPlayingCinema(cinemaId);
+            CreditNoneSceneActs();
+        }
 
         Owner.SendPacket(new SCQuestContextStartedPacket(this, ComponentId));
         Logger.Debug($"StartQuest, Quest:{TemplateId}, Player {Owner.Name} ({Owner.Id}) status={(byte)Status}");
@@ -148,18 +156,27 @@ public partial class Quest
                 case QuestComponentKind.Reward:
                     // Reward is the last possible step
 
-                    // Mark quest as completed
+                    // Mark quest as completed and refresh the client's bitset block before
+                    // SCQuestContextCompleted so Accept unit_req kind-31 sees the prior finish.
                     var completedBlock = Owner.Quests.SetCompletedQuestFlag(TemplateId, true);
-                    // copy body data for packet
-                    var body = new byte[8];
-                    completedBlock.Body.CopyTo(body, 0);
+                    Owner.Quests.SendCompletedBlock(completedBlock);
 
                     // Daily schedule: push Done status before remove so the UI still has questType.
                     if (Owner is Character character)
                         TodayAssignmentManager.Instance.NotifyQuestCompleted(character, TemplateId);
 
+                    var nextQuestIds = QuestRewardAcceptRules.NextQuestIds(Template).ToArray();
+                    var completedComponentId = QuestCompletedWire.ComponentIdForCompletedPacket(ComponentId, Template);
                     Owner.Quests.DropQuest(TemplateId, false, false);
-                    Owner.SendPacket(new SCQuestContextCompletedPacket(TemplateId, 0));
+                    Owner.SendPacket(new SCQuestContextCompletedPacket(TemplateId, completedComponentId));
+
+                    foreach (var nextQuestId in nextQuestIds)
+                    {
+                        if (Owner.CurrentTarget is Npc npc)
+                            Owner.Quests.AddQuest(nextQuestId, false, QuestAcceptorType.Npc, npc.TemplateId);
+                        else
+                            Owner.Quests.AddQuest(nextQuestId);
+                    }
 
                     return;
                 default:
@@ -200,6 +217,14 @@ public partial class Quest
         // Initialize Acts for this Step (if any)
         if (QuestSteps.TryGetValue(value, out var questSteps))
             questSteps.InitializeStep();
+
+        if (value == QuestComponentKind.Progress)
+        {
+            // Only this quest's Progress cinema. Fall-through to Ready/Start
+            // would steal the playing film when the next quest has no Progress.
+            var cinemaId = QuestCinemaRules.FirstCinema(Template, QuestComponentKind.Progress);
+            Owner?.Quests?.BindAndCreditPlayingCinema(cinemaId);
+        }
 
         // Trigger OnQuestStepChanged event, even if this step is not available
         Owner?.Events?.OnQuestStepChanged(Owner, new OnQuestStepChangedArgs { QuestId = TemplateId, Step = value });
@@ -374,5 +399,24 @@ public partial class Quest
     public void StartingEvaluation()
     {
         RequestEvaluationFlag = false;
+    }
+
+    /// <summary>
+    /// None acts on a scene quest are the film. Credit them on accept (or
+    /// again if the client retries the doodad while this quest is still live).
+    /// </summary>
+    public void CreditNoneSceneActs()
+    {
+        if (!QuestSteps.TryGetValue(QuestComponentKind.None, out var none))
+            return;
+
+        foreach (var component in none.Components.Values)
+        {
+            component.OverrideObjectiveCompleted = true;
+            foreach (var act in component.Acts)
+                act.OverrideObjectiveCompleted = true;
+        }
+
+        RequestEvaluation();
     }
 }

--- a/AAEmu.Game/Models/Game/Quests/Quest.cs
+++ b/AAEmu.Game/Models/Game/Quests/Quest.cs
@@ -5,6 +5,7 @@ using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Items;
 using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.Quests.Acts;
 using AAEmu.Game.Models.Game.Quests.Static;
 using AAEmu.Game.Models.Game.Quests.Templates;
 using AAEmu.Game.Models.Game.Skills;
@@ -18,7 +19,7 @@ namespace AAEmu.Game.Models.Game.Quests;
 
 public partial class Quest : PacketMarshaler
 {
-    private const int MaxObjectiveCount = 5;
+    private const int MaxObjectiveCount = QuestObjectiveSlotRules.MaxSlots;
     private readonly IQuestManager _questManager;
     private readonly ITaskManager _taskManager;
     private readonly ISkillManager _skillManager;
@@ -42,7 +43,8 @@ public partial class Quest : PacketMarshaler
     public IQuestTemplate Template { get; set; }
 
     /// <summary>
-    /// Objective counters for the Progress step
+    /// Objective counters. Progress journal lines use Progress-component-local
+    /// indexes (first Progress component is slot 0). None-step acts use leftover slots.
     /// </summary>
     internal int[] Objectives { get; set; }
 
@@ -179,10 +181,31 @@ public partial class Quest : PacketMarshaler
     }
 
     private bool _skipUpdatePacket;
+    private readonly HashSet<uint> _appliedComponentEffects = [];
 
     public void SkipUpdatePackets()
     {
         _skipUpdatePacket = true;
+    }
+
+    /// <summary>
+    /// Component skills/buffs/AI apply once when the component first succeeds.
+    /// </summary>
+    public bool TryApplyComponentEffects(QuestComponentTemplate component)
+    {
+        if (component == null)
+            return false;
+        return QuestComponentEffectRules.TryMarkApplied(component.Id, _appliedComponentEffects);
+    }
+
+        /// <summary>
+        /// Hold the component buff until the quest cinema ends (teleport after turn-in).
+        /// </summary>
+        public void DeferComponentEffectsUntilCinema(QuestComponentTemplate component, uint cinemaId)
+    {
+        if (!TryApplyComponentEffects(component))
+            return;
+        Owner?.Quests?.EnqueueCinemaEndEffects(cinemaId, component);
     }
 
     /// <summary>
@@ -248,37 +271,7 @@ public partial class Quest : PacketMarshaler
     /// <param name="component"></param>
     public void UseSkillAndBuff(QuestComponentTemplate component)
     {
-        if (component == null) { return; }
-        UseSkill(component);
-        UseBuff(component);
-    }
-
-    private void UseBuff(QuestComponentTemplate component)
-    {
-        if (component.BuffId > 0)
-        {
-            Owner.Buffs.AddBuff(new Buff(Owner, Owner, SkillCaster.GetByType(SkillCasterType.Unit), _skillManager.GetBuffTemplate(component.BuffId), null, DateTime.UtcNow));
-        }
-    }
-
-    /// <summary>
-    /// Use Skill defined in QuestComponent on yourself or on the Npc you interact with
-    /// </summary>
-    /// <param name="component"></param>
-    private void UseSkill(QuestComponentTemplate component)
-    {
-        if (component.SkillId > 0)
-        {
-            if (component.SkillSelf)
-            {
-                Owner.UseSkill(component.SkillId, Owner);
-            }
-            else if (component.NpcId > 0)
-            {
-                var npc = ((Character)Owner).ParentWorld.GetNpcByTemplateId(component.NpcId);
-                npc?.UseSkill(component.SkillId, npc);
-            }
-        }
+        QuestComponentEffectRules.ApplySkillAndBuff(Owner, component, _skillManager);
     }
 
     /// <summary>
@@ -452,10 +445,7 @@ public partial class Quest : PacketMarshaler
         {
             var component = Template.GetFirstComponent(step);
             if (component != null)
-            {
-                UseSkill(component);
-                UseBuff(component);
-            }
+                UseSkillAndBuff(component);
         }
 
         if (update)

--- a/AAEmu.Game/Models/Game/Quests/QuestAcceptRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestAcceptRules.cs
@@ -1,0 +1,71 @@
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// Start-act acceptor used when the caller did not name one (GM /quest add).
+/// </summary>
+public static class QuestAcceptRules
+{
+    public static bool TryResolveStartAcceptor(
+        IQuestTemplate template,
+        out QuestAcceptorType acceptorType,
+        out uint acceptorId)
+    {
+        acceptorType = QuestAcceptorType.Unknown;
+        acceptorId = 0;
+        if (template == null)
+            return false;
+
+        foreach (var component in template.GetComponents(QuestComponentKind.Start))
+        {
+            if (component?.ActTemplates == null)
+                continue;
+
+            foreach (var act in component.ActTemplates)
+            {
+                switch (act)
+                {
+                    case QuestActConAcceptNpc npc when npc.NpcId != 0:
+                        acceptorType = QuestAcceptorType.Npc;
+                        acceptorId = npc.NpcId;
+                        return true;
+                    case QuestActConAcceptDoodad doodad when doodad.DoodadId != 0:
+                        acceptorType = QuestAcceptorType.Doodad;
+                        acceptorId = doodad.DoodadId;
+                        return true;
+                    case QuestActConAcceptSphere sphere when sphere.SphereId != 0:
+                        acceptorType = QuestAcceptorType.Sphere;
+                        acceptorId = sphere.SphereId;
+                        return true;
+                    case QuestActConAcceptSkill skill when skill.SkillId != 0:
+                        acceptorType = QuestAcceptorType.Skill;
+                        acceptorId = skill.SkillId;
+                        return true;
+                    case QuestActConAcceptItem item when item.ItemId != 0:
+                        acceptorType = QuestAcceptorType.Item;
+                        acceptorId = item.ItemId;
+                        return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public static void FillUnknownAcceptor(
+        IQuestTemplate template,
+        ref QuestAcceptorType acceptorType,
+        ref uint acceptorId)
+    {
+        if (acceptorType != QuestAcceptorType.Unknown || acceptorId != 0)
+            return;
+        if (TryResolveStartAcceptor(template, out var type, out var id))
+        {
+            acceptorType = type;
+            acceptorId = id;
+        }
+    }
+}

--- a/AAEmu.Game/Models/Game/Quests/QuestAct.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestAct.cs
@@ -46,7 +46,13 @@ public class QuestAct(QuestComponent parentComponent, QuestActTemplate template)
 
     public bool RunAct()
     {
-        var count = QuestComponent.Template.KindId == QuestComponentKind.Progress && Template.ThisComponentObjectiveIndex < QuestComponent.Parent.Parent.Objectives.Length ? QuestComponent.Parent.Parent.Objectives[Template.ThisComponentObjectiveIndex] : 0;
+        var objectives = QuestComponent.Parent.Parent.Objectives;
+        var count = QuestObjectiveSlotRules.RunActUsesStoredCount(
+            QuestComponent.Template.KindId,
+            Template.ThisComponentObjectiveIndex,
+            objectives.Length)
+            ? objectives[Template.ThisComponentObjectiveIndex]
+            : 0;
         return Template.RunAct(QuestComponent.Parent.Parent, this, count) || OverrideObjectiveCompleted;
     }
 

--- a/AAEmu.Game/Models/Game/Quests/QuestCinemaBindRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestCinemaBindRules.cs
@@ -58,4 +58,12 @@ public static class QuestCinemaBindRules
 
         return found;
     }
+
+    /// <summary>
+    /// Dropped quests must not apply a deferred cinema skill or buff.
+    /// </summary>
+    public static bool ShouldApplyCinemaEndEffect(bool questStillActive) => questStillActive;
+
+    public static bool CinemaEndBelongsToQuest(uint pendingQuestId, uint droppedQuestId) =>
+        droppedQuestId != 0 && pendingQuestId == droppedQuestId;
 }

--- a/AAEmu.Game/Models/Game/Quests/QuestCinemaBindRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestCinemaBindRules.cs
@@ -60,9 +60,19 @@ public static class QuestCinemaBindRules
     }
 
     /// <summary>
-    /// Dropped quests must not apply a deferred cinema skill or buff.
+    /// Abandoned quests must not apply a deferred cinema skill or buff.
+    /// Reward also calls DropQuest after the completed flag, and the film
+    /// is still playing — that complete still owns the post-scene effect.
     /// </summary>
-    public static bool ShouldApplyCinemaEndEffect(bool questStillActive) => questStillActive;
+    public static bool ShouldApplyCinemaEndEffect(bool questStillActive, bool questCompleted) =>
+        questStillActive || questCompleted;
+
+    /// <summary>
+    /// Complete uses the same DropQuest as abandon. Keep the pending cinema-end
+    /// until the film finishes. GM force-clear and abandon drop it.
+    /// </summary>
+    public static bool ShouldClearCinemaEndOnDrop(bool questCompleted, bool forcibly) =>
+        forcibly || !questCompleted;
 
     public static bool CinemaEndBelongsToQuest(uint pendingQuestId, uint droppedQuestId) =>
         droppedQuestId != 0 && pendingQuestId == droppedQuestId;

--- a/AAEmu.Game/Models/Game/Quests/QuestCinemaBindRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestCinemaBindRules.cs
@@ -1,0 +1,61 @@
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// StartedCinema is an empty body. Bind only when permission / Progress
+/// enter already named this cinema, or the event carries the act id.
+/// An unnamed start is a different bubble and must not steal the quest cinema.
+/// </summary>
+public static class QuestCinemaBindRules
+{
+    public static bool ShouldBindStarted(uint eventCinemaId, uint actCinemaId, uint currentlyPlaying)
+    {
+        if (actCinemaId == 0)
+            return false;
+        if (eventCinemaId != 0 && eventCinemaId != actCinemaId)
+            return false;
+        if (eventCinemaId == 0 && currentlyPlaying != actCinemaId)
+            return false;
+        return true;
+    }
+
+    /// <summary>
+    /// Talk / permission can start the cinema while the step is still None.
+    /// Entering Progress must credit that already-playing cinema so Reward
+    /// and the next accept happen during the film, before the teleport buff.
+    /// </summary>
+    public static bool ShouldCreditOnEnterProgress(uint currentlyPlaying, uint progressCinemaId) =>
+        progressCinemaId != 0 && currentlyPlaying == progressCinemaId;
+
+    /// <summary>
+    /// Accepting the next quest walks a missing Progress step and must not
+    /// replace the film already playing (that cinema still owns the teleport).
+    /// </summary>
+    public static bool ShouldReplacePlaying(uint currentlyPlaying, uint incoming) =>
+        incoming != 0 && (currentlyPlaying == 0 || currentlyPlaying == incoming);
+
+    /// <summary>
+    /// CompletedCinema has an empty body. A skip before permission/start
+    /// leaves the playing id at 0; the only safe name is a single deferred
+    /// cinema on this character.
+    /// </summary>
+    public static uint ResolveCompletedCinema(uint currentlyPlaying, IReadOnlyList<uint> deferredCinemaIds)
+    {
+        if (currentlyPlaying != 0)
+            return currentlyPlaying;
+        if (deferredCinemaIds == null)
+            return 0;
+
+        uint found = 0;
+        foreach (var cinemaId in deferredCinemaIds)
+        {
+            if (cinemaId == 0)
+                continue;
+            if (found == 0)
+                found = cinemaId;
+            else if (found != cinemaId)
+                return 0;
+        }
+
+        return found;
+    }
+}

--- a/AAEmu.Game/Models/Game/Quests/QuestCinemaPermissionRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestCinemaPermissionRules.cs
@@ -1,0 +1,33 @@
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// Directing permission names a component id. Bind only when that cinema
+/// is on the component and the player is at a supplied NPC or doodad.
+/// </summary>
+public static class QuestCinemaPermissionRules
+{
+    /// <summary>
+    /// Same interact band as merchant / specialty (<c>InteractionRange</c> default).
+    /// </summary>
+    public const float MaxSourceDistanceMetres = 3f;
+
+    public static bool SourceAllowed(bool requested, bool found, float distanceMetres) =>
+        requested && found && distanceMetres <= MaxSourceDistanceMetres;
+
+    public static bool CanBind(
+        uint cinemaId,
+        bool componentKnown,
+        bool questActive,
+        QuestComponentKind? componentKind,
+        bool npcAllowed,
+        bool doodadAllowed)
+    {
+        if (cinemaId == 0 || !componentKnown)
+            return false;
+        if (!questActive && componentKind != QuestComponentKind.Start)
+            return false;
+        return npcAllowed || doodadAllowed;
+    }
+}

--- a/AAEmu.Game/Models/Game/Quests/QuestCinemaRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestCinemaRules.cs
@@ -1,0 +1,104 @@
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// Cinema id the client already owns on a Start/Ready/Progress component
+/// (column or cinema act). Directing permission records it so
+/// Started/Completed cinema events match.
+/// </summary>
+public static class QuestCinemaRules
+{
+    /// <summary>
+    /// Directing permission sends a component id, not a quest id.
+    /// Use that component's cinema when present.
+    /// </summary>
+    public static uint CinemaIdForPermission(
+        QuestComponentTemplate component,
+        IQuestTemplate template,
+        QuestComponentKind? preferStep = null)
+    {
+        var fromComponent = CinemaIdOnComponent(component);
+        if (fromComponent != 0)
+            return fromComponent;
+        return CinemaIdForDirecting(template, preferStep);
+    }
+
+    public static uint CinemaIdOnComponent(QuestComponentTemplate component)
+    {
+        if (component == null)
+            return 0;
+        if (component.CinemaId != 0)
+            return component.CinemaId;
+        if (component.ActTemplates == null)
+            return 0;
+        foreach (var act in component.ActTemplates)
+        {
+            if (act is QuestActObjCinema cinema && cinema.CinemaId != 0)
+                return cinema.CinemaId;
+        }
+
+        return 0;
+    }
+
+    public static uint CinemaIdForDirecting(IQuestTemplate template, QuestComponentKind? preferStep = null)
+    {
+        if (template == null)
+            return 0;
+
+        if (preferStep is { } step)
+        {
+            var preferred = FirstCinema(template, step);
+            if (preferred != 0)
+                return preferred;
+        }
+
+        foreach (var kind in new[]
+                 {
+                     QuestComponentKind.Ready,
+                     QuestComponentKind.Start,
+                     QuestComponentKind.Progress
+                 })
+        {
+            var cinemaId = FirstCinema(template, kind);
+            if (cinemaId != 0)
+                return cinemaId;
+        }
+
+        return 0;
+    }
+
+    public static uint FirstCinema(IQuestTemplate template, QuestComponentKind kind) =>
+        FirstCinemaHit(template, kind).CinemaId;
+
+    public static uint FirstCinemaComponentId(IQuestTemplate template, QuestComponentKind kind) =>
+        FirstCinemaHit(template, kind).ComponentId;
+
+    private static CinemaHit FirstCinemaHit(IQuestTemplate template, QuestComponentKind kind)
+    {
+        var components = template?.GetComponents(kind);
+        if (components == null)
+            return default;
+
+        foreach (var component in components)
+        {
+            if (component == null)
+                continue;
+            if (component.CinemaId != 0)
+                return new CinemaHit(component.Id, component.CinemaId);
+            if (component.ActTemplates == null)
+                continue;
+            foreach (var act in component.ActTemplates)
+            {
+                if (act is QuestActObjCinema cinema && cinema.CinemaId != 0)
+                    return new CinemaHit(component.Id, cinema.CinemaId);
+            }
+        }
+
+        return default;
+    }
+
+    private readonly record struct CinemaHit(uint ComponentId, uint CinemaId);
+}

--- a/AAEmu.Game/Models/Game/Quests/QuestCompletedWire.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestCompletedWire.cs
@@ -1,0 +1,42 @@
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// Finishing component on <c>SCQuestContextCompleted</c>. Zero skips the
+/// client's component lookup and leaves that quest's camera / chat work undone.
+/// Prefer Ready when it owns a cinema so directing cleanup can clear before
+/// the next quest accept. Progress cinema (column or act) is next so a
+/// no-Ready scene still names the camera that just played.
+/// </summary>
+public static class QuestCompletedWire
+{
+    public static uint ComponentIdForCompletedPacket(uint currentComponentId, IQuestTemplate template)
+    {
+        if (template != null)
+        {
+            var readyWithCinema = QuestCinemaRules.FirstCinemaComponentId(template, QuestComponentKind.Ready);
+            if (readyWithCinema != 0)
+                return readyWithCinema;
+            var progressWithCinema = QuestCinemaRules.FirstCinemaComponentId(template, QuestComponentKind.Progress);
+            if (progressWithCinema != 0)
+                return progressWithCinema;
+        }
+
+        if (currentComponentId != 0)
+            return currentComponentId;
+        if (template == null)
+            return 0;
+
+        var reward = template.GetComponents(QuestComponentKind.Reward);
+        if (reward is { Length: > 0 } && reward[0].Id != 0)
+            return reward[0].Id;
+
+        var ready = template.GetComponents(QuestComponentKind.Ready);
+        if (ready is { Length: > 0 } && ready[0].Id != 0)
+            return ready[0].Id;
+
+        return 0;
+    }
+}

--- a/AAEmu.Game/Models/Game/Quests/QuestComponent.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestComponent.cs
@@ -68,11 +68,20 @@ public class QuestComponent : IQuestComponent
 
         res |= OverrideObjectiveCompleted;
 
-        // If acts completed, handle skill and buff effects
+        // If acts completed, handle skill and buff effects once
         if (res)
         {
-            Parent.Parent.UseSkillAndBuff(Template);
-            Parent.Parent.SetNpcAggro(Template);
+            var cinemaId = QuestCinemaRules.CinemaIdForDirecting(Parent.Parent.Template, Parent.ThisStep);
+            if (QuestComponentEffectRules.ShouldDeferUntilCinema(
+                    Template.PlayCinemaBeforeBubble, Template.BuffId, cinemaId))
+            {
+                Parent.Parent.DeferComponentEffectsUntilCinema(Template, cinemaId);
+            }
+            else if (Parent.Parent.TryApplyComponentEffects(Template))
+            {
+                Parent.Parent.UseSkillAndBuff(Template);
+                Parent.Parent.SetNpcAggro(Template);
+            }
         }
 
         return res;

--- a/AAEmu.Game/Models/Game/Quests/QuestComponentEffectRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestComponentEffectRules.cs
@@ -1,0 +1,59 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// Component skills/buffs/AI run once when the component first succeeds.
+/// Re-eval (same target still selected, orb use, later ticks) must not fire them again.
+/// A play-cinema-before-bubble buff (the post-scene teleport) waits until that
+/// cinema ends. Talk skills on the same quest fire when their component succeeds.
+/// </summary>
+public static class QuestComponentEffectRules
+{
+    public static bool TryMarkApplied(uint componentId, ISet<uint> applied)
+    {
+        if (componentId == 0 || applied == null)
+            return false;
+        return applied.Add(componentId);
+    }
+
+    public static bool ShouldDeferUntilCinema(bool playCinemaBeforeBubble, uint buffId, uint cinemaId) =>
+        playCinemaBeforeBubble && buffId != 0 && cinemaId != 0;
+
+    public static void ApplySkillAndBuff(ICharacter owner, QuestComponentTemplate component, ISkillManager skillManager)
+    {
+        if (owner == null || component == null)
+            return;
+
+        if (component.SkillId > 0)
+        {
+            if (component.SkillSelf)
+            {
+                owner.UseSkill(component.SkillId, owner);
+            }
+            else if (component.NpcId > 0 && owner is Character character)
+            {
+                var npc = character.ParentWorld.GetNpcByTemplateId(component.NpcId);
+                npc?.UseSkill(component.SkillId, npc);
+            }
+        }
+
+        if (component.BuffId > 0 && skillManager != null)
+        {
+            var buff = skillManager.GetBuffTemplate(component.BuffId);
+            if (buff != null)
+            {
+                owner.Buffs.AddBuff(new Buff(
+                    owner,
+                    owner,
+                    SkillCaster.GetByType(SkillCasterType.Unit),
+                    buff,
+                    null,
+                    DateTime.UtcNow));
+            }
+        }
+    }
+}

--- a/AAEmu.Game/Models/Game/Quests/QuestNoneSceneRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestNoneSceneRules.cs
@@ -1,0 +1,45 @@
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// Accept starts the Progress cinema. None acts (orb / talk / loot) are
+/// the film and complete during it. The client owns doodad retry if that
+/// chain did not finish; World only re-runs the same path while the quest
+/// is still active.
+/// </summary>
+public static class QuestNoneSceneRules
+{
+    public static bool ShouldStartSceneCinema(bool playCinemaBeforeBubble, uint progressCinemaId) =>
+        playCinemaBeforeBubble && progressCinemaId != 0;
+
+    public static bool NoneHasPlayCinemaBeforeBubble(IQuestTemplate template)
+    {
+        var none = template?.GetComponents(QuestComponentKind.None);
+        if (none == null)
+            return false;
+        foreach (var component in none)
+        {
+            if (component.PlayCinemaBeforeBubble)
+                return true;
+        }
+
+        return false;
+    }
+
+    public static bool ShouldStartSceneOnAccept(IQuestTemplate template) =>
+        ShouldStartSceneCinema(
+            NoneHasPlayCinemaBeforeBubble(template),
+            QuestCinemaRules.FirstCinema(template, QuestComponentKind.Progress));
+
+    /// <summary>
+    /// None-step ReportNpc on a scene quest is the film talk. Leftover
+    /// accept target must not complete it before the scene credits the act.
+    /// </summary>
+    public static bool IsSceneReportTalk(
+        QuestComponentKind kind,
+        bool playCinemaBeforeBubble,
+        uint progressCinemaId) =>
+        kind == QuestComponentKind.None && ShouldStartSceneCinema(playCinemaBeforeBubble, progressCinemaId);
+}

--- a/AAEmu.Game/Models/Game/Quests/QuestObjectiveSlotRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestObjectiveSlotRules.cs
@@ -1,0 +1,54 @@
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// Journal lines are Progress components. Their counters are the Progress-local
+/// index (first Progress component is slot 0). None-step Use/Gather acts take
+/// leftover slots so they do not overwrite those journal counters, and they
+/// still read the stored count when the step evaluates.
+/// </summary>
+public static class QuestObjectiveSlotRules
+{
+    public const byte NoSlot = 0xFF;
+    public const int MaxSlots = 5;
+
+    public static byte SlotForProgressComponent(int progressComponentIndex, int maxSlots)
+    {
+        if (progressComponentIndex < 0 || progressComponentIndex >= maxSlots)
+            return NoSlot;
+        return (byte)progressComponentIndex;
+    }
+
+    public static byte NextIndex(ref byte actIndex, bool countsAsObjective, int maxSlots)
+    {
+        if (!countsAsObjective || actIndex >= maxSlots)
+            return NoSlot;
+        var assigned = actIndex;
+        actIndex++;
+        return assigned;
+    }
+
+    public static bool RunActUsesStoredCount(QuestComponentKind kind, byte index, int objectivesLength)
+    {
+        if (index == NoSlot || index >= objectivesLength)
+            return false;
+        return kind is QuestComponentKind.Progress or QuestComponentKind.None;
+    }
+
+    /// <summary>
+    /// Accept/orb can play a cinema while the step is still None.
+    /// Only the Progress step should tick a cinema journal line.
+    /// </summary>
+    public static bool CinemaWatchCounts(QuestComponentKind step) =>
+        step == QuestComponentKind.Progress;
+
+    public static bool ObjectiveActMet(byte index, int required, bool overrideCompleted, int[] objectives)
+    {
+        if (overrideCompleted)
+            return true;
+        if (objectives == null || index == NoSlot || index >= objectives.Length)
+            return false;
+        return objectives[index] >= required;
+    }
+}

--- a/AAEmu.Game/Models/Game/Quests/QuestReportNpcRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestReportNpcRules.cs
@@ -1,0 +1,31 @@
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// None-step ReportNpc is the talk that starts the scene. It must not wait
+/// for Progress (that cinema is later) and must not skip to Ready.
+/// A scene talk is credited with the orb, not leftover accept target or
+/// a second visit to the starter.
+/// </summary>
+public static class QuestReportNpcRules
+{
+    public static bool TalkCompletesWithoutProgress(QuestComponentKind kind) =>
+        kind == QuestComponentKind.None;
+
+    public static bool TalkAdvancesToReady(QuestComponentKind kind) =>
+        kind is QuestComponentKind.Ready or QuestComponentKind.Progress;
+
+    public static bool CompletesFromCurrentTarget(
+        QuestComponentKind kind,
+        bool playCinemaBeforeBubble,
+        uint progressCinemaId) =>
+        !QuestNoneSceneRules.IsSceneReportTalk(kind, playCinemaBeforeBubble, progressCinemaId);
+
+    public static bool CompletesFromTalkEvent(
+        QuestComponentKind kind,
+        bool playCinemaBeforeBubble,
+        uint progressCinemaId) =>
+        TalkCompletesWithoutProgress(kind)
+        && !QuestNoneSceneRules.IsSceneReportTalk(kind, playCinemaBeforeBubble, progressCinemaId);
+}

--- a/AAEmu.Game/Models/Game/Quests/QuestRewardAcceptRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestRewardAcceptRules.cs
@@ -1,0 +1,33 @@
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// Reward AcceptComponent rows start the next quest after this one is marked complete.
+/// </summary>
+public static class QuestRewardAcceptRules
+{
+    public static IEnumerable<uint> NextQuestIds(IQuestTemplate template)
+    {
+        if (template == null)
+            yield break;
+
+        var reward = template.GetComponents(QuestComponentKind.Reward);
+        if (reward == null)
+            yield break;
+
+        foreach (var component in reward)
+        {
+            if (component?.ActTemplates == null)
+                continue;
+            foreach (var act in component.ActTemplates)
+            {
+                if (act is QuestActConAcceptComponent accept && accept.QuestContextId != 0
+                    && accept.QuestContextId != template.Id)
+                    yield return accept.QuestContextId;
+            }
+        }
+    }
+}

--- a/AAEmu.Game/Models/Game/Quests/QuestTalkDoodadRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestTalkDoodadRules.cs
@@ -1,0 +1,205 @@
+using System.Globalization;
+
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// Doodad templates quests accept, report, or interact with, plus
+/// <c>npctype://</c> companions that share the same level-pack pad.
+/// Placements come from the level pack; this does not invent coordinates.
+/// </summary>
+public static class QuestTalkDoodadRules
+{
+    public const float SamePlacementMetres = 1f;
+
+    /// <summary>
+    /// 3901 extras sit ≤8 m from report 14226. The 17722 arrival square is ~300 m away.
+    /// </summary>
+    public const float SceneCompanionPadMetres = 12f;
+
+    public const string NpcTypeModelPrefix = "npctype://";
+
+    public readonly record struct Placement(uint TemplateId, float X, float Y, float Z, float YawDegrees);
+
+    public readonly record struct Existing(uint TemplateId, float X, float Y, float Z);
+
+    public static bool TryParseNpcTypeModel(string model, out uint npcId)
+    {
+        npcId = 0;
+        if (string.IsNullOrEmpty(model) ||
+            !model.StartsWith(NpcTypeModelPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var rest = model.AsSpan(NpcTypeModelPrefix.Length);
+        return uint.TryParse(rest, NumberStyles.Integer, CultureInfo.InvariantCulture, out npcId) &&
+               npcId != 0;
+    }
+
+    public static bool IsOnScenePad(float ax, float ay, float az, float bx, float by, float bz)
+    {
+        var dx = ax - bx;
+        var dy = ay - by;
+        var dz = az - bz;
+        return dx * dx + dy * dy + dz * dz <= SceneCompanionPadMetres * SceneCompanionPadMetres;
+    }
+
+    public static void AddTalkDoodads(IQuestTemplate template, ISet<uint> dest)
+    {
+        if (template?.Components == null || dest == null)
+            return;
+
+        foreach (var component in template.Components.Values)
+        {
+            if (component?.ActTemplates == null)
+                continue;
+
+            foreach (var act in component.ActTemplates)
+            {
+                switch (act)
+                {
+                    case QuestActConAcceptDoodad accept when accept.DoodadId != 0:
+                        dest.Add(accept.DoodadId);
+                        break;
+                    case QuestActConReportDoodad report when report.DoodadId != 0:
+                        dest.Add(report.DoodadId);
+                        break;
+                    case QuestActObjInteraction interact when interact.DoodadId != 0:
+                        dest.Add(interact.DoodadId);
+                        break;
+                    case QuestActObjDoodadPhaseCheck phase when phase.DoodadId != 0:
+                        dest.Add(phase.DoodadId);
+                        break;
+                }
+            }
+        }
+    }
+
+    public static void ExceptTowerAlmighty(ISet<uint> dest, IReadOnlySet<uint> towerAlmightyIds)
+    {
+        if (dest == null || towerAlmightyIds == null || towerAlmightyIds.Count == 0)
+            return;
+
+        dest.ExceptWith(towerAlmightyIds);
+    }
+
+    public static bool IsSamePlacement(float ax, float ay, float az, float bx, float by, float bz)
+    {
+        var dx = ax - bx;
+        var dy = ay - by;
+        var dz = az - bz;
+        return dx * dx + dy * dy + dz * dz <= SamePlacementMetres * SamePlacementMetres;
+    }
+
+    /// <summary>
+    /// Catalog rows to spawn. Skips a placement that already has that template within
+    /// <see cref="SamePlacementMetres"/>. Wanted ids with no catalog row are not invented.
+    /// </summary>
+    public static IReadOnlyList<Placement> Plan(
+        IReadOnlyCollection<uint> wanted,
+        IReadOnlyList<Placement> catalog,
+        IReadOnlyList<Existing> existing)
+    {
+        if (wanted == null || wanted.Count == 0 || catalog == null || catalog.Count == 0)
+            return [];
+
+        var wantedSet = wanted as ISet<uint> ?? wanted.ToHashSet();
+        var live = existing ?? [];
+        var planned = new List<Placement>();
+        foreach (var place in catalog)
+        {
+            if (place.TemplateId == 0 || !wantedSet.Contains(place.TemplateId))
+                continue;
+            if (HasExisting(live, place))
+                continue;
+            planned.Add(place);
+        }
+
+        return planned;
+    }
+
+    /// <summary>
+    /// <c>npctype://</c> catalog rows on the same pad as a talk doodad, excluding the
+    /// talk templates themselves. Live F on 3901 uses doodad 14227 — no NPC 11966.
+    /// </summary>
+    public static IReadOnlyList<Placement> PlanCompanions(
+        IReadOnlyCollection<uint> talkIds,
+        IReadOnlyList<Placement> talkCatalog,
+        IReadOnlyList<Placement> npcTypeCatalog,
+        IReadOnlyList<Existing> existing)
+    {
+        if (talkIds == null || talkCatalog == null || npcTypeCatalog == null)
+            return [];
+
+        var talkSet = talkIds as ISet<uint> ?? talkIds.ToHashSet();
+        if (talkSet.Count == 0)
+            return [];
+
+        List<Placement>? anchors = null;
+        foreach (var place in talkCatalog)
+        {
+            if (place.TemplateId == 0 || !talkSet.Contains(place.TemplateId))
+                continue;
+            anchors ??= [];
+            anchors.Add(place);
+        }
+
+        if (anchors == null || anchors.Count == 0)
+            return [];
+
+        var live = existing ?? [];
+        var planned = new List<Placement>();
+        foreach (var place in npcTypeCatalog)
+        {
+            if (place.TemplateId == 0 || talkSet.Contains(place.TemplateId))
+                continue;
+            if (!NearAnyAnchor(anchors, place))
+                continue;
+            if (HasExisting(live, place))
+                continue;
+            planned.Add(place);
+        }
+
+        return planned;
+    }
+
+    public static void AddCompanionTemplateIds(
+        ISet<uint> dest,
+        IReadOnlyCollection<uint> talkIds,
+        IReadOnlyList<Placement> talkCatalog,
+        IReadOnlyList<Placement> npcTypeCatalog)
+    {
+        if (dest == null)
+            return;
+
+        foreach (var place in PlanCompanions(talkIds, talkCatalog, npcTypeCatalog, []))
+            dest.Add(place.TemplateId);
+    }
+
+    private static bool NearAnyAnchor(IReadOnlyList<Placement> anchors, Placement place)
+    {
+        foreach (var anchor in anchors)
+        {
+            if (IsOnScenePad(anchor.X, anchor.Y, anchor.Z, place.X, place.Y, place.Z))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool HasExisting(IReadOnlyList<Existing> existing, Placement place)
+    {
+        foreach (var row in existing)
+        {
+            if (row.TemplateId != place.TemplateId)
+                continue;
+            if (IsSamePlacement(row.X, row.Y, row.Z, place.X, place.Y, place.Z))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/AAEmu.Game/Models/Game/Quests/QuestTalkNpcRules.cs
+++ b/AAEmu.Game/Models/Game/Quests/QuestTalkNpcRules.cs
@@ -1,0 +1,47 @@
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.Game.Models.Game.Quests;
+
+/// <summary>
+/// NPCs the client talks to for accept, report, or talk objectives.
+/// Hunt / kill starters stay off this list so combat NPCs keep their role skill.
+/// </summary>
+public static class QuestTalkNpcRules
+{
+    public static void AddTalkNpcs(IQuestTemplate template, ISet<uint> dest)
+    {
+        if (template?.Components == null || dest == null)
+            return;
+
+        foreach (var component in template.Components.Values)
+        {
+            if (component?.ActTemplates == null)
+                continue;
+
+            foreach (var act in component.ActTemplates)
+            {
+                switch (act)
+                {
+                    case QuestActConAcceptNpc accept when accept.NpcId != 0:
+                        dest.Add(accept.NpcId);
+                        break;
+                    case QuestActConAcceptNpcEmotion emotion when emotion.NpcId != 0:
+                        dest.Add(emotion.NpcId);
+                        break;
+                    case QuestActConReportNpc report when report.NpcId != 0:
+                        dest.Add(report.NpcId);
+                        break;
+                    case QuestActObjTalk talk when talk.NpcId != 0:
+                        dest.Add(talk.NpcId);
+                        break;
+                }
+            }
+        }
+    }
+
+    public static bool IsTalkNpc(ISet<uint> talkNpcs, uint npcTemplateId)
+    {
+        return npcTemplateId != 0 && talkNpcs != null && talkNpcs.Contains(npcTemplateId);
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/Effects/InteractionEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/InteractionEffect.cs
@@ -40,8 +40,7 @@ public class InteractionEffect : EffectTemplate
 
         if (caster is not Character character) { return; }
         if (character.SkillCancelled) { return; }
-        if (target is Doodad doodad &&
-            DoodadQuestFuncRules.ShouldCountInteraction(doodad.LastUseAppliedFunc))
+        if (target is Doodad doodad && doodad.ConsumeUseAppliedFunc(character.ObjId))
         {
             QuestManager.Instance.DoDoodadInteractionEvents((Character)caster, (Character)caster, target.TemplateId);
         }

--- a/AAEmu.Game/Models/Game/Skills/Effects/InteractionEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/InteractionEffect.cs
@@ -40,11 +40,9 @@ public class InteractionEffect : EffectTemplate
 
         if (caster is not Character character) { return; }
         if (character.SkillCancelled) { return; }
-        if (target is Doodad doodad)
+        if (target is Doodad doodad &&
+            DoodadQuestFuncRules.ShouldCountInteraction(doodad.LastUseAppliedFunc))
         {
-            //character.Quests.OnInteraction(WorldInteraction, target);
-            // инициируем событие
-            //Task.Run(() => QuestManager.Instance.DoInteractionEvents((Character)caster, target.TemplateId));
             QuestManager.Instance.DoDoodadInteractionEvents((Character)caster, (Character)caster, target.TemplateId);
         }
     }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Combo.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Combo.cs
@@ -1,10 +1,15 @@
-﻿using AAEmu.Game.Models.Game.Char;
-using AAEmu.Game.Models.Game.Units;
+﻿using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
 
+/// <summary>
+/// Combo names the next hold-hit for the client. World executes that skill only
+/// when the client starts it.
+/// </summary>
 public class Combo : SpecialEffectAction
 {
+    protected override SpecialType SpecialEffectActionType => SpecialType.Combo;
+
     public override void Execute(BaseUnit caster,
         SkillCaster casterObj,
         BaseUnit target,
@@ -18,6 +23,5 @@ public class Combo : SpecialEffectAction
         int value3,
         int value4)
     {
-        if (caster is Character) { Logger.Debug("Special effects: Combo comboSkillId {0}, timeFromNow {1}, value3 {2}, value4 {3}", comboSkillId, timeFromNow, value3, value4); }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Return.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Return.cs
@@ -1,4 +1,5 @@
 ﻿using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets.G2C;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Teleport;
@@ -40,81 +41,86 @@ public class Return : SpecialEffectAction
         }
         else
         {
-            // Worldgates
+            // value1 is return_points.id — worldgate / recall JSON, then return_point.g.
             returnPointId = (uint)value1;
-            trp = PortalManager.Instance.GetWorldGatesById(returnPointId);
+            trp = PortalManager.Instance.GetReturnPoint(returnPointId);
         }
 
         if (trp != null)
         {
-            // return to main_world
-            character.DisabledSetPosition = true;
-            character.SendPacket(
-                new SCLoadInstancePacket(
-                    1,
-                    trp.ZoneId,
-                    trp.X,
-                    trp.Y,
-                    trp.Z,
-                    0,
-                    0,
-                    trp.Yaw.DegToRad()
-                )
-            );
+            if (!ReturnTeleportRules.HasValidDestination(trp.X, trp.Y, trp.Z))
+            {
+                Logger.Warn("Return refused origin dest point={0}", returnPointId);
+                return;
+            }
 
-            character.Transform = new Transform(
+            ApplyReturn(
                 character,
-                null,
+                ReturnTeleportRules.LoadWorldId(trp.WorldId, WorldManager.DefaultWorldTemplateId),
+                WorldManager.DefaultInstanceId,
                 trp.ZoneId,
-                0,
                 trp.X,
                 trp.Y,
                 trp.Z,
                 trp.Yaw.DegToRad());
-            //character.MainWorldPosition = null; // we will not delete the return point to the main world
-        }
-        else if (character.MainWorldPosition != null)
-        {
-            character.DisabledSetPosition = true;
-            character.SendPacket(
-                new SCLoadInstancePacket(
-                    character.MainWorldPosition.InstanceId,
-                    character.MainWorldPosition.ZoneId,
-                    character.MainWorldPosition.World.Position.X,
-                    character.MainWorldPosition.World.Position.Y,
-                    character.MainWorldPosition.World.Position.Z,
-                    character.MainWorldPosition.World.Rotation.X.DegToRad(),
-                    character.MainWorldPosition.World.Rotation.Y.DegToRad(),
-                    character.MainWorldPosition.World.Rotation.Z.DegToRad()
-                )
-            );
-
-            character.Transform = character.MainWorldPosition.Clone(character);
-            //character.MainWorldPosition = null; // we will not delete the return point to the main world
-        }
-
-        if (trp == null)
-        {
-            Logger.Info($"Return: Need to add information to worldgates.json:\r\n" +
-                        $"        \"Id\": {value1}\r\n" +
-                        $"        \"ZoneId\": {character.Transform.ZoneId},\r\n" +
-                        $"        \"X\": {character.Transform.World.Position.X},\r\n" +
-                        $"        \"Y\": {character.Transform.World.Position.Y},\r\n" +
-                        $"        \"Z\": {character.Transform.World.Position.Z},\r\n" +
-                        $"        \"Yaw\": {character.Transform.World.Rotation.Z},\r\n" +
-                        $"        \"SubZoneId\": {character.SubZoneId}\r\n" +
-                        $"The coordinates need to be set correctly, these are just an example.");
             return;
         }
 
-        caster.DisabledSetPosition = true;
-        character.SendPacket(
-            new SCTeleportUnitPacket(
-            TeleportReason.MoveToLocation,
-            0,
-            trp.X,
-            trp.Y,
-            trp.Z,
-            trp.Yaw.DegToRad()));
+        if (character.MainWorldPosition != null)
+        {
+            var home = character.MainWorldPosition.World.Position;
+            if (!ReturnTeleportRules.HasValidDestination(home.X, home.Y, home.Z))
+            {
+                Logger.Warn("Return refused origin MainWorldPosition for {0}", character.Name);
+                return;
+            }
+
+            var homeRot = character.MainWorldPosition.World.Rotation;
+            ApplyReturn(
+                character,
+                ReturnTeleportRules.LoadWorldId(character.MainWorldPosition.WorldId, WorldManager.DefaultWorldTemplateId),
+                character.MainWorldPosition.InstanceId,
+                character.MainWorldPosition.ZoneId,
+                home.X,
+                home.Y,
+                home.Z,
+                homeRot.Z.DegToRad());
+            return;
+        }
+
+        Logger.Info($"Return: Need to add information to worldgates.json:\r\n" +
+                    $"        \"Id\": {value1}\r\n" +
+                    $"        \"ZoneId\": {character.Transform.ZoneId},\r\n" +
+                    $"        \"X\": {character.Transform.World.Position.X},\r\n" +
+                    $"        \"Y\": {character.Transform.World.Position.Y},\r\n" +
+                    $"        \"Z\": {character.Transform.World.Position.Z},\r\n" +
+                    $"        \"Yaw\": {character.Transform.World.Rotation.Z},\r\n" +
+                    $"        \"SubZoneId\": {character.SubZoneId}\r\n" +
+                    $"The coordinates need to be set correctly, these are just an example.");
+    }
+
+    private static void ApplyReturn(
+        Character character,
+        uint destWorldId,
+        uint destInstanceId,
+        uint zoneId,
+        float x,
+        float y,
+        float z,
+        float yawRad)
+    {
+        if (ReturnTeleportRules.NeedsInstanceLoad(character.Transform.InstanceId, destInstanceId))
+        {
+            character.DisabledSetPosition = true;
+            character.SendPacket(new SCLoadInstancePacket(destWorldId, zoneId, x, y, z, 0, 0, yawRad));
+            character.Transform = new Transform(character, null, zoneId, destInstanceId, x, y, z, yawRad);
+        }
+        else
+        {
+            character.SetPosition(x, y, z, 0f, 0f, yawRad);
+            character.Transform.FinalizeTransform();
+        }
+
+        character.SendPacket(new SCTeleportUnitPacket(TeleportReason.MoveToLocation, 0, x, y, z, yawRad));
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Plots/Plot.cs
+++ b/AAEmu.Game/Models/Game/Skills/Plots/Plot.cs
@@ -35,10 +35,22 @@ public class Plot
             var incomingHold = SportFishCombat.IsFishingHoldSkill(skill.Template.TargetType, incomingTags);
             var prevHold = prevSkill?.Template != null &&
                            SportFishCombat.IsFishingHoldSkill(prevSkill.Template.TargetType, prevTags);
-            if (SportFishCombat.ShouldCancelPreviousPlot(
+            var incomingCombo = skill.Template != null &&
+                                SkillCastOverlapRules.IsInstantComboHit(
+                                    skill.Template.CastingTime, skill.Template.CustomGcd);
+            var incomingSame = prevSkill != null && prevSkill.Id == skill.Id;
+            var previousIsFollowUp = prevSkill != null &&
+                                     SkillComboRules.IsComboFollowUpOf(
+                                         skill.Id, prevSkill.Id, SkillComboRules.NextFollowUp);
+            if (SkillCastOverlapRules.ShouldCancelPreviousPlot(
                     prev.IsCasting || prev.IsChanneling,
-                    prevHold,
-                    incomingHold))
+                    incomingCombo,
+                    incomingSame,
+                    SportFishCombat.ShouldCancelPreviousPlot(
+                        prev.IsCasting || prev.IsChanneling,
+                        prevHold,
+                        incomingHold),
+                    previousIsFollowUp))
                 prev.RequestCancellation();
         }
 

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -1,4 +1,4 @@
-using System.Numerics;
+﻿using System.Numerics;
 
 using AAEmu.Commons.Utils;
 using AAEmu.Game.Core.Managers;
@@ -1909,7 +1909,7 @@ AlwaysHit:
         if (Template.IgnoreGlobalCooldown)
             return;
 
-        if (!SkillCastOverlapRules.ArmsSharedGlobalCooldown(Template.CastingTime, Template.CustomGcd))
+        if (!SkillCastOverlapRules.ArmsSharedGlobalCooldown(Template.CastingTime, Template.CustomGcd, Template.DefaultGcd))
             return;
 
         // NOTE: default_gcd overriding custom_gcd is deliberate and matches the data — 29054 of the 29669

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -48,6 +48,8 @@ public class Skill
     private bool _bypassGcd;
     /// <summary>ZoneAuthority: avoid double WZSkillStarted (cast-time relays at Use, instant at Cast).</summary>
     private bool _zoneSkillStartedRelayed;
+    /// <summary>Plot-only GCD / cooldown armed at Use so hold-repeat cannot stack a new cast every 150 ms.</summary>
+    private bool _plotOnlyFireCostsApplied;
     private bool _zoneSkillFiredRelayed;
     private bool _zoneSkillEndedRelayed;
     private SkillCaster _zoneSkillCaster;
@@ -178,6 +180,7 @@ public class Skill
         _zoneSkillStartedRelayed = false;
         _zoneSkillFiredRelayed = false;
         _zoneSkillEndedRelayed = false;
+        _plotOnlyFireCostsApplied = false;
         _zoneSkillCaster = null;
         var skillTags = SkillManager.Instance.GetSkillTags(Template.Id);
         var fishingHold = character != null &&
@@ -194,23 +197,24 @@ public class Skill
                 if (Id == 2 || Id == 3 || Id == 4)
                     delay = character != null ? 100 : 1500;
 
-                if (!fishingHold && unit.SkillLastUsed.AddMilliseconds(delay) > DateTime.UtcNow)
+                // Instant combo hits skip the 150 ms anti-spam and must not write SkillLastUsed
+                // (that blocked the next parent press). They still wait for the shared GCD the
+                // first hit armed — the client starts them when that GCD is up.
+                var comboHit = SkillCastOverlapRules.BypassesSharedCastGate(Template.CastingTime, Template.CustomGcd);
+                if (!fishingHold && !comboHit && unit.SkillLastUsed.AddMilliseconds(delay) > DateTime.UtcNow)
                 {
                     Logger.Trace($"Skill: CooldownTime [{delay}]!");
                     return SkillResult.CooldownTime;
                 }
 
-                // Instant combo hits (e.g. Fireball 24894/24895 custom_gcd=10) must not be blocked by
-                // the parent's cast GCD — they fire at the same moment as plot cast-end.
-                var comboBypassGcd = fishingHold ||
-                    (Template.CastingTime <= 0 && Template.CustomGcd > 0 && Template.CustomGcd <= 50);
-                if (unit.GlobalCooldown >= DateTime.UtcNow && !Template.IgnoreGlobalCooldown && !comboBypassGcd)
+                if (unit.GlobalCooldown >= DateTime.UtcNow && !Template.IgnoreGlobalCooldown && !fishingHold)
                 {
                     Logger.Trace($"Skill: GlobalCooldown active for {Template.Id}");
                     return SkillResult.CooldownTime;
                 }
 
-                unit.SkillLastUsed = DateTime.UtcNow;
+                if (!comboHit)
+                    unit.SkillLastUsed = DateTime.UtcNow;
             }
         }
 
@@ -286,8 +290,14 @@ public class Skill
                 // (PlotNode → ApplyPlotOnlyFireCosts). Zone needs WZSkillStarted now (Cast never runs).
                 RelayZoneSkillStartedIfNeeded(casterCaster, targetCaster, skillObject);
                 ConsumeMana(caster);
-                if (Template.CastingTime <= 0)
-                    ApplyPlotOnlyFireCosts(unit);
+                // Arm GCD on press (including 10752's 1000 ms). Waiting until the plot fire-edge
+                // left a 850 ms window where hold-repeat started a new Flamebolt and cancelled
+                // the one that had not Fired yet.
+                ApplyPlotOnlyFireCosts(unit);
+                // Do not send SCSkillStarted here. Plot-only Flamebolt (and the rest of that
+                // family) already drive the cast bar from SCPlotEvent. SkillStarted with a
+                // 1 s RealCastTime locks the whole hotbar, and plot-only never EndSkill's, so
+                // hold-to-repeat dies on the first press.
                 Task.Run(() => Template.Plot.RunAsync(caster, casterCaster, target, targetCaster, skillObject, this));
                 return SkillResult.Success;
             }
@@ -369,8 +379,8 @@ public class Skill
                 {
                     if (specialEffect.Value1 > 0)
                     {
-                        // Worldgates
-                        trp = PortalManager.Instance.GetWorldGatesById((uint)specialEffect.Value1);
+                        var returnId = (uint)specialEffect.Value1;
+                        trp = PortalManager.Instance.GetReturnPoint(returnId);
                     }
                     else
                     {
@@ -1821,10 +1831,11 @@ AlwaysHit:
     /// </summary>
     public void ApplyPlotOnlyFireCosts(Unit unit)
     {
-        if (unit == null || _bypassGcd)
+        if (unit == null || _bypassGcd || _plotOnlyFireCostsApplied)
             return;
         if (!Template.PlotOnly && !ForcePlotGraphOnly)
             return;
+        _plotOnlyFireCostsApplied = true;
         ApplyGlobalCooldown(unit);
         // Skill cooldown is also applied in DoPlotEnd; applying early matches Cast() and blocks re-cast spam.
         if (Template.CooldownTime > 0)
@@ -1898,6 +1909,9 @@ AlwaysHit:
         if (Template.IgnoreGlobalCooldown)
             return;
 
+        if (!SkillCastOverlapRules.ArmsSharedGlobalCooldown(Template.CastingTime, Template.CustomGcd))
+            return;
+
         // NOTE: default_gcd overriding custom_gcd is deliberate and matches the data — 29054 of the 29669
         // skills with default_gcd set carry custom_gcd 0, i.e. "use the server default". The 619 that carry
         // both are ambiguous and are left on the default rather than guessed at.
@@ -1906,7 +1920,9 @@ AlwaysHit:
             gcd = unit is Npc ? 1500 : 1000;
         if (gcd <= 0)
             return;
-        unit.GlobalCooldown = DateTime.UtcNow.AddMilliseconds(gcd * (unit.GlobalCooldownMul / 100));
+        var gcdMul = SkillGcdRules.SharedGcdMultiplier(
+            Template.UseWeaponCooldownTime, unit.GlobalCooldownMul, unit.CastTimeMul);
+        unit.GlobalCooldown = DateTime.UtcNow.AddMilliseconds(gcd * gcdMul);
     }
 
     public void ConsumeMana(BaseUnit caster)

--- a/AAEmu.Game/Models/Game/Skills/SkillCastOverlapRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillCastOverlapRules.cs
@@ -1,0 +1,47 @@
+namespace AAEmu.Game.Models.Game.Skills;
+
+/// <summary>
+/// Hold-to-repeat and plot-only combo hits (Flamebolt 10752 + 24894/24895).
+/// The client starts each hit. Instant follow-ups skip the 150 ms anti-spam
+/// and must not cancel the in-flight plot.
+/// </summary>
+public static class SkillCastOverlapRules
+{
+    /// <summary>
+    /// Instant plot hits with a tiny custom GCD (Flamebolt 24894/24895 are 0 ms / 10 ms).
+    /// </summary>
+    public static bool IsInstantComboHit(int castingTime, int customGcd) =>
+        castingTime <= 0 && customGcd > 0 && customGcd <= 50;
+
+    /// <summary>
+    /// Combo hits skip the shared SkillLastUsed anti-spam. They still honor the
+    /// shared GCD (first hit 1000 ms, follow-ups 10 ms). They must not write
+    /// SkillLastUsed, or the next parent press is blocked.
+    /// </summary>
+    public static bool BypassesSharedCastGate(int castingTime, int customGcd) =>
+        IsInstantComboHit(castingTime, customGcd);
+
+    /// <summary>
+    /// Each hit arms its own custom_gcd. Follow-ups are 10 ms — the reduced
+    /// combo GCD, not a second 1000 ms lock.
+    /// </summary>
+    public static bool ArmsSharedGlobalCooldown(int castingTime, int customGcd) =>
+        customGcd > 0;
+
+    /// <summary>
+    /// A new plot cancels a busy one, except combo hits and a repeat of the same skill
+    /// (hold / GCD next). Those must finish their own Fired/Damaged.
+    /// Fishing hold swap still goes through <paramref name="sportFishWouldCancel"/>.
+    /// </summary>
+    public static bool ShouldCancelPreviousPlot(
+        bool previousWasBusy,
+        bool incomingIsInstantCombo,
+        bool incomingSameSkill,
+        bool sportFishWouldCancel,
+        bool previousIsComboFollowUpOfIncoming = false)
+    {
+        if (incomingIsInstantCombo || incomingSameSkill || previousIsComboFollowUpOfIncoming)
+            return false;
+        return sportFishWouldCancel;
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/SkillCastOverlapRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillCastOverlapRules.cs
@@ -1,4 +1,4 @@
-namespace AAEmu.Game.Models.Game.Skills;
+﻿namespace AAEmu.Game.Models.Game.Skills;
 
 /// <summary>
 /// Hold-to-repeat and plot-only combo hits (Flamebolt 10752 + 24894/24895).
@@ -23,10 +23,12 @@ public static class SkillCastOverlapRules
 
     /// <summary>
     /// Each hit arms its own custom_gcd. Follow-ups are 10 ms — the reduced
-    /// combo GCD, not a second 1000 ms lock.
+    /// combo GCD, not a second 1000 ms lock. A skill that only declares
+    /// <c>default_gcd</c> still arms the server default: 29054 skills carry
+    /// custom_gcd 0 with default_gcd set.
     /// </summary>
-    public static bool ArmsSharedGlobalCooldown(int castingTime, int customGcd) =>
-        customGcd > 0;
+    public static bool ArmsSharedGlobalCooldown(int castingTime, int customGcd, bool defaultGcd) =>
+        customGcd > 0 || defaultGcd;
 
     /// <summary>
     /// A new plot cancels a busy one, except combo hits and a repeat of the same skill

--- a/AAEmu.Game/Models/Game/Skills/SkillComboRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillComboRules.cs
@@ -1,0 +1,69 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models.Game.Skills.Effects;
+using AAEmu.Game.Models.Game.Skills.Templates;
+
+namespace AAEmu.Game.Models.Game.Skills;
+
+/// <summary>
+/// Combo special (type 48) names the next hold-hit. The client starts that skill
+/// when its GCD is up. World does not schedule or delay those hits.
+/// </summary>
+public static class SkillComboRules
+{
+    public const int MaxChainLength = 8;
+
+    public static bool TryGetComboFollowUp(SkillTemplate template, out uint nextSkillId, out int delayMs)
+    {
+        nextSkillId = 0;
+        delayMs = 0;
+        if (template?.Effects == null)
+            return false;
+        foreach (var effect in template.Effects)
+        {
+            if (effect.Template is not SpecialEffect special)
+                continue;
+            if (special.SpecialEffectTypeId != SpecialType.Combo || special.Value1 <= 0)
+                continue;
+            nextSkillId = (uint)special.Value1;
+            delayMs = Math.Max(0, special.Value2);
+            return true;
+        }
+        return false;
+    }
+
+    public static uint? NextFollowUp(uint skillId)
+    {
+        var template = SkillManager.Instance?.GetSkillTemplate(skillId);
+        return TryGetComboFollowUp(template, out var next, out _) ? next : null;
+    }
+
+    public static List<uint> WalkChain(uint firstFollowUp, Func<uint, uint?> nextFollowUp)
+    {
+        var chain = new List<uint>();
+        var id = firstFollowUp;
+        var guard = 0;
+        while (id != 0 && guard++ < MaxChainLength)
+        {
+            chain.Add(id);
+            id = nextFollowUp?.Invoke(id) ?? 0;
+        }
+        return chain;
+    }
+
+    /// <summary>
+    /// True when <paramref name="maybeFollowUp"/> is a later hold-hit of
+    /// <paramref name="rootSkillId"/>. Used so a repeat of the root does not
+    /// cancel an in-flight follow-up plot.
+    /// </summary>
+    public static bool IsComboFollowUpOf(uint rootSkillId, uint maybeFollowUp, Func<uint, uint?> nextFollowUp)
+    {
+        if (rootSkillId == 0 || maybeFollowUp == 0 || rootSkillId == maybeFollowUp)
+            return false;
+        foreach (var id in WalkChain(nextFollowUp?.Invoke(rootSkillId) ?? 0, nextFollowUp))
+        {
+            if (id == maybeFollowUp)
+                return true;
+        }
+        return false;
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/SkillGcdRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillGcdRules.cs
@@ -1,0 +1,16 @@
+namespace AAEmu.Game.Models.Game.Skills;
+
+/// <summary>
+/// Shared GCD length. Weapon swings use attack-speed (<c>GlobalCooldownMul</c>).
+/// Spells use cast speed. Flamebolt is <c>use_weapon_cooldown_time=f</c> — applying
+/// attack speed to its 1000 ms GCD made hold-repeat look like a machine gun.
+/// </summary>
+public static class SkillGcdRules
+{
+    public static float SharedGcdMultiplier(bool useWeaponCooldownTime, float globalCooldownMul, float castTimeMul)
+    {
+        if (useWeaponCooldownTime)
+            return globalCooldownMul / 100f;
+        return castTimeMul;
+    }
+}

--- a/AAEmu.Game/Models/Game/Slaves/SlaveHealthCapRules.cs
+++ b/AAEmu.Game/Models/Game/Slaves/SlaveHealthCapRules.cs
@@ -1,0 +1,18 @@
+namespace AAEmu.Game.Models.Game.Slaves;
+
+/// <summary>
+/// When a hull's MaxHp rises (kit parts, Ezi +10%), a bar that was already
+/// at the old cap stays full. Leaving current HP on the old ceiling makes
+/// the client draw wreck LOD and repair doodads on a fresh summon.
+/// </summary>
+public static class SlaveHealthCapRules
+{
+    public static int AfterMaxHpChanged(int hp, int oldMaxHp, int newMaxHp)
+    {
+        if (newMaxHp <= 0)
+            return Math.Max(hp, 0);
+        if (oldMaxHp > 0 && hp >= oldMaxHp)
+            return newMaxHp;
+        return Math.Min(hp, newMaxHp);
+    }
+}

--- a/AAEmu.Game/Models/Game/Teleport/ReturnPointFileRules.cs
+++ b/AAEmu.Game/Models/Game/Teleport/ReturnPointFileRules.cs
@@ -1,0 +1,99 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace AAEmu.Game.Models.Game.Teleport;
+
+/// <summary>
+/// Level-pack return points live in <c>level_design/zone/{zoneKey}/world_server/return_point.g</c>.
+/// Object names are <c>ReturnPoint_{editor_name}</c>; compact <c>return_points.id</c> is the
+/// SpecialEffect Return value. JSON worldgates/recalls win when they already have that id.
+/// </summary>
+public static partial class ReturnPointFileRules
+{
+    public const string NamePrefix = "ReturnPoint_";
+
+    public readonly record struct LocalPoint(string EditorName, uint ZoneKey, float X, float Y, float Z, float ZRotRadians);
+
+    public static bool ShouldUseLevelFile(bool haveWorldgate, bool haveRecall) =>
+        !haveWorldgate && !haveRecall;
+
+    public static bool TryEditorNameFromObject(string objectName, out string editorName)
+    {
+        editorName = null;
+        if (string.IsNullOrWhiteSpace(objectName))
+            return false;
+
+        var name = objectName.Trim().Trim('"');
+        if (!name.StartsWith(NamePrefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var rest = name[NamePrefix.Length..].Trim();
+        if (rest.Length == 0)
+            return false;
+
+        editorName = rest;
+        return true;
+    }
+
+    public static bool TryGetReturnPointId(IReadOnlyDictionary<string, uint> editorNameToId, string editorName, out uint id)
+    {
+        id = 0;
+        if (editorNameToId == null || string.IsNullOrWhiteSpace(editorName))
+            return false;
+        return editorNameToId.TryGetValue(editorName, out id) && id != 0;
+    }
+
+    public static float YawDegreesFromZRot(float zRotRadians) =>
+        zRotRadians * (180f / MathF.PI);
+
+    public static (float X, float Y, float Z) ToWorld(float originCellX, float originCellY, float localX, float localY, float localZ) =>
+        (originCellX * 1024f + localX, originCellY * 1024f + localY, localZ);
+
+    public static List<LocalPoint> Parse(string text, uint zoneKey)
+    {
+        var list = new List<LocalPoint>();
+        if (string.IsNullOrWhiteSpace(text) || zoneKey == 0)
+            return list;
+
+        foreach (var block in ObjectSplit().Split(text))
+        {
+            if (string.IsNullOrWhiteSpace(block))
+                continue;
+
+            var nameMatch = NameRegex().Match(block);
+            var posMatch = PosRegex().Match(block);
+            if (!nameMatch.Success || !posMatch.Success)
+                continue;
+            if (!TryEditorNameFromObject(nameMatch.Groups[1].Value, out var editorName))
+                continue;
+            if (!TryF(posMatch.Groups[1].Value, out var x) ||
+                !TryF(posMatch.Groups[2].Value, out var y) ||
+                !TryF(posMatch.Groups[3].Value, out var z))
+                continue;
+
+            var zRot = 0f;
+            var rotMatch = ZRotRegex().Match(block);
+            if (rotMatch.Success)
+                TryF(rotMatch.Groups[1].Value, out zRot);
+
+            list.Add(new LocalPoint(editorName, zoneKey, x, y, z, zRot));
+        }
+
+        return list;
+    }
+
+    private static bool TryF(string s, out float v) =>
+        float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out v);
+
+    [GeneratedRegex(@"^\s*object\s*$", RegexOptions.CultureInvariant | RegexOptions.Multiline)]
+    private static partial Regex ObjectSplit();
+
+    [GeneratedRegex(@"name\s+""?([^""\r\n]+)""?", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
+    private static partial Regex NameRegex();
+
+    [GeneratedRegex(@"pos\s*\(\s*x\s+([^,\s]+)\s*,\s*y\s+([^,\s]+)\s*,\s*z\s+([^)\s]+)\s*\)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
+    private static partial Regex PosRegex();
+
+    [GeneratedRegex(@"zRot\s+([^\s]+)", RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)]
+    private static partial Regex ZRotRegex();
+}

--- a/AAEmu.Game/Models/Game/Teleport/ReturnPointGCatalog.cs
+++ b/AAEmu.Game/Models/Game/Teleport/ReturnPointGCatalog.cs
@@ -1,0 +1,59 @@
+using System.Globalization;
+
+using NLog;
+
+namespace AAEmu.Game.Models.Game.Teleport;
+
+/// <summary>
+/// Reads <c>return_point.g</c> under configured ZoneGameDataRoot worlds. No fallback disk path.
+/// </summary>
+public static class ReturnPointGCatalog
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    public static List<ReturnPointFileRules.LocalPoint> LoadFromRoots(IEnumerable<string> roots)
+    {
+        var list = new List<ReturnPointFileRules.LocalPoint>();
+        if (roots == null)
+            return list;
+
+        foreach (var root in roots)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+                continue;
+            var worlds = Path.Combine(root, "worlds");
+            if (!Directory.Exists(worlds))
+                continue;
+
+            foreach (var worldDir in Directory.EnumerateDirectories(worlds))
+            {
+                var zoneRoot = Path.Combine(worldDir, "level_design", "zone");
+                if (!Directory.Exists(zoneRoot))
+                    continue;
+
+                foreach (var zoneDir in Directory.EnumerateDirectories(zoneRoot))
+                {
+                    var folder = Path.GetFileName(zoneDir);
+                    if (!uint.TryParse(folder, NumberStyles.Integer, CultureInfo.InvariantCulture, out var zoneKey) ||
+                        zoneKey == 0)
+                        continue;
+
+                    var path = Path.Combine(zoneDir, "world_server", "return_point.g");
+                    if (!File.Exists(path))
+                        continue;
+
+                    try
+                    {
+                        list.AddRange(ReturnPointFileRules.Parse(File.ReadAllText(path), zoneKey));
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn(ex, "Failed to read return_point.g {0}", path);
+                    }
+                }
+            }
+        }
+
+        return list;
+    }
+}

--- a/AAEmu.Game/Models/Game/Teleport/ReturnTeleportRules.cs
+++ b/AAEmu.Game/Models/Game/Teleport/ReturnTeleportRules.cs
@@ -1,0 +1,26 @@
+namespace AAEmu.Game.Models.Game.Teleport;
+
+/// <summary>
+/// Same-instance return is a seamless <c>SCTeleportUnit</c>. Crossing instances
+/// is the only path that may send <c>SCLoadInstance</c>.
+/// </summary>
+public static class ReturnTeleportRules
+{
+    public static bool NeedsInstanceLoad(uint currentInstanceId, uint destInstanceId) =>
+        currentInstanceId != destInstanceId;
+
+    /// <summary>
+    /// Origin is the unplaced default. Return must never resolve there —
+    /// missing catalog, fallback, or a same-world <c>SCLoadInstance</c>
+    /// that answers <c>CSTeleportEnded</c> at (0,0,0) all plant the unit
+    /// off the map (no character pip).
+    /// </summary>
+    public static bool HasValidDestination(float x, float y, float z) =>
+        x != 0f || y != 0f || z != 0f;
+
+    public static bool ShouldApplyEndedPosition(float x, float y, float z) =>
+        HasValidDestination(x, y, z);
+
+    public static uint LoadWorldId(uint portalWorldId, uint defaultWorldTemplateId) =>
+        portalWorldId != 0 ? portalWorldId : defaultWorldTemplateId;
+}

--- a/AAEmu.Game/Models/Game/Units/Movements/UnitIdleMoveRules.cs
+++ b/AAEmu.Game/Models/Game/Units/Movements/UnitIdleMoveRules.cs
@@ -1,4 +1,4 @@
-namespace AAEmu.Game.Models.Game.Units.Movements;
+﻿namespace AAEmu.Game.Models.Game.Units.Movements;
 
 /// <summary>
 /// Dedicate can emit a stand for every unit every tick. Those must not become
@@ -13,6 +13,9 @@ public static class UnitIdleMoveRules
     /// Callers fail open: any wider delta is handled as real movement.
     /// </summary>
     public const float SamePositionMetres = 0.15f;
+
+    /// <summary>Heading steps in a full circle; also the modulus for facing compares.</summary>
+    public const int HeadingSteps = 128;
 
     public static bool IsStationary(
         short velX, short velY, short velZ,
@@ -34,6 +37,11 @@ public static class UnitIdleMoveRules
         return dx * dx + dy * dy + dz * dz <= max * max;
     }
 
+    /// <summary>
+    /// Headings are packed into <see cref="HeadingSteps"/> steps around the circle
+    /// (<c>MathUtil.ConvertDegreeToSByteDirection</c>), so the distance between two
+    /// steps is circular: 85 and -42 are neighbours and must compare equal.
+    /// </summary>
     public static bool IsSameFacing(
         sbyte knownX, sbyte knownY, sbyte knownZ,
         sbyte moveX, sbyte moveY, sbyte moveZ,
@@ -41,9 +49,9 @@ public static class UnitIdleMoveRules
     {
         if (tolerance < 0)
             tolerance = 0;
-        return AbsDelta(knownX, moveX) <= tolerance
-               && AbsDelta(knownY, moveY) <= tolerance
-               && AbsDelta(knownZ, moveZ) <= tolerance;
+        return CircularDelta(knownX, moveX) <= tolerance
+               && CircularDelta(knownY, moveY) <= tolerance
+               && CircularDelta(knownZ, moveZ) <= tolerance;
     }
 
     public static bool ShouldSuppress(
@@ -61,9 +69,12 @@ public static class UnitIdleMoveRules
         return IsSameFacing(knownRx, knownRy, knownRz, moveRx, moveRy, moveRz);
     }
 
-    private static int AbsDelta(sbyte a, sbyte b)
+    /// <summary>Shortest heading distance around the 128-step circle.</summary>
+    private static int CircularDelta(sbyte a, sbyte b)
     {
-        var d = a - b;
-        return d < 0 ? -d : d;
+        var delta = (a - b) % HeadingSteps;
+        if (delta < 0)
+            delta += HeadingSteps;
+        return delta <= HeadingSteps / 2 ? delta : HeadingSteps - delta;
     }
 }

--- a/AAEmu.Game/Models/Game/Units/Movements/UnitIdleMoveRules.cs
+++ b/AAEmu.Game/Models/Game/Units/Movements/UnitIdleMoveRules.cs
@@ -8,6 +8,10 @@ namespace AAEmu.Game.Models.Game.Units.Movements;
 /// </summary>
 public static class UnitIdleMoveRules
 {
+    /// <summary>
+    /// Tolerance for treating a zone report as a repeat of the known pose.
+    /// Callers fail open: any wider delta is handled as real movement.
+    /// </summary>
     public const float SamePositionMetres = 0.15f;
 
     public static bool IsStationary(

--- a/AAEmu.Game/Models/Game/Units/Movements/UnitIdleMoveRules.cs
+++ b/AAEmu.Game/Models/Game/Units/Movements/UnitIdleMoveRules.cs
@@ -1,0 +1,65 @@
+namespace AAEmu.Game.Models.Game.Units.Movements;
+
+/// <summary>
+/// Dedicate can emit a stand for every unit every tick. Those must not become
+/// SCUnitMovements or rewrite World transforms — the client treats a repeat
+/// stand as a pose reset (flicker), and a sub-metre rewrite can hop a 64 m
+/// region line.
+/// </summary>
+public static class UnitIdleMoveRules
+{
+    public const float SamePositionMetres = 0.15f;
+
+    public static bool IsStationary(
+        short velX, short velY, short velZ,
+        sbyte deltaX, sbyte deltaY, sbyte deltaZ)
+    {
+        return velX == 0 && velY == 0 && velZ == 0
+               && deltaX == 0 && deltaY == 0 && deltaZ == 0;
+    }
+
+    public static bool IsSamePosition(
+        float knownX, float knownY, float knownZ,
+        float moveX, float moveY, float moveZ,
+        float epsilonMetres = SamePositionMetres)
+    {
+        var dx = knownX - moveX;
+        var dy = knownY - moveY;
+        var dz = knownZ - moveZ;
+        var max = epsilonMetres < 0f ? 0f : epsilonMetres;
+        return dx * dx + dy * dy + dz * dz <= max * max;
+    }
+
+    public static bool IsSameFacing(
+        sbyte knownX, sbyte knownY, sbyte knownZ,
+        sbyte moveX, sbyte moveY, sbyte moveZ,
+        int tolerance = 1)
+    {
+        if (tolerance < 0)
+            tolerance = 0;
+        return AbsDelta(knownX, moveX) <= tolerance
+               && AbsDelta(knownY, moveY) <= tolerance
+               && AbsDelta(knownZ, moveZ) <= tolerance;
+    }
+
+    public static bool ShouldSuppress(
+        float knownX, float knownY, float knownZ,
+        sbyte knownRx, sbyte knownRy, sbyte knownRz,
+        float moveX, float moveY, float moveZ,
+        sbyte moveRx, sbyte moveRy, sbyte moveRz,
+        short velX, short velY, short velZ,
+        sbyte deltaX, sbyte deltaY, sbyte deltaZ)
+    {
+        if (!IsStationary(velX, velY, velZ, deltaX, deltaY, deltaZ))
+            return false;
+        if (!IsSamePosition(knownX, knownY, knownZ, moveX, moveY, moveZ))
+            return false;
+        return IsSameFacing(knownRx, knownRy, knownRz, moveRx, moveRy, moveRz);
+    }
+
+    private static int AbsDelta(sbyte a, sbyte b)
+    {
+        var d = a - b;
+        return d < 0 ? -d : d;
+    }
+}

--- a/AAEmu.Game/Models/Game/Units/QuestContextUnitReqRules.cs
+++ b/AAEmu.Game/Models/Game/Units/QuestContextUnitReqRules.cs
@@ -1,0 +1,13 @@
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.Game.Models.Game.Units;
+
+/// <summary>
+/// <c>unit_reqs</c> kind 32 ProgressQuestContext: value1 is <c>quest_contexts.id</c>.
+/// The toast is "quest must be in progress" — journal status, not the internal step.
+/// Some quests keep Use/Hunt acts on <see cref="QuestComponentKind.None"/> (Under Dahuta's Veil).
+/// </summary>
+public static class QuestContextUnitReqRules
+{
+    public static bool IsInProgress(QuestStatus? status) => status == QuestStatus.Progress;
+}

--- a/AAEmu.Game/Models/Game/Units/Slave.cs
+++ b/AAEmu.Game/Models/Game/Units/Slave.cs
@@ -1309,6 +1309,10 @@ public class Slave : Unit
     /// </remarks>
     public void UpdateSlaveGearBonuses()
     {
+        var canReadCaps = FormulaManager.Instance.GetUnitFormula(FormulaOwnerType.Slave, UnitFormulaKind.MaxHealth) != null;
+        var oldMaxHp = canReadCaps ? MaxHp : 0;
+        var oldMaxMp = canReadCaps ? MaxMp : 0;
+
         Bonuses[GearBonusesIndex] = [];
         if (Equipment != null)
         {
@@ -1342,6 +1346,12 @@ public class Slave : Unit
                     AddBonus(GearBonusesIndex, new Bonus { Template = template, Value = template.Value });
                 }
             }
+        }
+
+        if (canReadCaps)
+        {
+            Hp = SlaveHealthCapRules.AfterMaxHpChanged(Hp, oldMaxHp, MaxHp);
+            Mp = SlaveHealthCapRules.AfterMaxHpChanged(Mp, oldMaxMp, MaxMp);
         }
 
         LogKitAddedMassIfChanged();

--- a/AAEmu.Game/Models/Game/Units/Unit.cs
+++ b/AAEmu.Game/Models/Game/Units/Unit.cs
@@ -790,8 +790,16 @@ public class Unit : BaseUnit, IUnit
             return;
         }
 
-        // Generate the loot for this Npc
-        LootingContainer.GenerateLoot(killer);
+        // Loot must not abort death. A missing loot-group key used to throw here and
+        // skip Zone corpse (WZUnitDeath) while World HP was already 0.
+        try
+        {
+            LootingContainer.GenerateLoot(killer);
+        }
+        catch (Exception ex)
+        {
+            Logger.Error(ex, "Loot generation failed for unit={0}, death continues", ObjId);
+        }
 
         // Cleanup targeting and aggro packets
         if (CurrentTarget != null)

--- a/AAEmu.Game/Models/Game/Units/UnitReqTargetNpcGroupRules.cs
+++ b/AAEmu.Game/Models/Game/Units/UnitReqTargetNpcGroupRules.cs
@@ -1,0 +1,17 @@
+namespace AAEmu.Game.Models.Game.Units;
+
+/// <summary>
+/// <c>unit_reqs</c> kind TargetNpcGroup: <c>value1</c> is the group id.
+/// <c>value2 == 0</c> requires membership; any other <c>value2</c> inverts
+/// (the target must not be in that group). A non-NPC target never passes.
+/// </summary>
+public static class UnitReqTargetNpcGroupRules
+{
+    public static bool Passes(bool isNpcTarget, bool inGroup, uint value2)
+    {
+        if (!isNpcTarget)
+            return false;
+
+        return value2 == 0 ? inGroup : !inGroup;
+    }
+}

--- a/AAEmu.Game/Models/Game/Units/UnitReqs.cs
+++ b/AAEmu.Game/Models/Game/Units/UnitReqs.cs
@@ -270,16 +270,19 @@ public class UnitReqs
 
             case UnitReqsKindType.ProgressQuestContext:
                 return RetWithValue(SkillResultKeys.skill_urk_progress_quest_context, Value1,
-                    player?.Quests.ActiveQuests.GetValueOrDefault(Value1)?.Step == QuestComponentKind.Progress);
+                    QuestContextUnitReqRules.IsInProgress(
+                        player?.Quests.ActiveQuests.GetValueOrDefault(Value1)?.Status));
 
             case UnitReqsKindType.ReadyQuestContext:
                 return RetWithValue(SkillResultKeys.skill_urk_ready_quest_context, Value1,
                     player?.Quests.ActiveQuests.GetValueOrDefault(Value1)?.Step == QuestComponentKind.Ready);
 
             case UnitReqsKindType.TargetNpcGroup:
+                var groupTarget = targetUnit as Npc;
+                var inNpcGroup = groupTarget != null &&
+                    QuestManager.Instance.CheckGroupNpc(Value1, groupTarget.TemplateId);
                 return RetWithValue(SkillResultKeys.skill_urk_target_npc_group, Value1,
-                    targetUnit is Npc groupTarget &&
-                    QuestManager.Instance.CheckGroupNpc(Value1, groupTarget.TemplateId));
+                    UnitReqTargetNpcGroupRules.Passes(groupTarget != null, inNpcGroup, Value2));
 
             case UnitReqsKindType.AreaSphere:
                 // Check Sphere for Quest

--- a/AAEmu.Game/Models/Game/Units/ZoneDeadUnitRules.cs
+++ b/AAEmu.Game/Models/Game/Units/ZoneDeadUnitRules.cs
@@ -1,0 +1,10 @@
+namespace AAEmu.Game.Models.Game.Units;
+
+/// <summary>
+/// Zone can keep simulating a unit after World HP is already 0. World must not
+/// start a new skill for that caster.
+/// </summary>
+public static class ZoneDeadUnitRules
+{
+    public static bool AcceptsZoneSkill(int hp) => hp > 0;
+}

--- a/AAEmu.Game/Models/Game/World/AreaSphereHitRules.cs
+++ b/AAEmu.Game/Models/Game/World/AreaSphereHitRules.cs
@@ -1,0 +1,47 @@
+using System.Numerics;
+
+namespace AAEmu.Game.Models.Game.World;
+
+/// <summary>
+/// Skill AreaSphere (kind 35) value1 is compact <c>spheres.id</c>, the same id as
+/// <c>quest_area_sphere.g</c> <c>stype</c>. Sign-sphere rows are keyed by a different
+/// quest id and must not be the only geometry used for that check.
+/// </summary>
+public static class AreaSphereHitRules
+{
+    public static SphereQuest FindHit(
+        uint requiredSphereId,
+        Vector3 worldPosition,
+        uint requiredComponentId,
+        IEnumerable<SphereQuest> areaSpheresAtPosition,
+        IEnumerable<SphereQuest> signSpheresForLinkedQuest)
+    {
+        if (requiredSphereId == 0)
+            return null;
+
+        if (areaSpheresAtPosition != null)
+        {
+            foreach (var area in areaSpheresAtPosition)
+            {
+                if (area == null || area.SphereId != requiredSphereId)
+                    continue;
+                if (area.Contains(worldPosition))
+                    return area;
+            }
+        }
+
+        if (signSpheresForLinkedQuest == null)
+            return null;
+
+        foreach (var sign in signSpheresForLinkedQuest)
+        {
+            if (sign == null || !sign.Contains(worldPosition))
+                continue;
+            if (requiredComponentId != 0 && sign.ComponentId != requiredComponentId)
+                continue;
+            return sign;
+        }
+
+        return null;
+    }
+}

--- a/AAEmu.Game/Models/Game/World/VisibleObjectResendRules.cs
+++ b/AAEmu.Game/Models/Game/World/VisibleObjectResendRules.cs
@@ -1,0 +1,19 @@
+namespace AAEmu.Game.Models.Game.World;
+
+/// <summary>
+/// Cinema can drop units the server still marks streamed. Teleport / login
+/// already painted from region enter — a second UnitState without a remove
+/// is a duplicate id on the client.
+/// </summary>
+public static class VisibleObjectResendRules
+{
+    public static bool ShouldRepaintMirror(bool alreadyStreamed, bool clientDroppedVisibility)
+    {
+        if (clientDroppedVisibility)
+            return true;
+        return !alreadyStreamed;
+    }
+
+    public static bool ShouldResendDoodadCreates(bool clientDroppedVisibility) =>
+        clientDroppedVisibility;
+}

--- a/AAEmu.Game/Models/Game/World/WorldLevelInfoRules.cs
+++ b/AAEmu.Game/Models/Game/World/WorldLevelInfoRules.cs
@@ -1,0 +1,126 @@
+namespace AAEmu.Game.Models.Game.World;
+
+/// <summary>
+/// <c>SCWorldLevelInfo</c> body. Field names match the client reader.
+/// </summary>
+public readonly record struct WorldLevelInfoWire(
+    uint WorldLevel,
+    uint ServerDays,
+    uint ExpModifier,
+    uint HardCapLevel,
+    uint CharacterLevel,
+    int LevelDiff);
+
+public readonly record struct WorldLevelHardCapRow(
+    int MinServerDays,
+    int MaxServerDays,
+    int HardCapLevel,
+    bool GetQuest);
+
+public readonly record struct WorldLevelExpModifierRow(
+    int LevelDiffMin,
+    int LevelDiffMax,
+    uint ExpModifier);
+
+/// <summary>
+/// World-level HUD body and the server-open stamp the client uses for
+/// <c>world_level_hard_caps</c>. Main-quest Accept hides when the selected
+/// hard-cap row has <c>get_quest</c> false and the character is at or over
+/// <c>hard_cap_level</c>. That row is chosen from calendar days since
+/// <c>SCServerInfo.serverOpenTime</c>, not from <c>SCWorldLevelInfo</c>.
+/// Sending "now" as the open time selects the first band. A zero stamp does
+/// not clear a stamp the client already cached.
+/// </summary>
+public static class WorldLevelInfoRules
+{
+    /// <summary>
+    /// Extra whole days on top of the unlock row's <c>min_server_days</c>.
+    /// The client diffs local calendar dates, not unix/86400, so a stamp
+    /// exactly N days back can still land on N-1.
+    /// </summary>
+    public const int LocalCalendarSlackDays = 1;
+
+    public const int SecondsPerDay = 86400;
+
+    public static WorldLevelInfoWire ForCharacter(
+        int characterLevel,
+        int playerLevelCap,
+        IReadOnlyList<WorldLevelHardCapRow> hardCaps,
+        IReadOnlyList<WorldLevelExpModifierRow> modifiers)
+    {
+        if (hardCaps == null || hardCaps.Count == 0)
+            throw new InvalidOperationException("world_level_hard_caps has no rows.");
+        if (modifiers == null || modifiers.Count == 0)
+            throw new InvalidOperationException("world_level_exp_modifiers has no rows.");
+        if (playerLevelCap <= 0)
+            throw new ArgumentOutOfRangeException(nameof(playerLevelCap));
+
+        var level = Math.Clamp(characterLevel, 1, playerLevelCap);
+        var unlock = SelectUnlockRow(hardCaps, playerLevelCap);
+        var worldLevel = (uint)unlock.HardCapLevel;
+        var levelDiff = level - unlock.HardCapLevel;
+        var exp = SelectExpModifier(modifiers, levelDiff);
+
+        return new WorldLevelInfoWire(
+            WorldLevel: worldLevel,
+            ServerDays: (uint)unlock.MinServerDays,
+            ExpModifier: exp,
+            HardCapLevel: (uint)unlock.HardCapLevel,
+            CharacterLevel: (uint)level,
+            LevelDiff: levelDiff);
+    }
+
+    public static WorldLevelHardCapRow SelectUnlockRow(
+        IReadOnlyList<WorldLevelHardCapRow> hardCaps,
+        int playerLevelCap)
+    {
+        if (hardCaps == null || hardCaps.Count == 0)
+            throw new InvalidOperationException("world_level_hard_caps has no rows.");
+        if (playerLevelCap <= 0)
+            throw new ArgumentOutOfRangeException(nameof(playerLevelCap));
+
+        WorldLevelHardCapRow? best = null;
+        foreach (var row in hardCaps)
+        {
+            if (!row.GetQuest || row.HardCapLevel < playerLevelCap)
+                continue;
+            if (best == null || row.MinServerDays < best.Value.MinServerDays)
+                best = row;
+        }
+
+        if (best != null)
+            return best.Value;
+
+        throw new InvalidOperationException(
+            $"world_level_hard_caps has no get_quest row with hard_cap_level >= {playerLevelCap}.");
+    }
+
+    /// <summary>
+    /// Unix seconds for <c>SCServerInfo</c>. Must be non-zero so the client
+    /// replaces any cached stamp. Age is the compact unlock row plus
+    /// <see cref="LocalCalendarSlackDays"/>.
+    /// </summary>
+    public static long ServerOpenUnixTime(long nowUnixSeconds, int unlockMinServerDays)
+    {
+        if (nowUnixSeconds <= 0)
+            throw new ArgumentOutOfRangeException(nameof(nowUnixSeconds));
+        if (unlockMinServerDays < 0)
+            throw new ArgumentOutOfRangeException(nameof(unlockMinServerDays));
+
+        var ageSeconds = (long)(unlockMinServerDays + LocalCalendarSlackDays) * SecondsPerDay;
+        var open = nowUnixSeconds - ageSeconds;
+        return open > 0 ? open : 1;
+    }
+
+    internal static uint SelectExpModifier(IReadOnlyList<WorldLevelExpModifierRow> modifiers, int levelDiff)
+    {
+        foreach (var row in modifiers)
+        {
+            if (levelDiff >= row.LevelDiffMin && levelDiff <= row.LevelDiffMax)
+                return row.ExpModifier;
+        }
+
+        throw new InvalidOperationException(
+            $"world_level_exp_modifiers has no band for levelDiff={levelDiff}.");
+    }
+}

--- a/AAEmu.Game/Models/StaticValues/SkillsEnum.cs
+++ b/AAEmu.Game/Models/StaticValues/SkillsEnum.cs
@@ -3,6 +3,7 @@
 public static class SkillsEnum
 {
     // Skills used by NPCs when talking to them, names taken from the english localization
+    public const uint NpcTalk = 13877; // 대화하기 — first skill on a quest NPC
     public const uint UseWarehouse = 13238;
     public const uint ChangeSkillsets = 12082;
     public const uint UseAuctioneer = 12083;

--- a/AAEmu.Game/Scripts/Commands/QuestCmd.cs
+++ b/AAEmu.Game/Scripts/Commands/QuestCmd.cs
@@ -17,7 +17,7 @@ public class QuestCmd : ICommand
 
     public string GetCommandLineHelp()
     {
-        return "<list||template||add||remove||step||prog||uncomplete||resetdaily||progress||objective>";
+        return "<list||template||add||remove||complete||step||prog||uncomplete||resetdaily||progress||objective>";
     }
 
     public string GetCommandHelpText()

--- a/AAEmu.Game/Utils/QuestCommandUtil.cs
+++ b/AAEmu.Game/Utils/QuestCommandUtil.cs
@@ -4,6 +4,7 @@ using AAEmu.Game.Models.Game;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Chat;
 using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.Game.Quests;
 using AAEmu.Game.Models.Game.Quests.Static;
 using AAEmu.Game.Utils.Scripts;
 using Discord;
@@ -145,6 +146,35 @@ public class QuestCommandUtil
                 else
                 {
                     character.SendMessage("[Quest] Proper usage: /quest remove <questId>");
+                }
+                break;
+            case "complete":
+                // Stamp a finished quest on the client without replaying it.
+                // Needed when Reward ran (bitset in MySQL) but SCCompletedQuests
+                // never went out, so directing still offers the previous step.
+                if (args.Length >= 2 && uint.TryParse(args[1], out questId))
+                {
+                    var template = QuestManager.Instance.GetTemplate(questId);
+                    if (template == null)
+                    {
+                        CommandManager.SendErrorText(command, messageOutput, $"No quest {questId}");
+                        break;
+                    }
+
+                    if (character.Quests.HasQuest(questId))
+                        character.Quests.DropQuest(questId, true, false);
+
+                    var completedBlock = character.Quests.SetCompletedQuestFlag(questId, true);
+                    character.Quests.SendCompletedBlock(completedBlock);
+                    var completedComponentId = QuestCompletedWire.ComponentIdForCompletedPacket(0, template);
+                    character.SendPacket(new SCQuestContextCompletedPacket(questId, completedComponentId));
+                    character.Quests.Send();
+                    CommandManager.SendNormalText(command, messageOutput,
+                        $"Quest @QUEST_NAME({questId}) ({questId}) marked complete. Char-select if the journal still shows it.");
+                }
+                else
+                {
+                    CommandManager.SendErrorText(command, messageOutput, "Proper usage: /quest complete <questId>");
                 }
                 break;
             case "uncomplete":

--- a/AAEmu.Game/WorldIntegration.cs
+++ b/AAEmu.Game/WorldIntegration.cs
@@ -1318,10 +1318,23 @@ public static class WorldIntegration
                 return false;
             }
 
-            // Idempotent remirror (same bc). Multi-zone MUST NOT share bcIds — UnitRegistry
-            // allocates process-wide; a hit here is the same NPC re-announced, not a sibling zone.
-            if (world.GetNpc(bcId) != null || world.GetBaseUnit(bcId) != null)
-                return true;
+            // Same-zone re-announce is idempotent. A recycled id that still names another
+            // zone's unit (or a World-authored unit) must not steal that slot.
+            var existing = FindUnitAcrossWorlds(bcId);
+            if (existing != null)
+            {
+                var existingZoneId = existing.Transform?.ZoneId ?? 0;
+                var existingInstanceId = existing.Transform?.InstanceId ?? uint.MaxValue;
+                var isMirror = existing is Npc { IsZoneMirror: true };
+                if (ZoneMirrorIdRules.IsIdempotentRemirror(
+                        existingZoneId, existingInstanceId, isMirror, zoneId, instanceId))
+                    return true;
+
+                Logger.Warn(
+                    "MirrorZoneNpcSpawn: bc={0} already owned zone={1} instance={2} incoming zone={3} instance={4} tpl={5}",
+                    bcId, existingZoneId, existingInstanceId, zoneId, instanceId, templateId);
+                return false;
+            }
 
             var npc = NpcManager.Instance.Create(world, bcId, templateId);
             if (npc == null)

--- a/AAEmu.UnitTests/Game/Core/Packets/G2C/SCCompletedQuestsPacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/G2C/SCCompletedQuestsPacketTests.cs
@@ -1,0 +1,63 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Quests;
+
+namespace AAEmu.UnitTests.Game.Core.Packets.G2C;
+
+public class SCCompletedQuestsPacketTests
+{
+    [Test]
+    public async Task FieldOfHonor_IsBlock37Bit17()
+    {
+        const uint questId = 2385;
+        var block = new CompletedQuest((ushort)(questId / 64));
+        block.Body.Set((int)(questId % 64), true);
+
+        var bytes = new SCCompletedQuestsPacket([block]).Write(new PacketStream()).GetBytes();
+        var expected = new PacketStream();
+        expected.Write(1);
+        expected.Write((uint)block.Id);
+        var body = new byte[8];
+        block.Body.CopyTo(body, 0);
+        expected.Write(body);
+
+        await Assert.That(block.Id).IsEqualTo((ushort)37);
+        await Assert.That(block.Body.Get(17)).IsTrue();
+        await Assert.That(BitConverter.ToUInt64(body, 0) & (1UL << 17)).IsEqualTo(1UL << 17);
+        await Assert.That(bytes).IsEquivalentTo(expected.GetBytes());
+        await Assert.That(SCOffsets.SCCompletedQuestsPacket).IsEqualTo((ushort)0x133);
+    }
+
+    [Test]
+    public async Task EmptyList_WritesCountZero()
+    {
+        var bytes = new SCCompletedQuestsPacket([]).Write(new PacketStream()).GetBytes();
+        var expected = new PacketStream();
+        expected.Write(0);
+
+        await Assert.That(bytes).IsEquivalentTo(expected.GetBytes());
+    }
+
+    [Test]
+    public async Task DirtyBlock_CarriesTournamentCompleteBits()
+    {
+        // Same 64-bit block as login SendCompleted; turn-in should push this delta.
+        const uint q2385 = 2385;
+        const uint q2388 = 2388;
+        var block = new CompletedQuest((ushort)(q2385 / 64));
+        block.Body.Set((int)(q2385 % 64), true);
+        block.Body.Set((int)(q2388 % 64), true);
+
+        var bytes = new SCCompletedQuestsPacket([block]).Write(new PacketStream()).GetBytes();
+        var expected = new PacketStream();
+        expected.Write(1);
+        expected.Write((uint)block.Id);
+        var body = new byte[8];
+        block.Body.CopyTo(body, 0);
+        expected.Write(body);
+
+        await Assert.That(block.Id).IsEqualTo((ushort)37);
+        await Assert.That(block.Body.Get((int)(q2388 % 64))).IsTrue();
+        await Assert.That(bytes).IsEquivalentTo(expected.GetBytes());
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Packets/G2C/SCDoodadQuestPacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/G2C/SCDoodadQuestPacketTests.cs
@@ -1,0 +1,25 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Packets.G2C;
+
+namespace AAEmu.UnitTests.Game.Core.Packets.G2C;
+
+public class SCDoodadQuestPacketTests
+{
+    [Test]
+    public async Task AcceptAndComplete_ShareBcThenQuestId()
+    {
+        var accept = new SCDoodadQuestAcceptPacket(189512, 2388).Write(new PacketStream()).GetBytes();
+        var complete = new SCDoodadCompleteQuestPacket(189512, 2387).Write(new PacketStream()).GetBytes();
+        var expectedAccept = new PacketStream();
+        expectedAccept.WriteBc(189512);
+        expectedAccept.Write(2388u);
+        var expectedComplete = new PacketStream();
+        expectedComplete.WriteBc(189512);
+        expectedComplete.Write(2387u);
+
+        await Assert.That(accept).IsEquivalentTo(expectedAccept.GetBytes());
+        await Assert.That(complete).IsEquivalentTo(expectedComplete.GetBytes());
+        await Assert.That(SCOffsets.SCDoodadQuestAcceptPacket).IsEqualTo((ushort)0x153);
+        await Assert.That(SCOffsets.SCDoodadCompleteQuestPacket).IsEqualTo((ushort)0x193);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Packets/G2C/SCQuestContextCompletedPacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/G2C/SCQuestContextCompletedPacketTests.cs
@@ -1,0 +1,17 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Packets.G2C;
+
+namespace AAEmu.UnitTests.Game.Core.Packets.G2C;
+
+public class SCQuestContextCompletedPacketTests
+{
+    [Test]
+    public async Task Body_IsQuestThenComponent()
+    {
+        var body = new SCQuestContextCompletedPacket(2385, 10255).Write(new PacketStream()).GetBytes();
+
+        await Assert.That(body.Length).IsEqualTo(8);
+        await Assert.That(BitConverter.ToInt32(body, 0)).IsEqualTo(2385);
+        await Assert.That(BitConverter.ToInt32(body, 4)).IsEqualTo(10255);
+    }
+}

--- a/AAEmu.UnitTests/Game/Core/Packets/G2C/SCWorldLevelInfoPacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/G2C/SCWorldLevelInfoPacketTests.cs
@@ -1,0 +1,50 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.World;
+
+namespace AAEmu.UnitTests.Game.Core.Packets.G2C;
+
+public class SCWorldLevelInfoPacketTests
+{
+    [Test]
+    public async Task Write_IsSixNamedU32s()
+    {
+        var info = new WorldLevelInfoWire(55, 9, 10000, 55, 55, 0);
+        var body = new SCWorldLevelInfoPacket(info).Write(new PacketStream()).GetBytes();
+
+        await Assert.That(body.Length).IsEqualTo(24);
+        await Assert.That(BitConverter.ToUInt32(body, 0)).IsEqualTo(55u);
+        await Assert.That(BitConverter.ToUInt32(body, 4)).IsEqualTo(9u);
+        await Assert.That(BitConverter.ToUInt32(body, 8)).IsEqualTo(10000u);
+        await Assert.That(BitConverter.ToUInt32(body, 12)).IsEqualTo(55u);
+        await Assert.That(BitConverter.ToUInt32(body, 16)).IsEqualTo(55u);
+        await Assert.That(BitConverter.ToInt32(body, 20)).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Write_DoesNotReuseTheMispackedCapture()
+    {
+        var info = WorldLevelInfoRules.ForCharacter(
+            55,
+            55,
+            [new WorldLevelHardCapRow(9, 9999, 55, true)],
+            [new WorldLevelExpModifierRow(-1, 1, 10000)]);
+        var body = new SCWorldLevelInfoPacket(info).Write(new PacketStream()).GetBytes();
+
+        await Assert.That(BitConverter.ToUInt32(body, 0)).IsNotEqualTo(42u);
+        await Assert.That(BitConverter.ToUInt32(body, 4)).IsNotEqualTo(6u);
+    }
+}
+
+public class SCServerInfoPacketTests
+{
+    [Test]
+    public async Task Write_IsUnixSecondsU64()
+    {
+        const long open = 1_777_136_000;
+        var body = new SCServerInfoPacket(open).Write(new PacketStream()).GetBytes();
+
+        await Assert.That(body.Length).IsEqualTo(8);
+        await Assert.That(BitConverter.ToInt64(body, 0)).IsEqualTo(open);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Char/CharacterCinemaEndFlushTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Char/CharacterCinemaEndFlushTests.cs
@@ -68,7 +68,7 @@ public class CharacterCinemaEndFlushTests
     }
 
     [Test]
-    public async Task Restore_AppliesTheSavedEntryForACompletedQuest()
+    public async Task Restore_QueuesTheEntryUntilWorldEntry()
     {
         var quests = NewQuests();
         quests.SetCompletedQuestFlag(QuestId, true);
@@ -76,6 +76,11 @@ public class CharacterCinemaEndFlushTests
         quests.RestorePendingCinemaEndEffects(
             new[] { (QuestId, CinemaId, ComponentId) },
             _ => BuildComponent());
+
+        // Queued, not applied: the buff packet needs the live connection world entry brings.
+        await Assert.That(quests.DeferredCinemaIds()).Count().IsEqualTo(1);
+
+        quests.FlushPendingCinemaEndEffects();
 
         await Assert.That(quests.DeferredCinemaIds()).IsEmpty();
     }

--- a/AAEmu.UnitTests/Game/Models/Game/Char/CharacterCinemaEndFlushTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Char/CharacterCinemaEndFlushTests.cs
@@ -1,0 +1,67 @@
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Templates;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Char;
+
+/// <summary>
+/// Leave-world flush of the deferred cinema-end effects. The client never reports
+/// the cinema end once the session is gone, and the quest step is already saved, so
+/// the pending entry must be applied rather than dropped with the in-memory list.
+/// </summary>
+public class CharacterCinemaEndFlushTests
+{
+    private const uint QuestId = 5804;
+    private const uint CinemaId = 228;
+
+    private static CharacterQuests WithPendingCinema()
+    {
+        var character = new Character(new UnitCustomModelParams());
+        var quests = new CharacterQuests(character);
+        var component = new QuestComponentTemplate(new QuestTemplate { Id = QuestId })
+        {
+            Id = 25087,
+            CinemaId = CinemaId,
+            // Zero buff/skill keeps the apply path a no-op; this test is about the entry.
+            BuffId = 0,
+            SkillId = 0
+        };
+
+        quests.EnqueueCinemaEndEffects(CinemaId, component);
+        return quests;
+    }
+
+    [Test]
+    public async Task Flush_WithoutPendingEffects_IsANoOp()
+    {
+        var character = new Character(new UnitCustomModelParams());
+        var quests = new CharacterQuests(character);
+
+        quests.FlushPendingCinemaEndEffects();
+
+        await Assert.That(quests.DeferredCinemaIds()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Flush_ConsumesTheEntryForACompletedQuest()
+    {
+        var quests = WithPendingCinema();
+        await Assert.That(quests.DeferredCinemaIds()).Count().IsEqualTo(1);
+
+        quests.SetCompletedQuestFlag(QuestId, true);
+        quests.FlushPendingCinemaEndEffects();
+
+        await Assert.That(quests.DeferredCinemaIds()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Flush_DropsTheEntryForAnAbandonedQuest()
+    {
+        var quests = WithPendingCinema();
+
+        quests.FlushPendingCinemaEndEffects();
+
+        await Assert.That(quests.DeferredCinemaIds()).IsEmpty();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Char/CharacterCinemaEndFlushTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Char/CharacterCinemaEndFlushTests.cs
@@ -6,37 +6,39 @@ using AAEmu.Game.Models.Game.Units;
 namespace AAEmu.UnitTests.Game.Models.Game.Char;
 
 /// <summary>
-/// Leave-world flush of the deferred cinema-end effects. The client never reports
-/// the cinema end once the session is gone, and the quest step is already saved, so
-/// the pending entry must be applied rather than dropped with the in-memory list.
+/// Deferred cinema-end effects. The client never reports the film ending once a session is
+/// gone, so a graceful leave applies them and a dropped connection restores them on login.
 /// </summary>
 public class CharacterCinemaEndFlushTests
 {
     private const uint QuestId = 5804;
     private const uint CinemaId = 228;
+    private const uint ComponentId = 25087;
 
-    private static CharacterQuests WithPendingCinema()
-    {
-        var character = new Character(new UnitCustomModelParams());
-        var quests = new CharacterQuests(character);
-        var component = new QuestComponentTemplate(new QuestTemplate { Id = QuestId })
+    private static QuestComponentTemplate BuildComponent() =>
+        new(new QuestTemplate { Id = QuestId })
         {
-            Id = 25087,
+            Id = ComponentId,
             CinemaId = CinemaId,
-            // Zero buff/skill keeps the apply path a no-op; this test is about the entry.
+            // Zero buff/skill keeps the apply path a no-op; these tests are about the entry.
             BuffId = 0,
             SkillId = 0
         };
 
-        quests.EnqueueCinemaEndEffects(CinemaId, component);
+    private static CharacterQuests NewQuests() =>
+        new(new Character(new UnitCustomModelParams()));
+
+    private static CharacterQuests WithPendingCinema()
+    {
+        var quests = NewQuests();
+        quests.EnqueueCinemaEndEffects(CinemaId, BuildComponent());
         return quests;
     }
 
     [Test]
     public async Task Flush_WithoutPendingEffects_IsANoOp()
     {
-        var character = new Character(new UnitCustomModelParams());
-        var quests = new CharacterQuests(character);
+        var quests = NewQuests();
 
         quests.FlushPendingCinemaEndEffects();
 
@@ -61,6 +63,41 @@ public class CharacterCinemaEndFlushTests
         var quests = WithPendingCinema();
 
         quests.FlushPendingCinemaEndEffects();
+
+        await Assert.That(quests.DeferredCinemaIds()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Restore_AppliesTheSavedEntryForACompletedQuest()
+    {
+        var quests = NewQuests();
+        quests.SetCompletedQuestFlag(QuestId, true);
+
+        quests.RestorePendingCinemaEndEffects(
+            new[] { (QuestId, CinemaId, ComponentId) },
+            _ => BuildComponent());
+
+        await Assert.That(quests.DeferredCinemaIds()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Restore_WithNoRows_IsANoOp()
+    {
+        var quests = NewQuests();
+
+        quests.RestorePendingCinemaEndEffects([], _ => BuildComponent());
+
+        await Assert.That(quests.DeferredCinemaIds()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Restore_DropsARowWhoseComponentIsGone()
+    {
+        var quests = NewQuests();
+
+        quests.RestorePendingCinemaEndEffects(
+            new[] { (QuestId, CinemaId, 999_999u) },
+            _ => null);
 
         await Assert.That(quests.DeferredCinemaIds()).IsEmpty();
     }

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadPhaseApplyTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadPhaseApplyTests.cs
@@ -1,0 +1,27 @@
+using AAEmu.Game.Models.Game.DoodadObj;
+
+namespace AAEmu.UnitTests.Game.Models.Game.DoodadObj;
+
+public class DoodadPhaseApplyTests
+{
+    [Test]
+    public async Task StayOnPhase_DoesNotRebroadcast()
+    {
+        await Assert.That(Doodad.ShouldApplyPhaseAfterSuccessfulFunc(
+            completesFromClientPacket: false, toNextPhase: false)).IsFalse();
+    }
+
+    [Test]
+    public async Task AdvancedPhase_StillApplies()
+    {
+        await Assert.That(Doodad.ShouldApplyPhaseAfterSuccessfulFunc(
+            completesFromClientPacket: false, toNextPhase: true)).IsTrue();
+    }
+
+    [Test]
+    public async Task ClientCompletedFunc_Waits()
+    {
+        await Assert.That(Doodad.ShouldApplyPhaseAfterSuccessfulFunc(
+            completesFromClientPacket: true, toNextPhase: true)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestFuncRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestFuncRulesTests.cs
@@ -89,6 +89,15 @@ public class DoodadQuestFuncRulesTests
     }
 
     [Test]
+    public async Task Interaction_CreditIsTiedToThatCaster()
+    {
+        await Assert.That(DoodadQuestFuncRules.ShouldCountInteractionForCaster(10, 10, true)).IsTrue();
+        await Assert.That(DoodadQuestFuncRules.ShouldCountInteractionForCaster(10, 11, true)).IsFalse();
+        await Assert.That(DoodadQuestFuncRules.ShouldCountInteractionForCaster(10, 10, false)).IsFalse();
+        await Assert.That(DoodadQuestFuncRules.ShouldCountInteractionForCaster(0, 0, true)).IsFalse();
+    }
+
+    [Test]
     public async Task NothingStartable_ReturnsDefault()
     {
         var picked = Pick(has: [], done: [2387, 2388, 2396, 2401]);

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestFuncRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestFuncRulesTests.cs
@@ -1,0 +1,90 @@
+using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.UnitTests.Game.Models.Game.DoodadObj;
+
+public class DoodadQuestFuncRulesTests
+{
+    private readonly record struct Row(uint Kind, uint QuestId);
+
+    // 14178 phase: report 2387, accept/report 2388, accept/report 2396, accept 2401
+    private static readonly Row[] Deltokin =
+    [
+        new(DoodadQuestFuncRules.ReportKind, 2387),
+        new(DoodadQuestFuncRules.AcceptKind, 2388),
+        new(DoodadQuestFuncRules.ReportKind, 2388),
+        new(DoodadQuestFuncRules.AcceptKind, 2396),
+        new(DoodadQuestFuncRules.ReportKind, 2396),
+        new(DoodadQuestFuncRules.AcceptKind, 2401)
+    ];
+
+    [Test]
+    public async Task AfterReportComplete_PicksNextAccept()
+    {
+        var picked = Pick(has: [], done: [2387]);
+
+        await Assert.That(picked.Kind).IsEqualTo(DoodadQuestFuncRules.AcceptKind);
+        await Assert.That(picked.QuestId).IsEqualTo(2388u);
+    }
+
+    [Test]
+    public async Task InProgressReport_BeatsLaterAccept()
+    {
+        var picked = Pick(has: [2387], done: []);
+
+        await Assert.That(picked.Kind).IsEqualTo(DoodadQuestFuncRules.ReportKind);
+        await Assert.That(picked.QuestId).IsEqualTo(2387u);
+    }
+
+    [Test]
+    public async Task CompletedAcceptRow_IsNotOfferedAgain()
+    {
+        await Assert.That(DoodadQuestFuncRules.ShouldOfferAccept(
+            DoodadQuestFuncRules.AcceptKind, hasQuest: false, completed: true, repeatable: false)).IsFalse();
+        await Assert.That(DoodadQuestFuncRules.ShouldOfferAccept(
+            DoodadQuestFuncRules.ReportKind, hasQuest: false, completed: true, repeatable: false)).IsFalse();
+    }
+
+    [Test]
+    public async Task CanStartFalse_SkipsThatAccept()
+    {
+        var picked = Pick(has: [], done: [2387], canStart: id => id != 2388);
+
+        await Assert.That(picked.QuestId).IsEqualTo(2396u);
+    }
+
+    [Test]
+    public async Task ReadyReport_OffersComplete_InProgressDoesNot()
+    {
+        await Assert.That(DoodadQuestFuncRules.ShouldOfferComplete(
+            QuestObjectiveStatus.QuestComplete, letItDone: false)).IsTrue();
+        await Assert.That(DoodadQuestFuncRules.ShouldOfferComplete(
+            QuestObjectiveStatus.NotReady, letItDone: false)).IsFalse();
+        await Assert.That(DoodadQuestFuncRules.ShouldOfferComplete(
+            QuestObjectiveStatus.CanEarlyComplete, letItDone: false)).IsFalse();
+        await Assert.That(DoodadQuestFuncRules.ShouldOfferComplete(
+            QuestObjectiveStatus.CanEarlyComplete, letItDone: true)).IsTrue();
+    }
+
+    [Test]
+    public async Task NothingStartable_ReturnsDefault()
+    {
+        var picked = Pick(has: [], done: [2387, 2388, 2396, 2401]);
+
+        await Assert.That(picked).IsEqualTo(default(Row));
+    }
+
+    private static Row Pick(uint[] has, uint[] done, Func<uint, bool> canStart = null)
+    {
+        var have = has.ToHashSet();
+        var completed = done.ToHashSet();
+        return DoodadQuestFuncRules.Select(
+            Deltokin,
+            r => r.Kind,
+            r => r.QuestId,
+            have.Contains,
+            completed.Contains,
+            _ => false,
+            canStart);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestFuncRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestFuncRulesTests.cs
@@ -1,4 +1,4 @@
-using AAEmu.Game.Models.Game.DoodadObj;
+﻿using AAEmu.Game.Models.Game.DoodadObj;
 using AAEmu.Game.Models.Game.Quests.Static;
 
 namespace AAEmu.UnitTests.Game.Models.Game.DoodadObj;
@@ -86,15 +86,6 @@ public class DoodadQuestFuncRulesTests
     {
         await Assert.That(DoodadQuestFuncRules.ShouldCountInteraction(true)).IsTrue();
         await Assert.That(DoodadQuestFuncRules.ShouldCountInteraction(false)).IsFalse();
-    }
-
-    [Test]
-    public async Task Interaction_CreditIsTiedToThatCaster()
-    {
-        await Assert.That(DoodadQuestFuncRules.ShouldCountInteractionForCaster(10, 10, true)).IsTrue();
-        await Assert.That(DoodadQuestFuncRules.ShouldCountInteractionForCaster(10, 11, true)).IsFalse();
-        await Assert.That(DoodadQuestFuncRules.ShouldCountInteractionForCaster(10, 10, false)).IsFalse();
-        await Assert.That(DoodadQuestFuncRules.ShouldCountInteractionForCaster(0, 0, true)).IsFalse();
     }
 
     [Test]

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestFuncRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestFuncRulesTests.cs
@@ -67,6 +67,28 @@ public class DoodadQuestFuncRulesTests
     }
 
     [Test]
+    public async Task ReadyStep_OffersCompleteEvenIfObjectivesReadNotReady()
+    {
+        await Assert.That(DoodadQuestFuncRules.ShouldOfferComplete(
+            QuestObjectiveStatus.NotReady,
+            letItDone: false,
+            QuestStatus.Ready,
+            QuestComponentKind.Ready)).IsTrue();
+        await Assert.That(DoodadQuestFuncRules.ShouldOfferComplete(
+            QuestObjectiveStatus.NotReady,
+            letItDone: false,
+            QuestStatus.Progress,
+            QuestComponentKind.Progress)).IsFalse();
+    }
+
+    [Test]
+    public async Task Interaction_CountsOnlyWhenUseRanAFunc()
+    {
+        await Assert.That(DoodadQuestFuncRules.ShouldCountInteraction(true)).IsTrue();
+        await Assert.That(DoodadQuestFuncRules.ShouldCountInteraction(false)).IsFalse();
+    }
+
+    [Test]
     public async Task NothingStartable_ReturnsDefault()
     {
         var picked = Pick(has: [], done: [2387, 2388, 2396, 2401]);

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestReactRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestReactRulesTests.cs
@@ -43,4 +43,14 @@ public class DoodadQuestReactRulesTests
         await Assert.That(DoodadQuestReactRules.ShouldAdvance(-1, 41730)).IsFalse();
         await Assert.That(DoodadQuestReactRules.ShouldAdvance(0, 41730)).IsFalse();
     }
+
+    [Test]
+    public async Task QuestReact_DoesNotMoveTheSharedPhase()
+    {
+        await Assert.That(DoodadQuestReactRules.ShouldMutateSharedPhase()).IsFalse();
+        await Assert.That(DoodadQuestReactRules.ShouldKeepViewerPhase(41880, 41881)).IsTrue();
+        await Assert.That(DoodadQuestReactRules.ShouldKeepViewerPhase(41880, 41880)).IsFalse();
+        await Assert.That(DoodadQuestReactRules.NextViewerPhase(41880, 41881)).IsEqualTo(41881u);
+        await Assert.That(DoodadQuestReactRules.NextViewerPhase(41880, 41880)).IsEqualTo(41880u);
+    }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestReactRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestReactRulesTests.cs
@@ -53,4 +53,11 @@ public class DoodadQuestReactRulesTests
         await Assert.That(DoodadQuestReactRules.NextViewerPhase(41880, 41881)).IsEqualTo(41881u);
         await Assert.That(DoodadQuestReactRules.NextViewerPhase(41880, 41880)).IsEqualTo(41880u);
     }
+
+    [Test]
+    public async Task SharedPhaseChange_DropsViewerOverlays()
+    {
+        await Assert.That(DoodadQuestReactRules.ShouldInvalidateViewerPhases(41880, 41882)).IsTrue();
+        await Assert.That(DoodadQuestReactRules.ShouldInvalidateViewerPhases(41880, 41880)).IsFalse();
+    }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestReactRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadQuestReactRulesTests.cs
@@ -1,0 +1,46 @@
+using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.UnitTests.Game.Models.Game.DoodadObj;
+
+public class DoodadQuestReactRulesTests
+{
+    [Test]
+    public async Task CompletedRow_MatchesCompletedOnly()
+    {
+        await Assert.That(DoodadQuestReactRules.MatchesStatus(5, QuestStatus.Completed)).IsTrue();
+        await Assert.That(DoodadQuestReactRules.MatchesStatus(5, QuestStatus.Progress)).IsFalse();
+        await Assert.That(DoodadQuestReactRules.MatchesStatus(5, QuestStatus.Invalid)).IsFalse();
+    }
+
+    [Test]
+    public async Task ProgressRow_MatchesProgress()
+    {
+        await Assert.That(DoodadQuestReactRules.MatchesStatus(1, QuestStatus.Progress)).IsTrue();
+        await Assert.That(DoodadQuestReactRules.MatchesStatus(1, QuestStatus.Completed)).IsFalse();
+    }
+
+    [Test]
+    public async Task ZeroComponent_AcceptsAny()
+    {
+        await Assert.That(DoodadQuestReactRules.MatchesComponent(0, 0, false)).IsTrue();
+        await Assert.That(DoodadQuestReactRules.MatchesComponent(0, 10824, false)).IsTrue();
+    }
+
+    [Test]
+    public async Task NamedComponent_NeedsExactOrReadyStep()
+    {
+        await Assert.That(DoodadQuestReactRules.MatchesComponent(39998, 39998, false)).IsTrue();
+        await Assert.That(DoodadQuestReactRules.MatchesComponent(39998, 0, false)).IsFalse();
+        await Assert.That(DoodadQuestReactRules.MatchesComponent(39998, 0, true)).IsTrue();
+    }
+
+    [Test]
+    public async Task ShouldAdvance_IgnoresMissingAndSelf()
+    {
+        await Assert.That(DoodadQuestReactRules.ShouldAdvance(41731, 41730)).IsTrue();
+        await Assert.That(DoodadQuestReactRules.ShouldAdvance(41731, 41731)).IsFalse();
+        await Assert.That(DoodadQuestReactRules.ShouldAdvance(-1, 41730)).IsFalse();
+        await Assert.That(DoodadQuestReactRules.ShouldAdvance(0, 41730)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadUseCreditTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/DoodadObj/DoodadUseCreditTests.cs
@@ -1,0 +1,22 @@
+using AAEmu.Game.Models.Game.DoodadObj;
+
+namespace AAEmu.UnitTests.Game.Models.Game.DoodadObj;
+
+/// <summary>
+/// Per-caster use credit: the map is keyed by the caster, so a consume can only
+/// ever return that caster's own recorded result.
+/// </summary>
+public class DoodadUseCreditTests
+{
+    [Test]
+    public async Task Consume_ZeroCaster_IsFalse()
+    {
+        await Assert.That(new Doodad().ConsumeUseAppliedFunc(0)).IsFalse();
+    }
+
+    [Test]
+    public async Task Consume_WithoutThisCastersUse_IsFalse()
+    {
+        await Assert.That(new Doodad().ConsumeUseAppliedFunc(4321)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Items/Loots/LootPackRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Items/Loots/LootPackRulesTests.cs
@@ -1,0 +1,54 @@
+using AAEmu.Game.Models.Game.Items.Loots;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Items.Loots;
+
+public class LootPackRulesTests
+{
+    [Test]
+    public async Task MergeQuestItems_WhenGroupWasNotRolled_AddsQuestItems()
+    {
+        var selected = new Dictionary<uint, List<Loot>>();
+        var quest = new Loot { Id = 10, Group = 1, ItemId = 100 };
+        var questByGroup = new Dictionary<uint, List<Loot>> { [1] = [quest] };
+
+        LootPackRules.MergeQuestItems(selected, questByGroup, 1);
+
+        await Assert.That(selected.ContainsKey(1)).IsTrue();
+        await Assert.That(selected[1]).Contains(quest);
+    }
+
+    [Test]
+    public async Task MergeQuestItems_WhenGroupAlreadyHasItem_DoesNotDuplicate()
+    {
+        var quest = new Loot { Id = 10, Group = 1, ItemId = 100 };
+        var selected = new Dictionary<uint, List<Loot>> { [1] = [quest] };
+        var questByGroup = new Dictionary<uint, List<Loot>> { [1] = [quest] };
+
+        LootPackRules.MergeQuestItems(selected, questByGroup, 1);
+
+        await Assert.That(selected[1].Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task MergeQuestItems_MissingQuestGroup_LeavesSelectedAlone()
+    {
+        var selected = new Dictionary<uint, List<Loot>>();
+        var questByGroup = new Dictionary<uint, List<Loot>>
+        {
+            [2] = [new Loot { Id = 11, Group = 2 }]
+        };
+
+        LootPackRules.MergeQuestItems(selected, questByGroup, 1);
+
+        await Assert.That(selected.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task MergeQuestItems_NullMaps_DoNotThrow()
+    {
+        var empty = new Dictionary<uint, List<Loot>>();
+        LootPackRules.MergeQuestItems(null, empty, 1);
+        LootPackRules.MergeQuestItems(empty, null, 1);
+        await Assert.That(empty.Count).IsEqualTo(0);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/NPChar/NpcInteractionRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/NPChar/NpcInteractionRulesTests.cs
@@ -1,0 +1,37 @@
+using AAEmu.Game.Models.Game.NPChar;
+using AAEmu.Game.Models.StaticValues;
+
+namespace AAEmu.UnitTests.Game.Models.Game.NPChar;
+
+public class NpcInteractionRulesTests
+{
+    [Test]
+    public async Task QuestTalkNpc_UsesNpcTalk()
+    {
+        await Assert.That(NpcInteractionRules.PrimarySkill(new NpcTemplate { Id = 7816 }, questTalk: true))
+            .IsEqualTo(SkillsEnum.NpcTalk);
+        await Assert.That(NpcInteractionRules.PrimarySkill(null)).IsEqualTo(0u);
+        await Assert.That(NpcInteractionRules.PrimarySkill(new NpcTemplate { Id = 7816 })).IsEqualTo(0u);
+    }
+
+    [Test]
+    public async Task Merchant_UsesStore()
+    {
+        await Assert.That(NpcInteractionRules.PrimarySkill(new NpcTemplate { Merchant = true }))
+            .IsEqualTo(SkillsEnum.UseStore);
+    }
+
+    [Test]
+    public async Task Banker_UsesWarehouse()
+    {
+        await Assert.That(NpcInteractionRules.PrimarySkill(new NpcTemplate { Banker = true }))
+            .IsEqualTo(SkillsEnum.UseWarehouse);
+    }
+
+    [Test]
+    public async Task MerchantQuestTalk_UsesNpcTalk()
+    {
+        await Assert.That(NpcInteractionRules.PrimarySkill(new NpcTemplate { Merchant = true }, questTalk: true))
+            .IsEqualTo(SkillsEnum.NpcTalk);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/NPChar/ZoneMirrorIdRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/NPChar/ZoneMirrorIdRulesTests.cs
@@ -1,0 +1,29 @@
+using AAEmu.Game.Models.Game.NPChar;
+
+namespace AAEmu.UnitTests.Game.Models.Game.NPChar;
+
+public class ZoneMirrorIdRulesTests
+{
+    [Test]
+    public async Task SameZoneMirror_IsIdempotent()
+    {
+        await Assert.That(ZoneMirrorIdRules.IsIdempotentRemirror(288, 0, true, 288, 0)).IsTrue();
+    }
+
+    [Test]
+    public async Task OtherZoneOrWorldUnit_IsNotTheSameMirror()
+    {
+        await Assert.That(ZoneMirrorIdRules.IsIdempotentRemirror(282, 0, true, 288, 0)).IsFalse();
+        await Assert.That(ZoneMirrorIdRules.IsIdempotentRemirror(288, 0, false, 288, 0)).IsFalse();
+        await Assert.That(ZoneMirrorIdRules.IsIdempotentRemirror(0, 0, true, 288, 0)).IsFalse();
+        await Assert.That(ZoneMirrorIdRules.IsIdempotentRemirror(288, 0, true, 0, 0)).IsFalse();
+        await Assert.That(ZoneMirrorIdRules.IsIdempotentRemirror(288, 1, true, 288, 2)).IsFalse();
+    }
+
+    [Test]
+    public async Task LiveUnit_SkipsRecycledId()
+    {
+        await Assert.That(ZoneMirrorIdRules.ShouldSkipAllocatedId(true)).IsTrue();
+        await Assert.That(ZoneMirrorIdRules.ShouldSkipAllocatedId(false)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/NPChar/ZoneMirrorIdRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/NPChar/ZoneMirrorIdRulesTests.cs
@@ -1,4 +1,4 @@
-using AAEmu.Game.Models.Game.NPChar;
+﻿using AAEmu.Game.Models.Game.NPChar;
 
 namespace AAEmu.UnitTests.Game.Models.Game.NPChar;
 
@@ -18,12 +18,5 @@ public class ZoneMirrorIdRulesTests
         await Assert.That(ZoneMirrorIdRules.IsIdempotentRemirror(0, 0, true, 288, 0)).IsFalse();
         await Assert.That(ZoneMirrorIdRules.IsIdempotentRemirror(288, 0, true, 0, 0)).IsFalse();
         await Assert.That(ZoneMirrorIdRules.IsIdempotentRemirror(288, 1, true, 288, 2)).IsFalse();
-    }
-
-    [Test]
-    public async Task LiveUnit_SkipsRecycledId()
-    {
-        await Assert.That(ZoneMirrorIdRules.ShouldSkipAllocatedId(true)).IsTrue();
-        await Assert.That(ZoneMirrorIdRules.ShouldSkipAllocatedId(false)).IsFalse();
     }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/LevelPackDoodadRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/LevelPackDoodadRulesTests.cs
@@ -1,0 +1,53 @@
+using AAEmu.Game.Models.Game.Quests;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class LevelPackDoodadRulesTests
+{
+    [Test]
+    public async Task ShouldAuthor_ClientNpcTypeOrTalk_NotTowerOrIgnore()
+    {
+        await Assert.That(LevelPackDoodadRules.ShouldAuthorPermanent(
+            clientDoodad: true, npcTypeModel: true, talkOrQuestFunc: true,
+            towerAlmighty: false, ignoredPermanent: false, scheduledEvent: false)).IsTrue();
+        await Assert.That(LevelPackDoodadRules.ShouldAuthorPermanent(
+            clientDoodad: true, npcTypeModel: false, talkOrQuestFunc: false,
+            towerAlmighty: false, ignoredPermanent: false, scheduledEvent: false)).IsTrue();
+        await Assert.That(LevelPackDoodadRules.ShouldAuthorPermanent(
+            clientDoodad: false, npcTypeModel: true, talkOrQuestFunc: false,
+            towerAlmighty: false, ignoredPermanent: false, scheduledEvent: false)).IsTrue();
+        await Assert.That(LevelPackDoodadRules.ShouldAuthorPermanent(
+            clientDoodad: false, npcTypeModel: false, talkOrQuestFunc: true,
+            towerAlmighty: false, ignoredPermanent: false, scheduledEvent: false)).IsTrue();
+        await Assert.That(LevelPackDoodadRules.ShouldAuthorPermanent(
+            clientDoodad: true, npcTypeModel: true, talkOrQuestFunc: true,
+            towerAlmighty: true, ignoredPermanent: false, scheduledEvent: false)).IsFalse();
+        await Assert.That(LevelPackDoodadRules.ShouldAuthorPermanent(
+            clientDoodad: true, npcTypeModel: true, talkOrQuestFunc: true,
+            towerAlmighty: false, ignoredPermanent: true, scheduledEvent: false)).IsFalse();
+        await Assert.That(LevelPackDoodadRules.ShouldAuthorPermanent(
+            clientDoodad: true, npcTypeModel: true, talkOrQuestFunc: true,
+            towerAlmighty: false, ignoredPermanent: false, scheduledEvent: true)).IsFalse();
+        await Assert.That(LevelPackDoodadRules.ShouldAuthorPermanent(
+            clientDoodad: false, npcTypeModel: false, talkOrQuestFunc: false,
+            towerAlmighty: false, ignoredPermanent: false, scheduledEvent: false)).IsFalse();
+    }
+
+    [Test]
+    public async Task Plan_3901Pad_TakesEhnoirFeosExtras_SkipsIgnored()
+    {
+        var wanted = new HashSet<uint> { 14226, 14227, 14228 };
+        var catalog = new[]
+        {
+            new QuestTalkDoodadRules.Placement(14226, 11546.626f, 11829.929f, 110.011f, 0f),
+            new QuestTalkDoodadRules.Placement(14227, 11544.631f, 11827.183f, 110.172f, 0f),
+            new QuestTalkDoodadRules.Placement(14228, 11538.821f, 11828.881f, 110.356f, 0f),
+            new QuestTalkDoodadRules.Placement(14228, 11547.599f, 11823.275f, 110.101f, 0f)
+        };
+
+        var planned = QuestTalkDoodadRules.Plan(wanted, catalog, []);
+        await Assert.That(planned.Count(p => p.TemplateId == 14226)).IsEqualTo(1);
+        await Assert.That(planned.Count(p => p.TemplateId == 14227)).IsEqualTo(1);
+        await Assert.That(planned.Count(p => p.TemplateId == 14228)).IsEqualTo(2);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestAcceptRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestAcceptRulesTests.cs
@@ -1,0 +1,62 @@
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestAcceptRulesTests
+{
+    [Test]
+    public async Task StartAcceptNpc_FillsUnknownAcceptor()
+    {
+        var template = TemplateWithStartAct(start =>
+            start.ActTemplates.Add(new QuestActConAcceptNpc(start) { NpcId = 7816 }));
+
+        var type = QuestAcceptorType.Unknown;
+        var id = 0u;
+        QuestAcceptRules.FillUnknownAcceptor(template, ref type, ref id);
+
+        await Assert.That(type).IsEqualTo(QuestAcceptorType.Npc);
+        await Assert.That(id).IsEqualTo(7816u);
+    }
+
+    [Test]
+    public async Task ExplicitAcceptor_IsLeftAlone()
+    {
+        var template = TemplateWithStartAct(start =>
+            start.ActTemplates.Add(new QuestActConAcceptNpc(start) { NpcId = 7816 }));
+
+        var type = QuestAcceptorType.Npc;
+        var id = 99u;
+        QuestAcceptRules.FillUnknownAcceptor(template, ref type, ref id);
+
+        await Assert.That(type).IsEqualTo(QuestAcceptorType.Npc);
+        await Assert.That(id).IsEqualTo(99u);
+    }
+
+    [Test]
+    public async Task MissingStartAct_LeavesUnknown()
+    {
+        var template = new QuestTemplate { Id = 1 };
+        var type = QuestAcceptorType.Unknown;
+        var id = 0u;
+        QuestAcceptRules.FillUnknownAcceptor(template, ref type, ref id);
+
+        await Assert.That(type).IsEqualTo(QuestAcceptorType.Unknown);
+        await Assert.That(id).IsEqualTo(0u);
+    }
+
+    private static QuestTemplate TemplateWithStartAct(Action<QuestComponentTemplate> fill)
+    {
+        var template = new QuestTemplate { Id = 2386 };
+        var start = new QuestComponentTemplate(template)
+        {
+            Id = 10256,
+            KindId = QuestComponentKind.Start
+        };
+        fill(start);
+        template.Components[start.Id] = start;
+        return template;
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCinemaBindRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCinemaBindRulesTests.cs
@@ -64,10 +64,19 @@ public class QuestCinemaBindRulesTests
     [Test]
     public async Task DroppedQuest_DoesNotApplyCinemaEnd()
     {
-        await Assert.That(QuestCinemaBindRules.ShouldApplyCinemaEndEffect(true)).IsTrue();
-        await Assert.That(QuestCinemaBindRules.ShouldApplyCinemaEndEffect(false)).IsFalse();
+        await Assert.That(QuestCinemaBindRules.ShouldApplyCinemaEndEffect(true, false)).IsTrue();
+        await Assert.That(QuestCinemaBindRules.ShouldApplyCinemaEndEffect(false, false)).IsFalse();
         await Assert.That(QuestCinemaBindRules.CinemaEndBelongsToQuest(3901, 3901)).IsTrue();
         await Assert.That(QuestCinemaBindRules.CinemaEndBelongsToQuest(3901, 2385)).IsFalse();
         await Assert.That(QuestCinemaBindRules.CinemaEndBelongsToQuest(0, 3901)).IsFalse();
+    }
+
+    [Test]
+    public async Task CompleteDuringFilm_KeepsTheCinemaEnd()
+    {
+        await Assert.That(QuestCinemaBindRules.ShouldApplyCinemaEndEffect(false, true)).IsTrue();
+        await Assert.That(QuestCinemaBindRules.ShouldClearCinemaEndOnDrop(true, false)).IsFalse();
+        await Assert.That(QuestCinemaBindRules.ShouldClearCinemaEndOnDrop(false, false)).IsTrue();
+        await Assert.That(QuestCinemaBindRules.ShouldClearCinemaEndOnDrop(true, true)).IsTrue();
     }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCinemaBindRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCinemaBindRulesTests.cs
@@ -60,4 +60,14 @@ public class QuestCinemaBindRulesTests
         await Assert.That(QuestCinemaBindRules.ResolveCompletedCinema(0, [])).IsEqualTo(0u);
         await Assert.That(QuestCinemaBindRules.ResolveCompletedCinema(0, null)).IsEqualTo(0u);
     }
+
+    [Test]
+    public async Task DroppedQuest_DoesNotApplyCinemaEnd()
+    {
+        await Assert.That(QuestCinemaBindRules.ShouldApplyCinemaEndEffect(true)).IsTrue();
+        await Assert.That(QuestCinemaBindRules.ShouldApplyCinemaEndEffect(false)).IsFalse();
+        await Assert.That(QuestCinemaBindRules.CinemaEndBelongsToQuest(3901, 3901)).IsTrue();
+        await Assert.That(QuestCinemaBindRules.CinemaEndBelongsToQuest(3901, 2385)).IsFalse();
+        await Assert.That(QuestCinemaBindRules.CinemaEndBelongsToQuest(0, 3901)).IsFalse();
+    }
 }

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCinemaBindRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCinemaBindRulesTests.cs
@@ -1,0 +1,63 @@
+using AAEmu.Game.Models.Game.Quests;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestCinemaBindRulesTests
+{
+    [Test]
+    public async Task NamedEvent_BindsWhenItMatchesTheAct()
+    {
+        await Assert.That(QuestCinemaBindRules.ShouldBindStarted(40, 40, 0)).IsTrue();
+        await Assert.That(QuestCinemaBindRules.ShouldBindStarted(41, 40, 40)).IsFalse();
+    }
+
+    [Test]
+    public async Task EmptyEvent_BindsOnlyWhenAlreadyPlayingThatCinema()
+    {
+        await Assert.That(QuestCinemaBindRules.ShouldBindStarted(0, 40, 40)).IsTrue();
+        await Assert.That(QuestCinemaBindRules.ShouldBindStarted(0, 40, 0)).IsFalse();
+        await Assert.That(QuestCinemaBindRules.ShouldBindStarted(0, 40, 9)).IsFalse();
+    }
+
+    [Test]
+    public async Task MissingAct_DoesNotBind()
+    {
+        await Assert.That(QuestCinemaBindRules.ShouldBindStarted(40, 0, 40)).IsFalse();
+    }
+
+    [Test]
+    public async Task EnterProgress_CreditsOnlyTheCinemaAlreadyPlaying()
+    {
+        await Assert.That(QuestCinemaBindRules.ShouldCreditOnEnterProgress(40, 40)).IsTrue();
+        await Assert.That(QuestCinemaBindRules.ShouldCreditOnEnterProgress(0, 40)).IsFalse();
+        await Assert.That(QuestCinemaBindRules.ShouldCreditOnEnterProgress(9, 40)).IsFalse();
+        await Assert.That(QuestCinemaBindRules.ShouldCreditOnEnterProgress(40, 0)).IsFalse();
+    }
+
+    [Test]
+    public async Task NextQuest_DoesNotReplaceThePlayingCinema()
+    {
+        await Assert.That(QuestCinemaBindRules.ShouldReplacePlaying(167, 78)).IsFalse();
+        await Assert.That(QuestCinemaBindRules.ShouldReplacePlaying(167, 167)).IsTrue();
+        await Assert.That(QuestCinemaBindRules.ShouldReplacePlaying(0, 167)).IsTrue();
+        await Assert.That(QuestCinemaBindRules.ShouldReplacePlaying(167, 0)).IsFalse();
+        await Assert.That(QuestCinemaBindRules.ShouldReplacePlaying(0, 0)).IsFalse();
+    }
+
+    [Test]
+    public async Task SkipWithEmptyBody_UsesTheSingleDeferredCinema()
+    {
+        await Assert.That(QuestCinemaBindRules.ResolveCompletedCinema(0, [167])).IsEqualTo(167u);
+        await Assert.That(QuestCinemaBindRules.ResolveCompletedCinema(0, [167, 167])).IsEqualTo(167u);
+        await Assert.That(QuestCinemaBindRules.ResolveCompletedCinema(0, [0, 167])).IsEqualTo(167u);
+    }
+
+    [Test]
+    public async Task SkipKeepsThePlayingIdWhenSet()
+    {
+        await Assert.That(QuestCinemaBindRules.ResolveCompletedCinema(167, [78])).IsEqualTo(167u);
+        await Assert.That(QuestCinemaBindRules.ResolveCompletedCinema(0, [167, 78])).IsEqualTo(0u);
+        await Assert.That(QuestCinemaBindRules.ResolveCompletedCinema(0, [])).IsEqualTo(0u);
+        await Assert.That(QuestCinemaBindRules.ResolveCompletedCinema(0, null)).IsEqualTo(0u);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCinemaPermissionRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCinemaPermissionRulesTests.cs
@@ -1,0 +1,38 @@
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestCinemaPermissionRulesTests
+{
+    [Test]
+    public async Task Bind_NeedsComponentCinemaAndANearbySource()
+    {
+        await Assert.That(QuestCinemaPermissionRules.CanBind(
+            78, true, true, QuestComponentKind.Progress, npcAllowed: false, doodadAllowed: true)).IsTrue();
+        await Assert.That(QuestCinemaPermissionRules.CanBind(
+            78, true, true, QuestComponentKind.Progress, npcAllowed: false, doodadAllowed: false)).IsFalse();
+        await Assert.That(QuestCinemaPermissionRules.CanBind(
+            0, true, true, QuestComponentKind.Progress, npcAllowed: false, doodadAllowed: true)).IsFalse();
+        await Assert.That(QuestCinemaPermissionRules.CanBind(
+            78, false, true, QuestComponentKind.Progress, npcAllowed: false, doodadAllowed: true)).IsFalse();
+    }
+
+    [Test]
+    public async Task StartCinema_MayBindBeforeTheQuestIsActive()
+    {
+        await Assert.That(QuestCinemaPermissionRules.CanBind(
+            167, true, false, QuestComponentKind.Start, npcAllowed: true, doodadAllowed: false)).IsTrue();
+        await Assert.That(QuestCinemaPermissionRules.CanBind(
+            78, true, false, QuestComponentKind.Progress, npcAllowed: true, doodadAllowed: false)).IsFalse();
+    }
+
+    [Test]
+    public async Task Source_MustExistInsideTheInteractBand()
+    {
+        await Assert.That(QuestCinemaPermissionRules.SourceAllowed(true, true, 2.5f)).IsTrue();
+        await Assert.That(QuestCinemaPermissionRules.SourceAllowed(true, true, 3.1f)).IsFalse();
+        await Assert.That(QuestCinemaPermissionRules.SourceAllowed(true, false, 0f)).IsFalse();
+        await Assert.That(QuestCinemaPermissionRules.SourceAllowed(false, true, 0f)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCinemaRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCinemaRulesTests.cs
@@ -1,0 +1,98 @@
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestCinemaRulesTests
+{
+    [Test]
+    public async Task Permission_UsesTheComponentCinemaNotAQuestLookup()
+    {
+        var template = Template(startCinema: 0, readyCinema: 78);
+        var ready = template.GetComponents(QuestComponentKind.Ready)[0];
+
+        await Assert.That(QuestCinemaRules.CinemaIdForPermission(ready, null)).IsEqualTo(78u);
+        await Assert.That(QuestCinemaRules.CinemaIdForPermission(null, template, QuestComponentKind.Ready))
+            .IsEqualTo(78u);
+        await Assert.That(QuestCinemaRules.CinemaIdForPermission(null, null)).IsEqualTo(0u);
+        await Assert.That(QuestCinemaRules.CinemaIdOnComponent(ready)).IsEqualTo(78u);
+        await Assert.That(QuestCinemaRules.CinemaIdForDirecting(null)).IsEqualTo(0u);
+    }
+
+    [Test]
+    public async Task PreferStep_Wins()
+    {
+        var template = Template(startCinema: 124, readyCinema: 55);
+
+        await Assert.That(QuestCinemaRules.CinemaIdForDirecting(template, QuestComponentKind.Ready))
+            .IsEqualTo(55u);
+        await Assert.That(QuestCinemaRules.CinemaIdForDirecting(template, QuestComponentKind.Start))
+            .IsEqualTo(124u);
+    }
+
+    [Test]
+    public async Task NoPrefer_UsesReadyThenStart()
+    {
+        var template = Template(startCinema: 124, readyCinema: 55);
+        await Assert.That(QuestCinemaRules.CinemaIdForDirecting(template)).IsEqualTo(55u);
+    }
+
+    [Test]
+    public async Task MissingTemplate_IsZero()
+    {
+        await Assert.That(QuestCinemaRules.CinemaIdForDirecting(null)).IsEqualTo(0u);
+        await Assert.That(QuestCinemaRules.CinemaIdForDirecting(new QuestTemplate { Id = 1 })).IsEqualTo(0u);
+    }
+
+    [Test]
+    public async Task ProgressCinemaAct_IsUsedWhenComponentColumnIsEmpty()
+    {
+        var template = new QuestTemplate { Id = 2 };
+        var progress = new QuestComponentTemplate(template)
+        {
+            Id = 20,
+            KindId = QuestComponentKind.Progress
+        };
+        progress.ActTemplates.Add(new QuestActObjCinema(progress) { CinemaId = 40 });
+        template.Components[progress.Id] = progress;
+
+        await Assert.That(QuestCinemaRules.CinemaIdForDirecting(template)).IsEqualTo(40u);
+        await Assert.That(QuestCinemaRules.CinemaIdForDirecting(template, QuestComponentKind.Progress))
+            .IsEqualTo(40u);
+        await Assert.That(QuestCinemaRules.FirstCinemaComponentId(template, QuestComponentKind.Progress))
+            .IsEqualTo(20u);
+    }
+
+    [Test]
+    public async Task ProgressStep_DoesNotFallThroughToReadyCinema()
+    {
+        var template = Template(startCinema: 0, readyCinema: 78);
+
+        await Assert.That(QuestCinemaRules.FirstCinema(template, QuestComponentKind.Progress))
+            .IsEqualTo(0u);
+        await Assert.That(QuestCinemaRules.CinemaIdForDirecting(template, QuestComponentKind.Progress))
+            .IsEqualTo(78u);
+    }
+
+    private static QuestTemplate Template(uint startCinema, uint readyCinema)
+    {
+        var template = new QuestTemplate { Id = 2385 };
+        var start = new QuestComponentTemplate(template)
+        {
+            Id = 10254,
+            KindId = QuestComponentKind.Start,
+            CinemaId = startCinema
+        };
+        var ready = new QuestComponentTemplate(template)
+        {
+            Id = 10255,
+            KindId = QuestComponentKind.Ready,
+            CinemaId = readyCinema
+        };
+        template.Components[start.Id] = start;
+        template.Components[ready.Id] = ready;
+        return template;
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCompletedWireTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestCompletedWireTests.cs
@@ -1,0 +1,90 @@
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestCompletedWireTests
+{
+    [Test]
+    public async Task CurrentComponent_Wins_WhenReadyHasNoCinema()
+    {
+        var template = TemplateWithRewardAndReady(10255, 10254, cinemaId: 0);
+        var id = QuestCompletedWire.ComponentIdForCompletedPacket(10255, template);
+        await Assert.That(id).IsEqualTo(10255u);
+    }
+
+    [Test]
+    public async Task ReadyWithCinema_BeatsRewardCurrent()
+    {
+        // 2387 Ready cinema 56 — clearing that component unblocks next directing.
+        var template = TemplateWithRewardAndReady(10264, 10263, cinemaId: 56);
+        var id = QuestCompletedWire.ComponentIdForCompletedPacket(10264, template);
+        await Assert.That(id).IsEqualTo(10263u);
+    }
+
+    [Test]
+    public async Task ZeroCurrent_FallsBackToReward()
+    {
+        var template = TemplateWithRewardAndReady(10255, 10254, cinemaId: 0);
+        var id = QuestCompletedWire.ComponentIdForCompletedPacket(0, template);
+        await Assert.That(id).IsEqualTo(10255u);
+    }
+
+    [Test]
+    public async Task MissingReward_FallsBackToReady()
+    {
+        var template = new QuestTemplate { Id = 2385 };
+        var ready = new QuestComponentTemplate(template)
+        {
+            Id = 10254,
+            KindId = QuestComponentKind.Ready
+        };
+        template.Components[ready.Id] = ready;
+
+        var id = QuestCompletedWire.ComponentIdForCompletedPacket(0, template);
+        await Assert.That(id).IsEqualTo(10254u);
+    }
+
+    [Test]
+    public async Task NullTemplate_StaysZero()
+    {
+        await Assert.That(QuestCompletedWire.ComponentIdForCompletedPacket(0, null)).IsEqualTo(0u);
+    }
+
+    [Test]
+    public async Task ProgressCinemaAct_BeatsRewardCurrent()
+    {
+        var template = TemplateWithRewardAndReady(30, 31, cinemaId: 0);
+        var progress = new QuestComponentTemplate(template)
+        {
+            Id = 32,
+            KindId = QuestComponentKind.Progress
+        };
+        progress.ActTemplates.Add(new QuestActObjCinema(progress) { CinemaId = 40 });
+        template.Components[progress.Id] = progress;
+
+        var id = QuestCompletedWire.ComponentIdForCompletedPacket(30, template);
+        await Assert.That(id).IsEqualTo(32u);
+    }
+
+    private static QuestTemplate TemplateWithRewardAndReady(uint rewardId, uint readyId, uint cinemaId)
+    {
+        var template = new QuestTemplate { Id = 2385 };
+        var reward = new QuestComponentTemplate(template)
+        {
+            Id = rewardId,
+            KindId = QuestComponentKind.Reward
+        };
+        var ready = new QuestComponentTemplate(template)
+        {
+            Id = readyId,
+            KindId = QuestComponentKind.Ready,
+            CinemaId = cinemaId
+        };
+        template.Components[reward.Id] = reward;
+        template.Components[ready.Id] = ready;
+        return template;
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestComponentEffectRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestComponentEffectRulesTests.cs
@@ -1,0 +1,37 @@
+using AAEmu.Game.Models.Game.Quests;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestComponentEffectRulesTests
+{
+    [Test]
+    public async Task FirstSuccess_MarksApplied()
+    {
+        var applied = new HashSet<uint>();
+        await Assert.That(QuestComponentEffectRules.TryMarkApplied(10, applied)).IsTrue();
+        await Assert.That(applied.Contains(10)).IsTrue();
+    }
+
+    [Test]
+    public async Task SecondSuccess_DoesNotApplyAgain()
+    {
+        var applied = new HashSet<uint> { 10 };
+        await Assert.That(QuestComponentEffectRules.TryMarkApplied(10, applied)).IsFalse();
+    }
+
+    [Test]
+    public async Task MissingIdOrSet_DoesNotApply()
+    {
+        await Assert.That(QuestComponentEffectRules.TryMarkApplied(0, new HashSet<uint>())).IsFalse();
+        await Assert.That(QuestComponentEffectRules.TryMarkApplied(10, null)).IsFalse();
+    }
+
+    [Test]
+    public async Task PlayCinemaBeforeBubble_DefersBuffUntilCinema()
+    {
+        await Assert.That(QuestComponentEffectRules.ShouldDeferUntilCinema(true, 99, 40)).IsTrue();
+        await Assert.That(QuestComponentEffectRules.ShouldDeferUntilCinema(true, 0, 40)).IsFalse();
+        await Assert.That(QuestComponentEffectRules.ShouldDeferUntilCinema(true, 99, 0)).IsFalse();
+        await Assert.That(QuestComponentEffectRules.ShouldDeferUntilCinema(false, 99, 40)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestNoneSceneRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestNoneSceneRulesTests.cs
@@ -1,0 +1,58 @@
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestNoneSceneRulesTests
+{
+    [Test]
+    public async Task OrbWithProgressCinema_StartsTheScene()
+    {
+        await Assert.That(QuestNoneSceneRules.ShouldStartSceneCinema(true, 167)).IsTrue();
+    }
+
+    [Test]
+    public async Task Accept_StartsWhenNonePlayCinemaAndProgressCinemaExist()
+    {
+        await Assert.That(QuestNoneSceneRules.ShouldStartSceneOnAccept(SceneTemplate())).IsTrue();
+        await Assert.That(QuestNoneSceneRules.ShouldStartSceneOnAccept(new QuestTemplate { Id = 1 })).IsFalse();
+    }
+
+    [Test]
+    public async Task NoProgressCinema_DoesNotBind()
+    {
+        await Assert.That(QuestNoneSceneRules.ShouldStartSceneCinema(true, 0)).IsFalse();
+        await Assert.That(QuestNoneSceneRules.ShouldStartSceneCinema(false, 167)).IsFalse();
+        await Assert.That(QuestNoneSceneRules.ShouldStartSceneCinema(false, 0)).IsFalse();
+    }
+
+    [Test]
+    public async Task SceneReportTalk_IsNoneWithProgressCinema()
+    {
+        await Assert.That(QuestNoneSceneRules.IsSceneReportTalk(QuestComponentKind.None, true, 167)).IsTrue();
+        await Assert.That(QuestNoneSceneRules.IsSceneReportTalk(QuestComponentKind.None, true, 0)).IsFalse();
+        await Assert.That(QuestNoneSceneRules.IsSceneReportTalk(QuestComponentKind.Ready, true, 167)).IsFalse();
+    }
+
+    private static QuestTemplate SceneTemplate()
+    {
+        var template = new QuestTemplate { Id = 3900 };
+        var none = new QuestComponentTemplate(template)
+        {
+            Id = 18603,
+            KindId = QuestComponentKind.None,
+            PlayCinemaBeforeBubble = true
+        };
+        var progress = new QuestComponentTemplate(template)
+        {
+            Id = 32016,
+            KindId = QuestComponentKind.Progress
+        };
+        progress.ActTemplates.Add(new QuestActObjCinema(progress) { CinemaId = 167 });
+        template.Components[none.Id] = none;
+        template.Components[progress.Id] = progress;
+        return template;
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestObjectiveSlotRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestObjectiveSlotRulesTests.cs
@@ -1,0 +1,82 @@
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestObjectiveSlotRulesTests
+{
+    [Test]
+    public async Task ProgressJournal_StaysOnSlotZero_NoneActsTakeLeftovers()
+    {
+        var cinema = QuestObjectiveSlotRules.SlotForProgressComponent(0, 5);
+        byte other = 1;
+        var interaction = QuestObjectiveSlotRules.NextIndex(ref other, true, 5);
+        var gather = QuestObjectiveSlotRules.NextIndex(ref other, true, 5);
+        var report = QuestObjectiveSlotRules.NextIndex(ref other, false, 5);
+
+        await Assert.That(cinema).IsEqualTo((byte)0);
+        await Assert.That(interaction).IsEqualTo((byte)1);
+        await Assert.That(gather).IsEqualTo((byte)2);
+        await Assert.That(report).IsEqualTo(QuestObjectiveSlotRules.NoSlot);
+    }
+
+    [Test]
+    public async Task ActsInTheSameProgressComponent_ShareOneSlot()
+    {
+        var first = QuestObjectiveSlotRules.SlotForProgressComponent(0, 5);
+        var second = QuestObjectiveSlotRules.SlotForProgressComponent(0, 5);
+        var nextComponent = QuestObjectiveSlotRules.SlotForProgressComponent(1, 5);
+
+        await Assert.That(first).IsEqualTo((byte)0);
+        await Assert.That(second).IsEqualTo((byte)0);
+        await Assert.That(nextComponent).IsEqualTo((byte)1);
+    }
+
+    [Test]
+    public async Task ProgressOnly_KeepsComponentLocalIndexes()
+    {
+        await Assert.That(QuestObjectiveSlotRules.SlotForProgressComponent(0, 5)).IsEqualTo((byte)0);
+        await Assert.That(QuestObjectiveSlotRules.SlotForProgressComponent(1, 5)).IsEqualTo((byte)1);
+        await Assert.That(QuestObjectiveSlotRules.SlotForProgressComponent(2, 5)).IsEqualTo((byte)2);
+        await Assert.That(QuestObjectiveSlotRules.SlotForProgressComponent(5, 5)).IsEqualTo(QuestObjectiveSlotRules.NoSlot);
+        await Assert.That(QuestObjectiveSlotRules.SlotForProgressComponent(-1, 5)).IsEqualTo(QuestObjectiveSlotRules.NoSlot);
+    }
+
+    [Test]
+    public async Task NoneOnly_StartsAtZero()
+    {
+        byte actIndex = 0;
+        var first = QuestObjectiveSlotRules.NextIndex(ref actIndex, true, 5);
+        var second = QuestObjectiveSlotRules.NextIndex(ref actIndex, true, 5);
+
+        await Assert.That(first).IsEqualTo((byte)0);
+        await Assert.That(second).IsEqualTo((byte)1);
+    }
+
+    [Test]
+    public async Task NoneAndProgress_ReadStoredCount()
+    {
+        await Assert.That(QuestObjectiveSlotRules.RunActUsesStoredCount(QuestComponentKind.None, 0, 5)).IsTrue();
+        await Assert.That(QuestObjectiveSlotRules.RunActUsesStoredCount(QuestComponentKind.Progress, 1, 5)).IsTrue();
+        await Assert.That(QuestObjectiveSlotRules.RunActUsesStoredCount(QuestComponentKind.Start, 0, 5)).IsFalse();
+        await Assert.That(QuestObjectiveSlotRules.RunActUsesStoredCount(QuestComponentKind.None, QuestObjectiveSlotRules.NoSlot, 5)).IsFalse();
+    }
+
+    [Test]
+    public async Task CinemaWatch_OnlyOnProgress()
+    {
+        await Assert.That(QuestObjectiveSlotRules.CinemaWatchCounts(QuestComponentKind.None)).IsFalse();
+        await Assert.That(QuestObjectiveSlotRules.CinemaWatchCounts(QuestComponentKind.Start)).IsFalse();
+        await Assert.That(QuestObjectiveSlotRules.CinemaWatchCounts(QuestComponentKind.Progress)).IsTrue();
+    }
+
+    [Test]
+    public async Task ObjectiveActMet_UsesOverrideOrStoredCount()
+    {
+        var objectives = new[] { 0, 1, 0, 0, 0 };
+        await Assert.That(QuestObjectiveSlotRules.ObjectiveActMet(1, 1, false, objectives)).IsTrue();
+        await Assert.That(QuestObjectiveSlotRules.ObjectiveActMet(0, 1, false, objectives)).IsFalse();
+        await Assert.That(QuestObjectiveSlotRules.ObjectiveActMet(0, 1, true, objectives)).IsTrue();
+        await Assert.That(QuestObjectiveSlotRules.ObjectiveActMet(QuestObjectiveSlotRules.NoSlot, 1, false, objectives)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestReportNpcRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestReportNpcRulesTests.cs
@@ -1,0 +1,38 @@
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Static;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestReportNpcRulesTests
+{
+    [Test]
+    public async Task NoneStepTalk_CompletesWithoutProgress()
+    {
+        await Assert.That(QuestReportNpcRules.TalkCompletesWithoutProgress(QuestComponentKind.None)).IsTrue();
+        await Assert.That(QuestReportNpcRules.TalkCompletesWithoutProgress(QuestComponentKind.Ready)).IsFalse();
+        await Assert.That(QuestReportNpcRules.TalkCompletesWithoutProgress(QuestComponentKind.Progress)).IsFalse();
+    }
+
+    [Test]
+    public async Task ReadyOrProgressTalk_AdvancesToReady()
+    {
+        await Assert.That(QuestReportNpcRules.TalkAdvancesToReady(QuestComponentKind.Ready)).IsTrue();
+        await Assert.That(QuestReportNpcRules.TalkAdvancesToReady(QuestComponentKind.Progress)).IsTrue();
+        await Assert.That(QuestReportNpcRules.TalkAdvancesToReady(QuestComponentKind.None)).IsFalse();
+    }
+
+    [Test]
+    public async Task SceneTalk_DoesNotCompleteFromAcceptTargetOrTownTalk()
+    {
+        await Assert.That(QuestReportNpcRules.CompletesFromCurrentTarget(QuestComponentKind.None, true, 167)).IsFalse();
+        await Assert.That(QuestReportNpcRules.CompletesFromTalkEvent(QuestComponentKind.None, true, 167)).IsFalse();
+    }
+
+    [Test]
+    public async Task HuntNoneTalk_StillCompletesFromTargetAndTalk()
+    {
+        await Assert.That(QuestReportNpcRules.CompletesFromCurrentTarget(QuestComponentKind.None, true, 0)).IsTrue();
+        await Assert.That(QuestReportNpcRules.CompletesFromTalkEvent(QuestComponentKind.None, true, 0)).IsTrue();
+        await Assert.That(QuestReportNpcRules.CompletesFromCurrentTarget(QuestComponentKind.Ready, true, 167)).IsTrue();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestRewardAcceptRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestRewardAcceptRulesTests.cs
@@ -1,0 +1,42 @@
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestRewardAcceptRulesTests
+{
+    [Test]
+    public async Task RewardAcceptComponent_YieldsNextQuest()
+    {
+        var template = new QuestTemplate { Id = 10 };
+        var reward = new QuestComponentTemplate(template)
+        {
+            Id = 11,
+            KindId = QuestComponentKind.Reward
+        };
+        reward.ActTemplates.Add(new QuestActConAcceptComponent(reward) { QuestContextId = 12 });
+        template.Components[reward.Id] = reward;
+
+        var ids = QuestRewardAcceptRules.NextQuestIds(template).ToArray();
+        await Assert.That(ids).IsEquivalentTo(new[] { 12u });
+    }
+
+    [Test]
+    public async Task SameQuestOrMissing_YieldsNothing()
+    {
+        var template = new QuestTemplate { Id = 10 };
+        var reward = new QuestComponentTemplate(template)
+        {
+            Id = 11,
+            KindId = QuestComponentKind.Reward
+        };
+        reward.ActTemplates.Add(new QuestActConAcceptComponent(reward) { QuestContextId = 10 });
+        template.Components[reward.Id] = reward;
+
+        await Assert.That(QuestRewardAcceptRules.NextQuestIds(template).ToArray()).IsEmpty();
+        await Assert.That(QuestRewardAcceptRules.NextQuestIds(null).ToArray()).IsEmpty();
+        await Assert.That(QuestRewardAcceptRules.NextQuestIds(new QuestTemplate { Id = 1 }).ToArray()).IsEmpty();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestTalkDoodadRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestTalkDoodadRulesTests.cs
@@ -1,0 +1,143 @@
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestTalkDoodadRulesTests
+{
+    [Test]
+    public async Task AcceptAndReport_AreTalkDoodads()
+    {
+        var dest = new HashSet<uint>();
+        var template = new QuestTemplate { Id = 2388 };
+        var start = new QuestComponentTemplate(template) { Id = 10265, KindId = QuestComponentKind.Start };
+        start.ActTemplates.Add(new QuestActConAcceptDoodad(start) { DoodadId = 14178 });
+        var ready = new QuestComponentTemplate(template) { Id = 10268, KindId = QuestComponentKind.Ready };
+        ready.ActTemplates.Add(new QuestActConReportDoodad(ready) { DoodadId = 14178 });
+        template.Components[start.Id] = start;
+        template.Components[ready.Id] = ready;
+
+        QuestTalkDoodadRules.AddTalkDoodads(template, dest);
+
+        await Assert.That(dest.Contains(14178)).IsTrue();
+    }
+
+    [Test]
+    public async Task HighlightOnly_IsNotTalkDoodad()
+    {
+        var dest = new HashSet<uint>();
+        var template = new QuestTemplate { Id = 1 };
+        var progress = new QuestComponentTemplate(template) { Id = 2, KindId = QuestComponentKind.Progress };
+        progress.ActTemplates.Add(new QuestActObjMonsterHunt(progress) { NpcId = 4175, HighlightDoodadId = 999 });
+        template.Components[progress.Id] = progress;
+
+        QuestTalkDoodadRules.AddTalkDoodads(template, dest);
+
+        await Assert.That(dest.Contains(999)).IsFalse();
+    }
+
+    [Test]
+    public async Task ExceptTowerAlmighty_RemovesEventTargets()
+    {
+        var dest = new HashSet<uint> { 14178, 8410 };
+        QuestTalkDoodadRules.ExceptTowerAlmighty(dest, new HashSet<uint> { 8410 });
+
+        await Assert.That(dest.Contains(14178)).IsTrue();
+        await Assert.That(dest.Contains(8410)).IsFalse();
+    }
+
+    [Test]
+    public async Task Plan_SkipsJsonDuplicate_DoesNotInventMissing()
+    {
+        var wanted = new HashSet<uint> { 14178, 14177 };
+        var catalog = new[]
+        {
+            new QuestTalkDoodadRules.Placement(14178, 10267.32f, 15267.89f, 239.54f, 90f)
+        };
+        var existing = new[]
+        {
+            new QuestTalkDoodadRules.Existing(14178, 10267.32f, 15267.89f, 239.54f)
+        };
+
+        var planned = QuestTalkDoodadRules.Plan(wanted, catalog, existing);
+
+        await Assert.That(planned).IsEmpty();
+    }
+
+    [Test]
+    public async Task Plan_SpawnsCatalogRowWhenWorldEmpty()
+    {
+        var wanted = new HashSet<uint> { 14178 };
+        var catalog = new[]
+        {
+            new QuestTalkDoodadRules.Placement(14178, 10267.32f, 15267.89f, 239.54f, 45f)
+        };
+
+        var planned = QuestTalkDoodadRules.Plan(wanted, catalog, []);
+
+        await Assert.That(planned.Count).IsEqualTo(1);
+        await Assert.That(planned[0].TemplateId).IsEqualTo(14178u);
+        await Assert.That(planned[0].X).IsEqualTo(10267.32f);
+        await Assert.That(planned[0].YawDegrees).IsEqualTo(45f);
+    }
+
+    [Test]
+    public async Task TryParseNpcTypeModel_ReadsNpcId()
+    {
+        await Assert.That(QuestTalkDoodadRules.TryParseNpcTypeModel("npctype://11966", out var feos)).IsTrue();
+        await Assert.That(feos).IsEqualTo(11966u);
+        await Assert.That(QuestTalkDoodadRules.TryParseNpcTypeModel("cgf://x", out _)).IsFalse();
+        await Assert.That(QuestTalkDoodadRules.TryParseNpcTypeModel("npctype://0", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task PlanCompanions_TakesPadNpcTypeRows_SkipsFarAndTalkSelf()
+    {
+        var talkIds = new HashSet<uint> { 14226 };
+        var talk = new[]
+        {
+            new QuestTalkDoodadRules.Placement(14226, 11546.626f, 11829.929f, 110.011f, 0f)
+        };
+        var npcType = new[]
+        {
+            new QuestTalkDoodadRules.Placement(14226, 11546.626f, 11829.929f, 110.011f, 0f),
+            new QuestTalkDoodadRules.Placement(14227, 11544.631f, 11827.183f, 110.172f, 0f),
+            new QuestTalkDoodadRules.Placement(14228, 11538.821f, 11828.881f, 110.356f, 0f),
+            new QuestTalkDoodadRules.Placement(14228, 11547.599f, 11823.275f, 110.101f, 0f),
+            new QuestTalkDoodadRules.Placement(14178, 11468.733f, 11550.127f, 124.619f, 0f)
+        };
+
+        var planned = QuestTalkDoodadRules.PlanCompanions(talkIds, talk, npcType, []);
+
+        await Assert.That(planned.Any(p => p.TemplateId == 14226)).IsFalse();
+        await Assert.That(planned.Count(p => p.TemplateId == 14227)).IsEqualTo(1);
+        await Assert.That(planned.Count(p => p.TemplateId == 14228)).IsEqualTo(2);
+        await Assert.That(planned.Any(p => p.TemplateId == 14178)).IsFalse();
+    }
+
+    [Test]
+    public async Task PlanCompanions_SkipsExisting_DoesNotInvent()
+    {
+        var talkIds = new HashSet<uint> { 14226 };
+        var talk = new[]
+        {
+            new QuestTalkDoodadRules.Placement(14226, 11546.626f, 11829.929f, 110.011f, 0f)
+        };
+        var npcType = new[]
+        {
+            new QuestTalkDoodadRules.Placement(14227, 11544.631f, 11827.183f, 110.172f, 0f)
+        };
+        var existing = new[]
+        {
+            new QuestTalkDoodadRules.Existing(14227, 11544.631f, 11827.183f, 110.172f)
+        };
+
+        var planned = QuestTalkDoodadRules.PlanCompanions(talkIds, talk, npcType, existing);
+
+        await Assert.That(planned).IsEmpty();
+        await Assert.That(
+            QuestTalkDoodadRules.PlanCompanions(talkIds, talk, [], [])).IsEmpty();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Quests/QuestTalkNpcRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Quests/QuestTalkNpcRulesTests.cs
@@ -1,0 +1,61 @@
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.Quests.Acts;
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Quests.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Quests;
+
+public class QuestTalkNpcRulesTests
+{
+    [Test]
+    public async Task AcceptAndReport_AreTalkNpcs()
+    {
+        var dest = new HashSet<uint>();
+        QuestTalkNpcRules.AddTalkNpcs(TemplateWith(
+            start => start.ActTemplates.Add(new QuestActConAcceptNpc(start) { NpcId = 7816 }),
+            ready => ready.ActTemplates.Add(new QuestActConReportNpc(ready) { NpcId = 7816 })), dest);
+
+        await Assert.That(QuestTalkNpcRules.IsTalkNpc(dest, 7816)).IsTrue();
+        await Assert.That(QuestTalkNpcRules.IsTalkNpc(dest, 1)).IsFalse();
+    }
+
+    [Test]
+    public async Task HuntNpc_IsNotTalkNpc()
+    {
+        var dest = new HashSet<uint>();
+        var template = new QuestTemplate { Id = 1 };
+        var progress = new QuestComponentTemplate(template) { Id = 2, KindId = QuestComponentKind.Progress };
+        progress.ActTemplates.Add(new QuestActObjMonsterHunt(progress) { NpcId = 4175 });
+        template.Components[progress.Id] = progress;
+        QuestTalkNpcRules.AddTalkNpcs(template, dest);
+
+        await Assert.That(QuestTalkNpcRules.IsTalkNpc(dest, 4175)).IsFalse();
+    }
+
+    [Test]
+    public async Task TalkObjective_IsTalkNpc()
+    {
+        var dest = new HashSet<uint>();
+        var template = new QuestTemplate { Id = 1 };
+        var progress = new QuestComponentTemplate(template) { Id = 2, KindId = QuestComponentKind.Progress };
+        progress.ActTemplates.Add(new QuestActObjTalk(progress) { NpcId = 4220 });
+        template.Components[progress.Id] = progress;
+        QuestTalkNpcRules.AddTalkNpcs(template, dest);
+
+        await Assert.That(QuestTalkNpcRules.IsTalkNpc(dest, 4220)).IsTrue();
+    }
+
+    private static QuestTemplate TemplateWith(
+        Action<QuestComponentTemplate> startFill,
+        Action<QuestComponentTemplate> readyFill)
+    {
+        var template = new QuestTemplate { Id = 2386 };
+        var start = new QuestComponentTemplate(template) { Id = 10256, KindId = QuestComponentKind.Start };
+        startFill(start);
+        var ready = new QuestComponentTemplate(template) { Id = 10255, KindId = QuestComponentKind.Ready };
+        readyFill(ready);
+        template.Components[start.Id] = start;
+        template.Components[ready.Id] = ready;
+        return template;
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/SkillCastOverlapRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/SkillCastOverlapRulesTests.cs
@@ -1,0 +1,78 @@
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Effects;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills;
+
+public class SkillCastOverlapRulesTests
+{
+    [Test]
+    public async Task FlameboltComboHits_AreInstantCombo()
+    {
+        await Assert.That(SkillCastOverlapRules.IsInstantComboHit(0, 10)).IsTrue();
+        await Assert.That(SkillCastOverlapRules.BypassesSharedCastGate(0, 10)).IsTrue();
+        await Assert.That(SkillCastOverlapRules.IsInstantComboHit(1000, 1000)).IsFalse();
+        await Assert.That(SkillCastOverlapRules.IsInstantComboHit(0, 0)).IsFalse();
+        await Assert.That(SkillCastOverlapRules.IsInstantComboHit(0, 1000)).IsFalse();
+        await Assert.That(SkillCastOverlapRules.ArmsSharedGlobalCooldown(0, 10)).IsTrue();
+        await Assert.That(SkillCastOverlapRules.ArmsSharedGlobalCooldown(1000, 1000)).IsTrue();
+        await Assert.That(SkillCastOverlapRules.ArmsSharedGlobalCooldown(0, 0)).IsFalse();
+    }
+
+    [Test]
+    public async Task ComboHit_DoesNotCancelParentPlot()
+    {
+        await Assert.That(SkillCastOverlapRules.ShouldCancelPreviousPlot(
+            previousWasBusy: true,
+            incomingIsInstantCombo: true,
+            incomingSameSkill: false,
+            sportFishWouldCancel: true)).IsFalse();
+    }
+
+    [Test]
+    public async Task SameSkillRepeat_DoesNotCancelInFlightPlot()
+    {
+        await Assert.That(SkillCastOverlapRules.ShouldCancelPreviousPlot(
+            previousWasBusy: true,
+            incomingIsInstantCombo: false,
+            incomingSameSkill: true,
+            sportFishWouldCancel: true)).IsFalse();
+    }
+
+    [Test]
+    public async Task ComboFollowUpPlot_IsNotCancelledByParent()
+    {
+        await Assert.That(SkillCastOverlapRules.ShouldCancelPreviousPlot(
+            previousWasBusy: true,
+            incomingIsInstantCombo: false,
+            incomingSameSkill: false,
+            sportFishWouldCancel: true,
+            previousIsComboFollowUpOfIncoming: true)).IsFalse();
+    }
+
+    [Test]
+    public async Task OtherSkill_StillCancelsABusyPlot()
+    {
+        await Assert.That(SkillCastOverlapRules.ShouldCancelPreviousPlot(
+            previousWasBusy: true,
+            incomingIsInstantCombo: false,
+            incomingSameSkill: false,
+            sportFishWouldCancel: true)).IsTrue();
+        await Assert.That(SkillCastOverlapRules.ShouldCancelPreviousPlot(
+            previousWasBusy: false,
+            incomingIsInstantCombo: false,
+            incomingSameSkill: false,
+            sportFishWouldCancel: false)).IsFalse();
+    }
+
+    [Test]
+    public async Task FishingHoldSwap_StillCancelsThroughSportFishRule()
+    {
+        var holdSwap = SportFishCombat.ShouldCancelPreviousPlot(true, previousWasHold: true, incomingIsHold: true);
+        await Assert.That(holdSwap).IsTrue();
+        await Assert.That(SkillCastOverlapRules.ShouldCancelPreviousPlot(
+            previousWasBusy: true,
+            incomingIsInstantCombo: false,
+            incomingSameSkill: false,
+            sportFishWouldCancel: holdSwap)).IsTrue();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/SkillCastOverlapRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/SkillCastOverlapRulesTests.cs
@@ -1,4 +1,4 @@
-using AAEmu.Game.Models.Game.Skills;
+﻿using AAEmu.Game.Models.Game.Skills;
 using AAEmu.Game.Models.Game.Skills.Effects;
 
 namespace AAEmu.UnitTests.Game.Models.Game.Skills;
@@ -13,9 +13,11 @@ public class SkillCastOverlapRulesTests
         await Assert.That(SkillCastOverlapRules.IsInstantComboHit(1000, 1000)).IsFalse();
         await Assert.That(SkillCastOverlapRules.IsInstantComboHit(0, 0)).IsFalse();
         await Assert.That(SkillCastOverlapRules.IsInstantComboHit(0, 1000)).IsFalse();
-        await Assert.That(SkillCastOverlapRules.ArmsSharedGlobalCooldown(0, 10)).IsTrue();
-        await Assert.That(SkillCastOverlapRules.ArmsSharedGlobalCooldown(1000, 1000)).IsTrue();
-        await Assert.That(SkillCastOverlapRules.ArmsSharedGlobalCooldown(0, 0)).IsFalse();
+        await Assert.That(SkillCastOverlapRules.ArmsSharedGlobalCooldown(0, 10, false)).IsTrue();
+        await Assert.That(SkillCastOverlapRules.ArmsSharedGlobalCooldown(1000, 1000, false)).IsTrue();
+        await Assert.That(SkillCastOverlapRules.ArmsSharedGlobalCooldown(0, 0, false)).IsFalse();
+        // Skill 10025 shape: default_gcd only, and it must still arm the default.
+        await Assert.That(SkillCastOverlapRules.ArmsSharedGlobalCooldown(5000, 0, true)).IsTrue();
     }
 
     [Test]

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/SkillComboRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/SkillComboRulesTests.cs
@@ -1,0 +1,68 @@
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Effects;
+using AAEmu.Game.Models.Game.Skills.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills;
+
+public class SkillComboRulesTests
+{
+    private const uint Root = 1;
+    private const uint Second = 2;
+    private const uint Third = 3;
+
+    private static uint? NextOf(uint id) => id switch
+    {
+        Root => Second,
+        Second => Third,
+        _ => null
+    };
+
+    [Test]
+    public async Task TryGetComboFollowUp_ReadsComboSpecialOnly()
+    {
+        var template = new SkillTemplate
+        {
+            Effects =
+            [
+                new SkillEffect
+                {
+                    Template = new SpecialEffect
+                    {
+                        SpecialEffectTypeId = SpecialType.Cooldown,
+                        Value1 = 1000
+                    }
+                },
+                new SkillEffect
+                {
+                    Template = new SpecialEffect
+                    {
+                        SpecialEffectTypeId = SpecialType.Combo,
+                        Value1 = 22,
+                        Value2 = 1000
+                    }
+                }
+            ]
+        };
+
+        await Assert.That(SkillComboRules.TryGetComboFollowUp(template, out var next, out var delay)).IsTrue();
+        await Assert.That(next).IsEqualTo(22u);
+        await Assert.That(delay).IsEqualTo(1000);
+        await Assert.That(SkillComboRules.TryGetComboFollowUp(new SkillTemplate(), out _, out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task WalkChain_FollowsComboLinks()
+    {
+        var chain = SkillComboRules.WalkChain(Second, NextOf);
+        await Assert.That(chain).IsEquivalentTo(new uint[] { Second, Third });
+    }
+
+    [Test]
+    public async Task IsComboFollowUpOf_FindsSecondAndThirdHit()
+    {
+        await Assert.That(SkillComboRules.IsComboFollowUpOf(Root, Second, NextOf)).IsTrue();
+        await Assert.That(SkillComboRules.IsComboFollowUpOf(Root, Third, NextOf)).IsTrue();
+        await Assert.That(SkillComboRules.IsComboFollowUpOf(Root, Root, NextOf)).IsFalse();
+        await Assert.That(SkillComboRules.IsComboFollowUpOf(Second, Root, NextOf)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/SkillGcdRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/SkillGcdRulesTests.cs
@@ -1,0 +1,22 @@
+using AAEmu.Game.Models.Game.Skills;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills;
+
+public class SkillGcdRulesTests
+{
+    [Test]
+    public async Task SpellGcd_UsesCastSpeedNotAttackSpeed()
+    {
+        await Assert.That(SkillGcdRules.SharedGcdMultiplier(false, globalCooldownMul: 50f, castTimeMul: 1f))
+            .IsEqualTo(1f);
+        await Assert.That(SkillGcdRules.SharedGcdMultiplier(false, globalCooldownMul: 100f, castTimeMul: 0.8f))
+            .IsEqualTo(0.8f);
+    }
+
+    [Test]
+    public async Task WeaponGcd_UsesAttackSpeed()
+    {
+        await Assert.That(SkillGcdRules.SharedGcdMultiplier(true, globalCooldownMul: 50f, castTimeMul: 1f))
+            .IsEqualTo(0.5f);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Slaves/SlaveHealthCapRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Slaves/SlaveHealthCapRulesTests.cs
@@ -1,0 +1,34 @@
+using AAEmu.Game.Models.Game.Slaves;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Slaves;
+
+public class SlaveHealthCapRulesTests
+{
+    [Test]
+    public async Task FullBar_FollowsARaisedCap()
+    {
+        await Assert.That(SlaveHealthCapRules.AfterMaxHpChanged(95000, 95000, 104500))
+            .IsEqualTo(104500);
+    }
+
+    [Test]
+    public async Task DamagedBar_StaysDamaged()
+    {
+        await Assert.That(SlaveHealthCapRules.AfterMaxHpChanged(40000, 95000, 104500))
+            .IsEqualTo(40000);
+    }
+
+    [Test]
+    public async Task OverCapSaved_ClampsWhenNotFullAgainstOldMax()
+    {
+        // Saved Ezi-full HP vs the bare cap still counts as full, so kit/Ezi raise stays full.
+        await Assert.That(SlaveHealthCapRules.AfterMaxHpChanged(104500, 85000, 95000))
+            .IsEqualTo(95000);
+    }
+
+    [Test]
+    public async Task NewMaxZero_DoesNotGoNegative()
+    {
+        await Assert.That(SlaveHealthCapRules.AfterMaxHpChanged(10, 10, 0)).IsEqualTo(10);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Teleport/ReturnPointFileRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Teleport/ReturnPointFileRulesTests.cs
@@ -1,0 +1,117 @@
+using AAEmu.Game.Models.Game.Teleport;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Teleport;
+
+public class ReturnPointFileRulesTests
+{
+    [Test]
+    public async Task Prefix_StripsReturnPoint()
+    {
+        await Assert.That(ReturnPointFileRules.TryEditorNameFromObject("ReturnPoint_sample", out var name)).IsTrue();
+        await Assert.That(name).IsEqualTo("sample");
+        await Assert.That(ReturnPointFileRules.TryEditorNameFromObject("returnpoint_sample", out name)).IsTrue();
+        await Assert.That(name).IsEqualTo("sample");
+        await Assert.That(ReturnPointFileRules.TryEditorNameFromObject("\"ReturnPoint_sample\"", out name)).IsTrue();
+        await Assert.That(name).IsEqualTo("sample");
+        await Assert.That(ReturnPointFileRules.TryEditorNameFromObject("ReturnPoint_", out _)).IsFalse();
+        await Assert.That(ReturnPointFileRules.TryEditorNameFromObject("other_sample", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task Parse_ReadsLocalPosAndZRot()
+    {
+        const string body = """
+            object
+                name ReturnPoint_sample
+                pos ( x 1320.18, y 1580.35, z 109.345 )
+                zRot 1.16937
+                radius 3
+            object
+                name ReturnPoint_skip_me
+                pos ( x 1, y 2, z 3 )
+            """;
+
+        var rows = ReturnPointFileRules.Parse(body, 133);
+        await Assert.That(rows.Count).IsEqualTo(2);
+        await Assert.That(rows[0].EditorName).IsEqualTo("sample");
+        await Assert.That(rows[0].ZoneKey).IsEqualTo(133u);
+        await Assert.That(rows[0].X).IsEqualTo(1320.18f);
+        await Assert.That(rows[0].Y).IsEqualTo(1580.35f);
+        await Assert.That(rows[0].Z).IsEqualTo(109.345f);
+        await Assert.That(rows[0].ZRotRadians).IsEqualTo(1.16937f);
+        await Assert.That(rows[1].EditorName).IsEqualTo("skip_me");
+        await Assert.That(rows[1].ZRotRadians).IsEqualTo(0f);
+    }
+
+    [Test]
+    public async Task Parse_SkipsUnknownNameAndZeroZone()
+    {
+        await Assert.That(ReturnPointFileRules.Parse("object\n    name NotAReturn\n    pos ( x 1, y 2, z 3 )\n", 10).Count)
+            .IsEqualTo(0);
+        await Assert.That(ReturnPointFileRules.Parse("object\n    name ReturnPoint_sample\n    pos ( x 1, y 2, z 3 )\n", 0).Count)
+            .IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Match_UsesEditorNameDictionary()
+    {
+        var map = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase) { ["sample"] = 9 };
+        await Assert.That(ReturnPointFileRules.TryGetReturnPointId(map, "sample", out var id)).IsTrue();
+        await Assert.That(id).IsEqualTo(9u);
+        await Assert.That(ReturnPointFileRules.TryGetReturnPointId(map, "SAMPLE", out id)).IsTrue();
+        await Assert.That(id).IsEqualTo(9u);
+        await Assert.That(ReturnPointFileRules.TryGetReturnPointId(map, "missing", out _)).IsFalse();
+        await Assert.That(ReturnPointFileRules.TryGetReturnPointId(null, "sample", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task JsonOrRecall_WinsOverLevelFile()
+    {
+        await Assert.That(ReturnPointFileRules.ShouldUseLevelFile(false, false)).IsTrue();
+        await Assert.That(ReturnPointFileRules.ShouldUseLevelFile(true, false)).IsFalse();
+        await Assert.That(ReturnPointFileRules.ShouldUseLevelFile(false, true)).IsFalse();
+        await Assert.That(ReturnPointFileRules.ShouldUseLevelFile(true, true)).IsFalse();
+    }
+
+    [Test]
+    public async Task ToWorld_AddsOriginCells()
+    {
+        var (x, y, z) = ReturnPointFileRules.ToWorld(10, 10, 1320.18f, 1580.35f, 109.345f);
+        await Assert.That(x).IsEqualTo(11560.18f);
+        await Assert.That(y).IsEqualTo(11820.35f);
+        await Assert.That(z).IsEqualTo(109.345f);
+    }
+
+    [Test]
+    public async Task YawDegrees_FromZRotRadians()
+    {
+        var yaw = ReturnPointFileRules.YawDegreesFromZRot(MathF.PI);
+        await Assert.That(MathF.Abs(yaw - 180f)).IsLessThan(0.01f);
+    }
+
+    [Test]
+    public async Task Catalog_ReadsZoneFolderFile()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "aaemu-rp-" + Guid.NewGuid().ToString("N"));
+        var dir = Path.Combine(root, "worlds", "main_world", "level_design", "zone", "133", "world_server");
+        Directory.CreateDirectory(dir);
+        await File.WriteAllTextAsync(
+            Path.Combine(dir, "return_point.g"),
+            """
+            object
+                name ReturnPoint_sample
+                pos ( x 1, y 2, z 3 )
+            """);
+        try
+        {
+            var rows = ReturnPointGCatalog.LoadFromRoots([root]);
+            await Assert.That(rows.Count).IsEqualTo(1);
+            await Assert.That(rows[0].ZoneKey).IsEqualTo(133u);
+            await Assert.That(rows[0].EditorName).IsEqualTo("sample");
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Teleport/ReturnTeleportRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Teleport/ReturnTeleportRulesTests.cs
@@ -1,0 +1,34 @@
+using AAEmu.Game.Models.Game.Teleport;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Teleport;
+
+public class ReturnTeleportRulesTests
+{
+    [Test]
+    public async Task SameInstance_DoesNotLoad()
+    {
+        await Assert.That(ReturnTeleportRules.NeedsInstanceLoad(0, 0)).IsFalse();
+        await Assert.That(ReturnTeleportRules.NeedsInstanceLoad(1, 1)).IsFalse();
+        await Assert.That(ReturnTeleportRules.NeedsInstanceLoad(0, 1)).IsTrue();
+        await Assert.That(ReturnTeleportRules.NeedsInstanceLoad(2, 0)).IsTrue();
+    }
+
+    [Test]
+    public async Task Origin_IsNeverAReturnDestination()
+    {
+        await Assert.That(ReturnTeleportRules.HasValidDestination(0f, 0f, 0f)).IsFalse();
+        await Assert.That(ReturnTeleportRules.HasValidDestination(11791.4f, 11799.6f, 136.5f)).IsTrue();
+        await Assert.That(ReturnTeleportRules.HasValidDestination(21204.3f, 10428.6f, 107.5f)).IsTrue();
+        await Assert.That(ReturnTeleportRules.HasValidDestination(0f, 1f, 0f)).IsTrue();
+        await Assert.That(ReturnTeleportRules.ShouldApplyEndedPosition(0f, 0f, 0f)).IsFalse();
+        await Assert.That(ReturnTeleportRules.ShouldApplyEndedPosition(11791.4f, 11799.6f, 136.5f)).IsTrue();
+    }
+
+    [Test]
+    public async Task LoadWorld_UsesPortalWhenSet()
+    {
+        await Assert.That(ReturnTeleportRules.LoadWorldId(0, 0)).IsEqualTo(0u);
+        await Assert.That(ReturnTeleportRules.LoadWorldId(1, 0)).IsEqualTo(1u);
+        await Assert.That(ReturnTeleportRules.LoadWorldId(0, 1)).IsEqualTo(1u);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Units/Movements/UnitIdleMoveRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Units/Movements/UnitIdleMoveRulesTests.cs
@@ -1,0 +1,61 @@
+using AAEmu.Game.Models.Game.Units.Movements;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Units.Movements;
+
+public class UnitIdleMoveRulesTests
+{
+    [Test]
+    public async Task StationaryStand_AtKnownPose_IsSuppressed()
+    {
+        await Assert.That(UnitIdleMoveRules.ShouldSuppress(
+            19628f, 28276f, 295f, 0, 0, 10,
+            19628f, 28276f, 295f, 0, 0, 10,
+            0, 0, 0, 0, 0, 0)).IsTrue();
+    }
+
+    [Test]
+    public async Task QuantizedNoise_InsideBand_IsSuppressed()
+    {
+        await Assert.That(UnitIdleMoveRules.ShouldSuppress(
+            19628f, 28276f, 295f, 0, 0, 10,
+            19628.1f, 28276.05f, 295.02f, 0, 0, 10,
+            0, 0, 0, 0, 0, 0)).IsTrue();
+    }
+
+    [Test]
+    public async Task WalkVelocity_IsRelayed()
+    {
+        await Assert.That(UnitIdleMoveRules.ShouldSuppress(
+            19628f, 28276f, 295f, 0, 0, 10,
+            19628f, 28276f, 295f, 0, 0, 10,
+            40, 0, 0, 0, 0, 0)).IsFalse();
+    }
+
+    [Test]
+    public async Task RealStep_IsRelayed()
+    {
+        await Assert.That(UnitIdleMoveRules.ShouldSuppress(
+            19628f, 28276f, 295f, 0, 0, 10,
+            19629f, 28276f, 295f, 0, 0, 10,
+            0, 0, 0, 0, 0, 0)).IsFalse();
+    }
+
+    [Test]
+    public async Task TurnInPlace_IsRelayed()
+    {
+        await Assert.That(UnitIdleMoveRules.ShouldSuppress(
+            19628f, 28276f, 295f, 0, 0, 10,
+            19628f, 28276f, 295f, 0, 0, 40,
+            0, 0, 0, 0, 0, 0)).IsFalse();
+    }
+
+    [Test]
+    public async Task SectorLine_DoesNotSuppressARealCrossing()
+    {
+        // 28288 is a 64 m region edge. A metre of travel must stay live.
+        await Assert.That(UnitIdleMoveRules.ShouldSuppress(
+            19660f, 28287.6f, 295f, 0, 0, 0,
+            19660f, 28288.8f, 295f, 0, 0, 0,
+            0, 0, 0, 0, 0, 0)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Units/Movements/UnitIdleMoveRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Units/Movements/UnitIdleMoveRulesTests.cs
@@ -1,4 +1,4 @@
-using AAEmu.Game.Models.Game.Units.Movements;
+﻿using AAEmu.Game.Models.Game.Units.Movements;
 
 namespace AAEmu.UnitTests.Game.Models.Game.Units.Movements;
 
@@ -20,6 +20,25 @@ public class UnitIdleMoveRulesTests
             19628f, 28276f, 295f, 0, 0, 10,
             19628.1f, 28276.05f, 295.02f, 0, 0, 10,
             0, 0, 0, 0, 0, 0)).IsTrue();
+    }
+
+    [Test]
+    public async Task WrappedHeading_IsStillStationary()
+    {
+        // 85 and -42 are one step apart on the 128-step heading circle.
+        await Assert.That(UnitIdleMoveRules.ShouldSuppress(
+            19628f, 28276f, 295f, 85, 0, 10,
+            19628f, 28276f, 295f, -42, 0, 10,
+            0, 0, 0, 0, 0, 0)).IsTrue();
+    }
+
+    [Test]
+    public async Task OppositeHeading_IsRelayed()
+    {
+        await Assert.That(UnitIdleMoveRules.ShouldSuppress(
+            19628f, 28276f, 295f, 0, 0, 10,
+            19628f, 28276f, 295f, 64, 0, 10,
+            0, 0, 0, 0, 0, 0)).IsFalse();
     }
 
     [Test]

--- a/AAEmu.UnitTests/Game/Models/Game/Units/QuestContextUnitReqRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Units/QuestContextUnitReqRulesTests.cs
@@ -1,0 +1,29 @@
+using AAEmu.Game.Models.Game.Quests.Static;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Units;
+
+public class QuestContextUnitReqRulesTests
+{
+    [Test]
+    public async Task JournalProgress_CountsRegardlessOfStep()
+    {
+        await Assert.That(QuestContextUnitReqRules.IsInProgress(QuestStatus.Progress)).IsTrue();
+    }
+
+    [Test]
+    public async Task ReadyOrCompleted_IsNotInProgress()
+    {
+        await Assert.That(QuestContextUnitReqRules.IsInProgress(QuestStatus.Ready)).IsFalse();
+        await Assert.That(QuestContextUnitReqRules.IsInProgress(QuestStatus.Completed)).IsFalse();
+        await Assert.That(QuestContextUnitReqRules.IsInProgress(QuestStatus.Dropped)).IsFalse();
+        await Assert.That(QuestContextUnitReqRules.IsInProgress(QuestStatus.Failed)).IsFalse();
+    }
+
+    [Test]
+    public async Task MissingQuest_IsNotInProgress()
+    {
+        await Assert.That(QuestContextUnitReqRules.IsInProgress(null)).IsFalse();
+        await Assert.That(QuestContextUnitReqRules.IsInProgress(QuestStatus.Invalid)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Units/UnitReqTargetNpcGroupRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Units/UnitReqTargetNpcGroupRulesTests.cs
@@ -1,0 +1,28 @@
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Units;
+
+public class UnitReqTargetNpcGroupRulesTests
+{
+    [Test]
+    public async Task Value2Zero_RequiresMembership()
+    {
+        await Assert.That(UnitReqTargetNpcGroupRules.Passes(true, true, 0)).IsTrue();
+        await Assert.That(UnitReqTargetNpcGroupRules.Passes(true, false, 0)).IsFalse();
+    }
+
+    [Test]
+    public async Task Value2NonZero_InvertsMembership()
+    {
+        await Assert.That(UnitReqTargetNpcGroupRules.Passes(true, false, 1)).IsTrue();
+        await Assert.That(UnitReqTargetNpcGroupRules.Passes(true, true, 1)).IsFalse();
+    }
+
+    [Test]
+    public async Task NonNpcTarget_AlwaysFails()
+    {
+        await Assert.That(UnitReqTargetNpcGroupRules.Passes(false, false, 0)).IsFalse();
+        await Assert.That(UnitReqTargetNpcGroupRules.Passes(false, false, 1)).IsFalse();
+        await Assert.That(UnitReqTargetNpcGroupRules.Passes(false, true, 1)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Units/ZoneDeadUnitRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Units/ZoneDeadUnitRulesTests.cs
@@ -1,0 +1,14 @@
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Units;
+
+public class ZoneDeadUnitRulesTests
+{
+    [Test]
+    public async Task AcceptsZoneSkill_OnlyWhileAlive()
+    {
+        await Assert.That(ZoneDeadUnitRules.AcceptsZoneSkill(1)).IsTrue();
+        await Assert.That(ZoneDeadUnitRules.AcceptsZoneSkill(0)).IsFalse();
+        await Assert.That(ZoneDeadUnitRules.AcceptsZoneSkill(-1)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/World/AreaSphereHitRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/World/AreaSphereHitRulesTests.cs
@@ -1,0 +1,91 @@
+using System.Numerics;
+using AAEmu.Game.Models.Game.World;
+
+namespace AAEmu.UnitTests.Game.Models.Game.World;
+
+public class AreaSphereHitRulesTests
+{
+    private static SphereQuest Area(uint sphereId, Vector3 center, float radius) =>
+        new() { SphereId = sphereId, Xyz = center, Radius = radius };
+
+    private static SphereQuest Sign(uint componentId, Vector3 center, float radius) =>
+        new() { ComponentId = componentId, Xyz = center, Radius = radius };
+
+    [Test]
+    public async Task AreaSphereId_HitsEvenWhenSignQuestIsEmpty()
+    {
+        var pos = new Vector3(10f, 20f, 30f);
+        var hit = AreaSphereHitRules.FindHit(
+            1448,
+            pos,
+            requiredComponentId: 18562,
+            areaSpheresAtPosition: [Area(1448, pos, 8f)],
+            signSpheresForLinkedQuest: []);
+
+        await Assert.That(hit).IsNotNull();
+        await Assert.That(hit.SphereId).IsEqualTo(1448u);
+    }
+
+    [Test]
+    public async Task WrongAreaId_DoesNotHit()
+    {
+        var pos = new Vector3(10f, 20f, 30f);
+        var hit = AreaSphereHitRules.FindHit(
+            1448,
+            pos,
+            requiredComponentId: 0,
+            areaSpheresAtPosition: [Area(708, pos, 8f)],
+            signSpheresForLinkedQuest: []);
+
+        await Assert.That(hit).IsNull();
+    }
+
+    [Test]
+    public async Task OutsideRadius_Misses()
+    {
+        var center = new Vector3(10f, 20f, 30f);
+        var hit = AreaSphereHitRules.FindHit(
+            1448,
+            center + new Vector3(50f, 0f, 0f),
+            requiredComponentId: 0,
+            areaSpheresAtPosition: [Area(1448, center, 8f)],
+            signSpheresForLinkedQuest: []);
+
+        await Assert.That(hit).IsNull();
+    }
+
+    [Test]
+    public async Task SignFallback_NeedsMatchingComponentWhenAsked()
+    {
+        var pos = new Vector3(1f, 2f, 3f);
+        var miss = AreaSphereHitRules.FindHit(
+            1448,
+            pos,
+            requiredComponentId: 18562,
+            areaSpheresAtPosition: [],
+            signSpheresForLinkedQuest: [Sign(0, pos, 8f)]);
+        var hit = AreaSphereHitRules.FindHit(
+            1448,
+            pos,
+            requiredComponentId: 18562,
+            areaSpheresAtPosition: [],
+            signSpheresForLinkedQuest: [Sign(18562, pos, 8f)]);
+
+        await Assert.That(miss).IsNull();
+        await Assert.That(hit).IsNotNull();
+    }
+
+    [Test]
+    public async Task ZeroSphereId_Misses()
+    {
+        var pos = new Vector3(1f, 2f, 3f);
+        var hit = AreaSphereHitRules.FindHit(
+            0,
+            pos,
+            requiredComponentId: 0,
+            areaSpheresAtPosition: [Area(1448, pos, 8f)],
+            signSpheresForLinkedQuest: []);
+
+        await Assert.That(hit).IsNull();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/World/VisibleObjectResendRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/World/VisibleObjectResendRulesTests.cs
@@ -1,0 +1,22 @@
+using AAEmu.Game.Models.Game.World;
+
+namespace AAEmu.UnitTests.Game.Models.Game.World;
+
+public class VisibleObjectResendRulesTests
+{
+    [Test]
+    public async Task CinemaDrop_RepaintsEvenWhenAlreadyStreamed()
+    {
+        await Assert.That(VisibleObjectResendRules.ShouldRepaintMirror(true, true)).IsTrue();
+        await Assert.That(VisibleObjectResendRules.ShouldRepaintMirror(false, true)).IsTrue();
+        await Assert.That(VisibleObjectResendRules.ShouldResendDoodadCreates(true)).IsTrue();
+    }
+
+    [Test]
+    public async Task TeleportOrLogin_SkipsAlreadyStreamed()
+    {
+        await Assert.That(VisibleObjectResendRules.ShouldRepaintMirror(true, false)).IsFalse();
+        await Assert.That(VisibleObjectResendRules.ShouldRepaintMirror(false, false)).IsTrue();
+        await Assert.That(VisibleObjectResendRules.ShouldResendDoodadCreates(false)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/World/WorldLevelInfoRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/World/WorldLevelInfoRulesTests.cs
@@ -1,0 +1,80 @@
+using AAEmu.Game.Models.Game.World;
+
+namespace AAEmu.UnitTests.Game.Models.Game.World;
+
+public class WorldLevelInfoRulesTests
+{
+    [Test]
+    public async Task UnlockRow_IsTheFirstGetQuestAtCap()
+    {
+        var row = WorldLevelInfoRules.SelectUnlockRow(CompactHardCaps(), playerLevelCap: 55);
+
+        await Assert.That(row.MinServerDays).IsEqualTo(9);
+        await Assert.That(row.HardCapLevel).IsEqualTo(55);
+        await Assert.That(row.GetQuest).IsTrue();
+    }
+
+    [Test]
+    public async Task ForCharacter_AtCap_UsesUnlockWorldLevelNotCaptureSlots()
+    {
+        var info = WorldLevelInfoRules.ForCharacter(55, 55, CompactHardCaps(), CompactModifiers());
+
+        await Assert.That(info.WorldLevel).IsEqualTo(55u);
+        await Assert.That(info.ServerDays).IsEqualTo(9u);
+        await Assert.That(info.ExpModifier).IsEqualTo(10000u);
+        await Assert.That(info.HardCapLevel).IsEqualTo(55u);
+        await Assert.That(info.CharacterLevel).IsEqualTo(55u);
+        await Assert.That(info.LevelDiff).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task ForCharacter_BelowWorld_UsesTheUnderLevelExpBand()
+    {
+        var info = WorldLevelInfoRules.ForCharacter(30, 55, CompactHardCaps(), CompactModifiers());
+
+        await Assert.That(info.WorldLevel).IsEqualTo(55u);
+        await Assert.That(info.LevelDiff).IsEqualTo(-25);
+        await Assert.That(info.ExpModifier).IsEqualTo(20000u);
+    }
+
+    [Test]
+    public async Task ServerOpenUnixTime_AgesPastTheUnlockRow()
+    {
+        const long now = 1_778_000_000;
+        var open = WorldLevelInfoRules.ServerOpenUnixTime(now, unlockMinServerDays: 9);
+
+        await Assert.That(open).IsEqualTo(now - 10L * WorldLevelInfoRules.SecondsPerDay);
+        await Assert.That(open).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task ServerOpenUnixTime_NeverReturnsZero()
+    {
+        var open = WorldLevelInfoRules.ServerOpenUnixTime(1, unlockMinServerDays: 9);
+
+        await Assert.That(open).IsEqualTo(1L);
+    }
+
+    [Test]
+    public async Task MissingGetQuestRow_FailsLoudly()
+    {
+        var lockedOnly = new[] { new WorldLevelHardCapRow(0, 1, 28, GetQuest: false) };
+
+        await Assert.That(() => WorldLevelInfoRules.SelectUnlockRow(lockedOnly, 55))
+            .Throws<InvalidOperationException>();
+    }
+
+    private static WorldLevelHardCapRow[] CompactHardCaps() =>
+    [
+        new(0, 1, 28, false),
+        new(6, 6, 50, false),
+        new(9, 9999, 55, true)
+    ];
+
+    private static WorldLevelExpModifierRow[] CompactModifiers() =>
+    [
+        new(-999, -10, 20000),
+        new(-1, 1, 10000),
+        new(10, 999, 5000)
+    ];
+}

--- a/AAEmu.UnitTests/World/Core/Relay/ZoneDoodadPlacementCatalogTests.cs
+++ b/AAEmu.UnitTests/World/Core/Relay/ZoneDoodadPlacementCatalogTests.cs
@@ -1,3 +1,4 @@
+using AAEmu.Game.Models.Game.Quests;
 using AAEmu.World.Core.Relay;
 
 namespace AAEmu.UnitTests.World.Core.Relay;
@@ -62,6 +63,128 @@ public class ZoneDoodadPlacementCatalogTests
         finally
         {
             File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task ParseFile_011_011Pad_ConvertsEhnoirAndFeosToWorld()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"doodad_3901_{Guid.NewGuid():N}.g");
+        await File.WriteAllTextAsync(path, """
+            doodad
+                category 17
+                type 14226
+                family 0
+                vegetation false
+                pos ( x 282.626, y 565.929, z 110.011 )
+                ori ( x 0, y 0, z 0.951057, w 0.309017 )
+                scale 1
+            doodad
+                category 17
+                type 14227
+                family 0
+                vegetation false
+                pos ( x 280.631, y 563.183, z 110.172 )
+                ori ( x 0, y 0, z -0.325568, w 0.945519 )
+                scale 1
+            doodad
+                category 17
+                type 14220
+                family 0
+                vegetation false
+                pos ( x 204.733, y 286.127, z 124.619 )
+                ori ( x 0, y 0, z 0.0174524, w 0.999848 )
+                scale 1
+            """);
+        try
+        {
+            var list = ZoneDoodadPlacementCatalog.ParseFile(path, cellX: 11, cellY: 11);
+            await Assert.That(list.Count).IsEqualTo(3);
+            await Assert.That(list[0].TemplateId).IsEqualTo(14226u);
+            await Assert.That(list[0].X).IsEqualTo(11546.626f).Within(0.001f);
+            await Assert.That(list[0].Y).IsEqualTo(11829.929f).Within(0.001f);
+            await Assert.That(list[1].TemplateId).IsEqualTo(14227u);
+            await Assert.That(list[1].X).IsEqualTo(11544.631f).Within(0.001f);
+            await Assert.That(list[1].Y).IsEqualTo(11827.183f).Within(0.001f);
+            await Assert.That(list[2].TemplateId).IsEqualTo(14220u);
+            await Assert.That(list[2].X).IsEqualTo(11468.733f).Within(0.001f);
+            await Assert.That(list[2].Y).IsEqualTo(11550.127f).Within(0.001f);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task GetByTemplates_ThenPlanCompanions_TakesPadSkipsPlaza()
+    {
+        const string world = "companion_plan_test_world";
+        ZoneDoodadPlacementCatalog.SeedIndexForTests(world,
+        [
+            new(14226, 11546.626f, 11829.929f, 110.011f, 0f),
+            new(14227, 11544.631f, 11827.183f, 110.172f, 0f),
+            new(14228, 11538.821f, 11828.881f, 110.356f, 0f),
+            new(14178, 11468.733f, 11550.127f, 124.619f, 0f)
+        ]);
+        try
+        {
+            var talk = ToRules(ZoneDoodadPlacementCatalog.GetByTemplates(world, [14226u]));
+            var npcType = ToRules(
+                ZoneDoodadPlacementCatalog.GetByTemplates(world, [14226u, 14227u, 14228u, 14178u]));
+            var planned = QuestTalkDoodadRules.PlanCompanions([14226u], talk, npcType, []);
+
+            await Assert.That(planned.Any(p => p.TemplateId == 14227)).IsTrue();
+            await Assert.That(planned.Count(p => p.TemplateId == 14228)).IsEqualTo(1);
+            await Assert.That(planned.Any(p => p.TemplateId is 14226 or 14178)).IsFalse();
+        }
+        finally
+        {
+            ZoneDoodadPlacementCatalog.Invalidate(world);
+        }
+    }
+
+    private static List<QuestTalkDoodadRules.Placement> ToRules(
+        IReadOnlyList<ZoneDoodadPlacementCatalog.DoodadPlacement> catalog)
+    {
+        var list = new List<QuestTalkDoodadRules.Placement>(catalog.Count);
+        foreach (var p in catalog)
+            list.Add(new QuestTalkDoodadRules.Placement(p.TemplateId, p.X, p.Y, p.Z, p.YawDegrees));
+        return list;
+    }
+
+    [Test]
+    public async Task ParseIgnoreDoodadTypes_ReadsOpenAndIgnoreLists()
+    {
+        var ids = ZoneDoodadPlacementCatalog.ParseIgnoreDoodadTypes("""
+            ignore_spawners
+                doodadType 8411
+                doodadType 8412
+            """);
+        await Assert.That(ids.SetEquals([8411u, 8412u])).IsTrue();
+        await Assert.That(ZoneDoodadPlacementCatalog.IsIgnoreListFileName("doodad_open_03.g")).IsTrue();
+        await Assert.That(ZoneDoodadPlacementCatalog.IsIgnoreListFileName("ignore_doodad_spawners_01.g")).IsTrue();
+        await Assert.That(ZoneDoodadPlacementCatalog.IsIgnoreListFileName("doodad.g")).IsFalse();
+    }
+
+    [Test]
+    public async Task GetByTemplates_MarksIgnoredPermanentFromSeed()
+    {
+        const string world = "ignore_flag_test_world";
+        ZoneDoodadPlacementCatalog.SeedIndexForTests(world,
+        [
+            new(14226, 11546.626f, 11829.929f, 110.011f, 0f),
+            new(8411, 20113.5f, 21012.5f, 102.8f, 0f, IgnoredPermanent: true)
+        ]);
+        try
+        {
+            var list = ZoneDoodadPlacementCatalog.GetByTemplates(world, [14226u, 8411u]);
+            await Assert.That(list.Single(p => p.TemplateId == 14226).IgnoredPermanent).IsFalse();
+            await Assert.That(list.Single(p => p.TemplateId == 8411).IgnoredPermanent).IsTrue();
+        }
+        finally
+        {
+            ZoneDoodadPlacementCatalog.Invalidate(world);
         }
     }
 

--- a/AAEmu.UnitTests/World/Core/Zone/UnitRegistryTests.cs
+++ b/AAEmu.UnitTests/World/Core/Zone/UnitRegistryTests.cs
@@ -1,0 +1,42 @@
+using AAEmu.World.Core.Zone;
+
+namespace AAEmu.UnitTests.World.Core.Zone;
+
+public class UnitRegistryTests
+{
+    [Test]
+    public async Task ExhaustedLiveSkips_DropsTheUnitInsteadOfReusingAnOccupiedId()
+    {
+        var registry = new UnitRegistry();
+        var allocated = 0u;
+        var calls = 0;
+
+        var bcId = registry.Register(
+            [1, 2, 3],
+            () =>
+            {
+                calls++;
+                return ++allocated;
+            },
+            _ => true);
+
+        await Assert.That(bcId).IsEqualTo(0u);
+        await Assert.That(registry.Count).IsEqualTo(0);
+        await Assert.That(calls).IsGreaterThan(1);
+    }
+
+    [Test]
+    public async Task FirstIdGameDoesNotOwn_IsRegistered()
+    {
+        var registry = new UnitRegistry();
+        var allocated = 0u;
+
+        var bcId = registry.Register([4, 5, 6], () => ++allocated, candidate => candidate < 3);
+
+        await Assert.That(bcId).IsEqualTo(3u);
+        await Assert.That(registry.Count).IsEqualTo(1);
+        await Assert.That(registry.Contains(3)).IsTrue();
+        await Assert.That(registry.TryGet(3, out var body)).IsTrue();
+        await Assert.That(body).IsEquivalentTo(new byte[] { 4, 5, 6 });
+    }
+}

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/CombatRelay.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/CombatRelay.cs
@@ -211,6 +211,12 @@ public class CombatRelay
             return false;
         }
 
+        if (!ZoneDeadUnitRules.AcceptsZoneSkill(casterUnit.Hp))
+        {
+            Logger.Info("ZWStartSkill skip dead caster={0} skill={1} hp={2}", casterId, skillId, casterUnit.Hp);
+            return true;
+        }
+
         if (casterUnit is Character character &&
             HeirGameData.Instance.TryGetHeirSkillForSuccessor(skillId, out _, out _) &&
             !character.HeirSkills.IsActiveSuccessor(skillId))

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/MovementRelay.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/MovementRelay.cs
@@ -210,6 +210,29 @@ public class MovementRelay
     }
 
     /// <summary>Copies zone-owned NPC and mate positions onto their World mirrors.</summary>
+    private static bool ShouldSuppressIdleUnitMove(uint bcId, UnitMoveType move)
+    {
+        if (WorldIntegration.FindUnitAcrossWorlds(bcId) is not Unit unit ||
+            unit is not Npc && unit is not Mate)
+            return false;
+
+        var pos = unit.Transform?.World;
+        if (pos == null)
+            return false;
+
+        var (rx, ry, rz) = pos.ToRollPitchYawSBytesMovement();
+        var delta = move.DeltaMovement ?? [0, 0, 0];
+        return UnitIdleMoveRules.ShouldSuppress(
+            pos.Position.X, pos.Position.Y, pos.Position.Z,
+            rx, ry, rz,
+            move.X, move.Y, move.Z,
+            move.RotationX, move.RotationY, move.RotationZ,
+            move.VelX, move.VelY, move.VelZ,
+            delta.Length > 0 ? delta[0] : (sbyte)0,
+            delta.Length > 1 ? delta[1] : (sbyte)0,
+            delta.Length > 2 ? delta[2] : (sbyte)0);
+    }
+
     private static void ApplyCombatUnitPosition(uint bcId, UnitMoveType move, ZoneConnection source)
     {
         if (DisableHullPositionSync)
@@ -595,6 +618,10 @@ public class MovementRelay
                 {
                     // NPC / mate World mirrors lagged ZWUnitMovements so Skill.Use range and mate
                     // chase measured stale centers (TooFarRange 5–9 m). Hulls use ApplyHullPosition.
+                    // Idle stands (every unit, every tick when movement-skip is off) must not
+                    // rewrite Transform or hit SC — that is the plaza flicker with many zones up.
+                    if (ShouldSuppressIdleUnitMove(bcId, unitMove))
+                        continue;
                     ApplyCombatUnitPosition(bcId, unitMove, source);
                 }
 

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/QuestTalkDoodads.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/QuestTalkDoodads.cs
@@ -1,0 +1,157 @@
+using AAEmu.Game;
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Models;
+using AAEmu.Game.Core.Managers.UnitManagers;
+using AAEmu.Game.Core.Managers.World;
+using AAEmu.Game.GameData;
+using AAEmu.Game.Models.Game.DoodadObj;
+using AAEmu.Game.Models.Game.Quests;
+using AAEmu.Game.Models.Game.World;
+using AAEmu.Game.Models.Game.World.Transform;
+using AAEmu.Game.Utils;
+
+using NLog;
+
+namespace AAEmu.World.Core.Relay;
+
+/// <summary>
+/// World-authors level-pack doodads from <c>cells/*/doodad.g</c> that
+/// <c>doodad_spawns.json</c> never exported: quest talk/func, <c>client_doodad</c>,
+/// and <c>npctype://</c> scene bodies (3901 Feos 14227). Coordinates come from
+/// <see cref="ZoneDoodadPlacementCatalog"/> only. Cell ignore/open lists and
+/// tower DoodadAlmighty stay off the permanent plant. No live NPC for those models.
+/// </summary>
+public static class QuestTalkDoodads
+{
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+
+    private static bool Disabled =>
+        Environment.GetEnvironmentVariable("AAEMU_DISABLE_LEVEL_PACK_DOODADS") == "1" ||
+        Environment.GetEnvironmentVariable("AAEMU_DISABLE_QUEST_TALK_DOODADS") == "1";
+
+    public static void EnsureAllWorlds()
+    {
+        if (Disabled)
+            return;
+
+        var worlds = WorldManager.Instance.GetWorlds();
+        if (worlds == null)
+            return;
+
+        foreach (var world in worlds)
+            Ensure(world);
+    }
+
+    public static void Ensure(WorldInstance world)
+    {
+        if (Disabled || world?.Template == null || !AppConfiguration.Instance.World.SpawnDoodads)
+            return;
+
+        var wanted = new HashSet<uint>(QuestManager.Instance.GetQuestTalkDoodadIds());
+        DoodadManager.Instance.AddQuestFuncTemplateIds(wanted);
+        DoodadManager.Instance.AddClientDoodadTemplateIds(wanted);
+        DoodadManager.Instance.AddNpcTypeTemplateIds(wanted);
+        QuestTalkDoodadRules.ExceptTowerAlmighty(
+            wanted,
+            TowerDefGameData.Instance.GetDoodadAlmightyTargetIds());
+        wanted.RemoveWhere(id =>
+            GameScheduleManager.Instance.CheckDoodadInScheduleSpawners((int)id));
+        if (wanted.Count == 0)
+            return;
+
+        var worldName = world.Template.Name;
+        var catalog = ZoneDoodadPlacementCatalog.GetByTemplates(worldName, wanted);
+        var places = new List<QuestTalkDoodadRules.Placement>(catalog.Count);
+        foreach (var p in catalog)
+        {
+            if (p.IgnoredPermanent)
+                continue;
+            places.Add(new QuestTalkDoodadRules.Placement(p.TemplateId, p.X, p.Y, p.Z, p.YawDegrees));
+        }
+
+        var existing = ListExisting(world, wanted);
+        var planned = QuestTalkDoodadRules.Plan(wanted, places, existing);
+        if (planned.Count == 0)
+        {
+            Logger.Info(
+                "LevelPackDoodads world={0} wanted={1} catalog={2} already present or no .g row",
+                worldName, wanted.Count, places.Count);
+            return;
+        }
+
+        var spawned = 0;
+        foreach (var place in planned)
+        {
+            if (!DoodadManager.Instance.Exist(place.TemplateId))
+            {
+                Logger.Warn("LevelPackDoodads unknown doodad template {0}", place.TemplateId);
+                continue;
+            }
+
+            var zoneId = WorldManager.Instance.GetZoneId(world.Template, place.X, place.Y);
+            if (zoneId == 0)
+            {
+                Logger.Warn(
+                    "LevelPackDoodads tpl={0} at {1:0.##},{2:0.##} has no zone — not spawning",
+                    place.TemplateId, place.X, place.Y);
+                continue;
+            }
+
+            var spawner = new DoodadSpawner
+            {
+                ParentWorld = world,
+                Id = 0,
+                UnitId = place.TemplateId,
+                Position = new WorldSpawnPosition
+                {
+                    WorldId = world.Id,
+                    X = place.X,
+                    Y = place.Y,
+                    Z = place.Z,
+                    ZoneId = zoneId,
+                    Yaw = place.YawDegrees.DegToRad()
+                }
+            };
+
+            Doodad doodad;
+            try
+            {
+                doodad = spawner.Spawn(0);
+            }
+            catch (Exception ex)
+            {
+                Logger.Warn(ex, "LevelPackDoodads spawn failed tpl={0}", place.TemplateId);
+                continue;
+            }
+
+            if (doodad == null || doodad.ObjId == 0)
+            {
+                Logger.Warn("LevelPackDoodads tpl={0} spawn returned no objId", place.TemplateId);
+                continue;
+            }
+
+            spawned++;
+        }
+
+        Logger.Info(
+            "LevelPackDoodads world={0} wanted={1} catalog={2} spawned={3}",
+            worldName, wanted.Count, places.Count, spawned);
+    }
+
+    private static List<QuestTalkDoodadRules.Existing> ListExisting(WorldInstance world, HashSet<uint> wanted)
+    {
+        var list = new List<QuestTalkDoodadRules.Existing>();
+        foreach (var id in wanted)
+        {
+            foreach (var doodad in world.GetDoodadsByTemplateId(id))
+            {
+                var pos = doodad.Transform?.World;
+                if (pos == null)
+                    continue;
+                list.Add(new QuestTalkDoodadRules.Existing(id, pos.Position.X, pos.Position.Y, pos.Position.Z));
+            }
+        }
+
+        return list;
+    }
+}

--- a/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneDoodadPlacementCatalog.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Relay/ZoneDoodadPlacementCatalog.cs
@@ -22,7 +22,8 @@ public static partial class ZoneDoodadPlacementCatalog
         float X,
         float Y,
         float Z,
-        float YawDegrees);
+        float YawDegrees,
+        bool IgnoredPermanent = false);
 
     /// <summary>All placements of <paramref name="templateId"/> in a world (empty when root/files missing).</summary>
     public static IReadOnlyList<DoodadPlacement> GetByTemplate(string worldName, uint templateId)
@@ -157,15 +158,19 @@ public static partial class ZoneDoodadPlacementCatalog
                 continue;
 
             files++;
+            var ignore = ReadCellIgnoreTemplateIds(cellDir);
             foreach (var place in ParsePlacements(path, cellX, cellY))
             {
-                if (!byTemplate.TryGetValue(place.TemplateId, out var list))
+                var row = ignore.Count == 0 || !ignore.Contains(place.TemplateId)
+                    ? place
+                    : place with { IgnoredPermanent = true };
+                if (!byTemplate.TryGetValue(row.TemplateId, out var list))
                 {
                     list = [];
-                    byTemplate[place.TemplateId] = list;
+                    byTemplate[row.TemplateId] = list;
                 }
 
-                list.Add(place);
+                list.Add(row);
                 placements++;
             }
         }
@@ -228,6 +233,53 @@ public static partial class ZoneDoodadPlacementCatalog
         return list;
     }
 
+    /// <summary>
+    /// <c>doodadType</c> ids from that cell's <c>doodad_open_*.g</c> /
+    /// <c>ignore_*doodad*.g</c> lists. Those rows stay in the catalog for
+    /// event steps; they are not a permanent boot plant.
+    /// </summary>
+    public static HashSet<uint> ParseIgnoreDoodadTypes(string text)
+    {
+        var set = new HashSet<uint>();
+        if (string.IsNullOrWhiteSpace(text))
+            return set;
+
+        foreach (Match m in IgnoreTypeRegex().Matches(text))
+        {
+            if (uint.TryParse(m.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var id) &&
+                id != 0)
+            {
+                set.Add(id);
+            }
+        }
+
+        return set;
+    }
+
+    private static HashSet<uint> ReadCellIgnoreTemplateIds(string cellDir)
+    {
+        var set = new HashSet<uint>();
+        foreach (var path in Directory.EnumerateFiles(cellDir, "*.g"))
+        {
+            var name = Path.GetFileName(path);
+            if (!IsIgnoreListFileName(name))
+                continue;
+            set.UnionWith(ParseIgnoreDoodadTypes(File.ReadAllText(path)));
+        }
+
+        return set;
+    }
+
+    internal static bool IsIgnoreListFileName(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+            return false;
+        if (fileName.StartsWith("doodad_open", StringComparison.OrdinalIgnoreCase))
+            return true;
+        return fileName.Contains("ignore", StringComparison.OrdinalIgnoreCase) &&
+               fileName.Contains("doodad", StringComparison.OrdinalIgnoreCase);
+    }
+
     private static bool TryF(string s, out float v) =>
         float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out v);
 
@@ -249,4 +301,7 @@ public static partial class ZoneDoodadPlacementCatalog
 
     [GeneratedRegex(@"(?m)^doodad\r?\n", RegexOptions.CultureInvariant)]
     private static partial Regex SplitDoodadBlocks();
+
+    [GeneratedRegex(@"doodadType\s+(\d+)", RegexOptions.CultureInvariant)]
+    private static partial Regex IgnoreTypeRegex();
 }

--- a/AAEmu.WorldServer/AAEmu.World/Core/Zone/UnitRegistry.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Zone/UnitRegistry.cs
@@ -1,5 +1,10 @@
 using System.Collections.Concurrent;
+
+using AAEmu.Game;
 using AAEmu.Game.Core.Managers.Id;
+using AAEmu.Game.Models.Game.NPChar;
+
+using NLog;
 
 namespace AAEmu.World.Core.Zone;
 
@@ -10,11 +15,26 @@ namespace AAEmu.World.Core.Zone;
 /// </summary>
 public class UnitRegistry
 {
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+    private const int MaxLiveIdSkips = 32;
     private readonly ConcurrentDictionary<uint, byte[]> _units = new();
 
     public uint Register(byte[] rawBody)
     {
-        var bcId = ObjectIdManager.Instance.GetNextId();
+        uint bcId = 0;
+        for (var i = 0; i < MaxLiveIdSkips; i++)
+        {
+            bcId = ObjectIdManager.Instance.GetNextId();
+            if (!ZoneMirrorIdRules.ShouldSkipAllocatedId(WorldIntegration.FindUnitAcrossWorlds(bcId) != null))
+            {
+                _units[bcId] = rawBody;
+                return bcId;
+            }
+
+            Logger.Warn("UnitRegistry skipped live bc={0} (still owned in Game)", bcId);
+        }
+
+        Logger.Error("UnitRegistry exhausted live-id skips, using bc={0}", bcId);
         _units[bcId] = rawBody;
         return bcId;
     }

--- a/AAEmu.WorldServer/AAEmu.World/Core/Zone/UnitRegistry.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Zone/UnitRegistry.cs
@@ -19,13 +19,20 @@ public class UnitRegistry
     private const int MaxLiveIdSkips = 32;
     private readonly ConcurrentDictionary<uint, byte[]> _units = new();
 
-    public uint Register(byte[] rawBody)
+    public uint Register(byte[] rawBody) => Register(rawBody, NextPoolId, IsOwnedByGame);
+
+    /// <summary>
+    /// Allocate the next bcId that Game does not already own. Exhaustion drops the unit
+    /// instead of reusing an occupied id: <c>MirrorZoneNpcSpawn</c> rejects a bcId another
+    /// unit still owns, while the zone keeps reusing that id, so the unit would never reach
+    /// Game or its clients.
+    /// </summary>
+    internal uint Register(byte[] rawBody, Func<uint> allocateId, Func<uint, bool> isOwnedByGame)
     {
-        uint bcId = 0;
         for (var i = 0; i < MaxLiveIdSkips; i++)
         {
-            bcId = ObjectIdManager.Instance.GetNextId();
-            if (!ZoneMirrorIdRules.ShouldSkipAllocatedId(WorldIntegration.FindUnitAcrossWorlds(bcId) != null))
+            var bcId = allocateId();
+            if (!ZoneMirrorIdRules.ShouldSkipAllocatedId(isOwnedByGame(bcId)))
             {
                 _units[bcId] = rawBody;
                 return bcId;
@@ -34,10 +41,16 @@ public class UnitRegistry
             Logger.Warn("UnitRegistry skipped live bc={0} (still owned in Game)", bcId);
         }
 
-        Logger.Error("UnitRegistry exhausted live-id skips, using bc={0}", bcId);
-        _units[bcId] = rawBody;
-        return bcId;
+        Logger.Error(
+            "UnitRegistry exhausted {0} live-id skips, unit not registered (every candidate is still owned in Game, bodyLen={1})",
+            MaxLiveIdSkips,
+            rawBody?.Length ?? 0);
+        return 0;
     }
+
+    private static uint NextPoolId() => ObjectIdManager.Instance.GetNextId();
+
+    private static bool IsOwnedByGame(uint bcId) => WorldIntegration.FindUnitAcrossWorlds(bcId) != null;
 
     public void RegisterWithId(uint bcId, byte[] rawBody)
     {

--- a/AAEmu.WorldServer/AAEmu.World/Core/Zone/UnitRegistry.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Core/Zone/UnitRegistry.cs
@@ -1,8 +1,7 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 
 using AAEmu.Game;
 using AAEmu.Game.Core.Managers.Id;
-using AAEmu.Game.Models.Game.NPChar;
 
 using NLog;
 
@@ -32,7 +31,7 @@ public class UnitRegistry
         for (var i = 0; i < MaxLiveIdSkips; i++)
         {
             var bcId = allocateId();
-            if (!ZoneMirrorIdRules.ShouldSkipAllocatedId(isOwnedByGame(bcId)))
+            if (!isOwnedByGame(bcId))
             {
                 _units[bcId] = rawBody;
                 return bcId;

--- a/AAEmu.WorldServer/AAEmu.World/Program.cs
+++ b/AAEmu.WorldServer/AAEmu.World/Program.cs
@@ -187,6 +187,7 @@ public static class Program
             // tracked units applies the same window rules as a live announcement.
             NpcScheduleGate.Start();
             NpcSpawnRelay.RemirrorAllZones();
+            QuestTalkDoodads.EnsureAllWorlds();
             zoneHost.ConfigureWarmWorldFactory(
                 templateName =>
                 {

--- a/SQL/aaemu_game.sql
+++ b/SQL/aaemu_game.sql
@@ -55,6 +55,14 @@ CREATE TABLE IF NOT EXISTS `character_bless_uthstin_pages` (
   PRIMARY KEY (`owner`, `page_index`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Bless Uthstin applied stats per page';
 
+CREATE TABLE IF NOT EXISTS `character_quest_cinema_end_effects` (
+  `owner` int unsigned NOT NULL,
+  `quest_id` int unsigned NOT NULL,
+  `cinema_id` int unsigned NOT NULL,
+  `component_id` int unsigned NOT NULL,
+  PRIMARY KEY (`owner`, `component_id`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Quest cinema-end effects still owed to the character';
+
 CREATE TABLE IF NOT EXISTS `character_arche_passes` (
   `owner` int unsigned NOT NULL,
   `pass_id` int unsigned NOT NULL,

--- a/SQL/updates/2026-09-11_aaemu_game_character_quest_cinema_end.sql
+++ b/SQL/updates/2026-09-11_aaemu_game_character_quest_cinema_end.sql
@@ -1,0 +1,14 @@
+USE aaemu_game;
+
+-- Quest cinema-end effects that are still owed to the character.
+-- A component that defers its buff or teleport until the film ends must survive a
+-- dropped connection: the client never reports the end and the quest step is already
+-- saved, so the row is replayed on the next login and cleared once applied.
+
+CREATE TABLE IF NOT EXISTS `character_quest_cinema_end_effects` (
+  `owner` int unsigned NOT NULL,
+  `quest_id` int unsigned NOT NULL,
+  `cinema_id` int unsigned NOT NULL,
+  `component_id` int unsigned NOT NULL,
+  PRIMARY KEY (`owner`, `component_id`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Quest cinema-end effects still owed to the character';


### PR DESCRIPTION
## Summary
- World-level stamp uses the compact `get_quest` band so main-quest Accept is not hidden behind a now `SCServerInfo` time.
- Quest cinema, report, talk, unit_req, and level-pack doodad pads (`.g` only) match the live 10.0 play we smoked.
- Hold-cast GCD, combo overlap, loot-group merge, and Zone death relay stop ghost NPCs and stacked plots.

## Test plan
- [ ] Relog so lobby `SCServerInfo` / `SCWorldLevelInfo` refresh; main-quest Accept is offered.
- [ ] Walk a starter quest through talk / cinema / report without a second click.
- [ ] 3901 Feos pad: F on doodad 14227 after Return 732, no `/spawn doodad`.
- [ ] Riven Gates kill step: mob corpses and stays dead; `/kill` is not needed.
- [ ] Hold-repeat a plot-only spell (Flamebolt family): one cast per GCD, no stacked plots.
- [ ] Return / hearth lands on a real point, not (0,0,0).
- [ ] `dotnet test AAEmu.UnitTests --treenode-filter` for the new `*RulesTests` / packet tests.
