### PR TITLE
feat(game): lunagem socket changes and socket level limits

### DIFF
--- a/AAEmu.Game/Core/Managers/IItemManager.cs
+++ b/AAEmu.Game/Core/Managers/IItemManager.cs
@@ -29,6 +29,9 @@ public interface IItemManager : ILoadable
     bool TryGetFishConversion(uint functionId, uint sourceItemId, out uint outputItemId);
     GradeDistributions GetGradeDistributions(byte id);
     uint GetSocketChance(uint numSockets);
+    uint GetSocketChangeTarget(uint enchantItemTemplateId, uint sourceGemTemplateId);
+    bool IsSocketChangeStone(uint enchantItemTemplateId);
+    uint GetSocketLevelLimit(uint gemTemplateId);
     float GetDurabilityRepairCostFactor();
     float GetDurabilityConst();
     float GetHoldableDurabilityConst();

--- a/AAEmu.Game/Core/Managers/ItemManager.cs
+++ b/AAEmu.Game/Core/Managers/ItemManager.cs
@@ -67,6 +67,21 @@ public class ItemManager(ISkillManager skillManager, IItemIdManager itemIdManage
 
     /// <summary>Which chance row a lunagem is seated under, by its item template.</summary>
     private Dictionary<uint, uint> _gemSocketChanceRow;
+
+    /// <summary>
+    /// Socket changes (<c>item_socket_changes</c>): a conversion or upgrade stone turns one seated gem
+    /// into another. Keyed by (stone template, seated gem template); the value is the gem it becomes.
+    /// </summary>
+    private Dictionary<(uint enchantItem, uint sourceGem), uint> _socketChanges;
+
+    /// <summary>Stones that change at least one gem, for a cheap "is this a socket change item" check.</summary>
+    private HashSet<uint> _socketChangeStones;
+
+    /// <summary>
+    /// The lowest equipment level a lunagem may be seated into (<c>item_socket_level_limits</c>), by
+    /// gem template. Zero means no limit.
+    /// </summary>
+    private Dictionary<uint, uint> _socketLevelLimits;
     private Dictionary<uint, List<BonusTemplate>> _itemUnitModifiers;
 
     // Loot related
@@ -235,6 +250,27 @@ public class ItemManager(ISkillManager skillManager, IItemIdManager itemIdManage
     {
         return !_gemSocketChanceRow.TryGetValue(gemTemplateId, out var rowId) ||
                _socketChanceFailBreaks.Contains(rowId);
+    }
+
+    /// <summary>
+    /// What the seated gem <paramref name="sourceGemTemplateId"/> becomes when the stone
+    /// <paramref name="enchantItemTemplateId"/> is used on it, or 0 when that stone does not touch it.
+    /// </summary>
+    public uint GetSocketChangeTarget(uint enchantItemTemplateId, uint sourceGemTemplateId)
+    {
+        return _socketChanges.GetValueOrDefault((enchantItemTemplateId, sourceGemTemplateId), 0u);
+    }
+
+    /// <summary>Whether an item template is a socket change stone at all.</summary>
+    public bool IsSocketChangeStone(uint enchantItemTemplateId)
+    {
+        return _socketChangeStones.Contains(enchantItemTemplateId);
+    }
+
+    /// <summary>The lowest equipment level this gem may be seated into; 0 when unrestricted.</summary>
+    public uint GetSocketLevelLimit(uint gemTemplateId)
+    {
+        return _socketLevelLimits.GetValueOrDefault(gemTemplateId, 0u);
     }
 
     public float GetDurabilityRepairCostFactor()
@@ -482,6 +518,9 @@ public class ItemManager(ISkillManager skillManager, IItemIdManager itemIdManage
         _socketNumLimits = [];
         _socketChanceFailBreaks = [];
         _gemSocketChanceRow = [];
+        _socketChanges = [];
+        _socketChangeStones = [];
+        _socketLevelLimits = [];
         _itemLookConverts = [];
         _holdableItemLookConverts = [];
         _wearableItemLookConverts = [];
@@ -1392,6 +1431,42 @@ public class ItemManager(ISkillManager skillManager, IItemIdManager itemIdManage
                         _gemSocketChanceRow[gemTemplateId] = reader.GetUInt32("item_socket_chance_id", 0);
                 }
             }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT enchant_item_id, source_item_id, target_item_id FROM item_socket_changes";
+                command.Prepare();
+                using var sqliteReader = command.ExecuteReader();
+                using var reader = new SQLiteWrapperReader(sqliteReader);
+                while (reader.Read())
+                {
+                    var stone = reader.GetUInt32("enchant_item_id", 0);
+                    var source = reader.GetUInt32("source_item_id", 0);
+                    var target = reader.GetUInt32("target_item_id", 0);
+                    if (stone == 0 || source == 0 || target == 0)
+                        continue;
+                    _socketChanges[(stone, source)] = target;
+                    _socketChangeStones.Add(stone);
+                }
+            }
+
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT item_id, level FROM item_socket_level_limits";
+                command.Prepare();
+                using var sqliteReader = command.ExecuteReader();
+                using var reader = new SQLiteWrapperReader(sqliteReader);
+                while (reader.Read())
+                {
+                    var gemTemplateId = reader.GetUInt32("item_id", 0);
+                    var level = reader.GetUInt32("level", 0);
+                    if (gemTemplateId != 0 && level > 0)
+                        _socketLevelLimits[gemTemplateId] = level;
+                }
+            }
+
+            Logger.Info("Loaded {0} socket changes for {1} stones and {2} socket level limits",
+                _socketChanges.Count, _socketChangeStones.Count, _socketLevelLimits.Count);
 
             // Load main item templates
 

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ItemSocketChange.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ItemSocketChange.cs
@@ -1,0 +1,192 @@
+using AAEmu.Game.Core.Managers;
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Items;
+using AAEmu.Game.Models.Game.Items.Actions;
+using AAEmu.Game.Models.Game.Units;
+
+namespace AAEmu.Game.Models.Game.Skills.Effects.SpecialEffects;
+
+/// <summary>
+/// Socket change (special effect type 169): a conversion or upgrade stone turns the lunagems already
+/// seated in a piece into other lunagems. No roll, and the other sockets are left alone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The stone's use-skill casts with the stone as the item caster and the piece as the item target,
+/// the same shape lunagem seating uses. <c>item_socket_changes</c> says, per stone, which seated
+/// gem becomes which. The gear window's upgrade tab only lets the player tick sockets whose gem the
+/// stone can change, and sends the ticked ones as a bit mask in the cast's first extra value, bit N
+/// for socket N.
+/// </para>
+/// <para>
+/// One stone and <c>value1</c> labor (200 on every shipped stone) per changed socket. The labor is
+/// what the stone's description says and what the tab shows next to its button. The stone count
+/// comes from the tab itself, which stops taking ticks once they equal the stones in the bag. The
+/// stones are not <c>use_skill_as_reagent</c> and their skill rows carry no
+/// <c>consume_source_item</c>, so the skill system leaves them in the bag and this effect takes
+/// them. The piece goes out on the item detail packet, the way seating does, and the socketing
+/// result packet closes the tab's run.
+/// </para>
+/// </remarks>
+public class ItemSocketChange : SpecialEffectAction
+{
+    protected override SpecialType SpecialEffectActionType => SpecialType.ItemSocketChange;
+
+    /// <summary>The client tells the tab apart from a gem seating by this kind.</summary>
+    private const byte KindSocketChange = 2;
+
+    public override void Execute(BaseUnit caster,
+        SkillCaster casterObj,
+        BaseUnit target,
+        SkillCastTarget targetObj,
+        CastAction castObj,
+        Skill skill,
+        SkillObject skillObject,
+        DateTime time,
+        int value1,
+        int value2,
+        int value3,
+        int value4)
+    {
+        Logger.Debug("Special effects: ItemSocketChange value1 {0}, value2 {1}, value3 {2}, value4 {3}", value1, value2, value3, value4);
+
+        if (caster is not Character owner)
+        {
+            Logger.Error($"Special effects: ItemSocketChange caster {caster?.Id} is not a character");
+            return;
+        }
+
+        if (casterObj is not SkillItem stoneSkillItem)
+        {
+            Logger.Error($"Special effects: ItemSocketChange casterObj {casterObj} is not a SkillItem");
+            return;
+        }
+
+        if (targetObj is not SkillCastItemTarget skillTargetItem)
+        {
+            Logger.Error($"Special effects: ItemSocketChange targetObj {targetObj} is not a SkillCastItemTarget");
+            return;
+        }
+
+        var targetItem = owner.Inventory.GetItemById(skillTargetItem.Id);
+        var stone = owner.Inventory.GetItemById(stoneSkillItem.ItemId);
+        if (targetItem is null || stone is null)
+        {
+            Logger.Warn($"Special effects: ItemSocketChange target {skillTargetItem.Id} or stone {stoneSkillItem.ItemId} not found");
+            return;
+        }
+
+        if (targetItem is not EquipItem equipItem)
+        {
+            owner.SendErrorMessage(ErrorMessageType.ItemCannotUse);
+            return;
+        }
+
+        if (!ItemManager.Instance.IsSocketChangeStone(stone.TemplateId))
+        {
+            Logger.Warn($"Special effects: ItemSocketChange item {stone.TemplateId} has no item_socket_changes rows");
+            owner.SendErrorMessage(ErrorMessageType.ItemCannotUse);
+            return;
+        }
+
+        // The sockets the tab ticked. A cast without the block, or with nothing ticked, is refused:
+        // the tab never sends one, and guessing "all of them" would spend stones the player did not
+        // put down.
+        var mask = SelectedSockets(skillObject);
+        if (mask == 0)
+        {
+            Logger.Warn($"Special effects: ItemSocketChange from {owner.Name} carried no socket mask");
+            owner.SendErrorMessage(ErrorMessageType.ItemCannotUse);
+            return;
+        }
+
+        var changes = new List<(int index, uint from, uint to)>();
+        for (var i = 0; i < equipItem.GemIds.Length; i++)
+        {
+            if ((mask & (1u << i)) == 0)
+                continue;
+            var seated = equipItem.GemIds[i];
+            if (seated == 0)
+                continue;
+            var becomes = ItemManager.Instance.GetSocketChangeTarget(stone.TemplateId, seated);
+            if (becomes != 0)
+                changes.Add((i, seated, becomes));
+        }
+
+        if (changes.Count == 0)
+        {
+            // A ticked socket holds nothing this stone changes. The tab greys those out itself, so
+            // this is a stale window or a hand-built cast.
+            owner.SendErrorMessage(ErrorMessageType.ItemCannotUse);
+            return;
+        }
+
+        var labor = Math.Max(0, value1) * changes.Count;
+        if (labor > 0 && owner.LaborPower + owner.LocalLaborPower < labor)
+        {
+            owner.SendErrorMessage(ErrorMessageType.NotEnoughLaborPower);
+            return;
+        }
+
+        // The stones go first, and the piece only changes once all of them are gone. The skill
+        // system does not take them (see above), and the bag can change between the check and the
+        // take, so a short take is put back and the cast refused.
+        if (!owner.Inventory.CheckItems(SlotType.Inventory, stone.TemplateId, changes.Count))
+        {
+            owner.SendErrorMessage(ErrorMessageType.NotEnoughItem);
+            return;
+        }
+
+        var consumed = owner.Inventory.ConsumeItem([SlotType.Inventory], ItemTaskType.ItemSocketChange,
+            stone.TemplateId, changes.Count, stone);
+        if (consumed < changes.Count)
+        {
+            Logger.Warn($"ItemSocketChange: {owner.Name} had {consumed} of {changes.Count} stones ({stone.TemplateId}), putting them back");
+            if (consumed > 0)
+                owner.Inventory.Bag.AcquireDefaultItem(ItemTaskType.ItemSocketChange, stone.TemplateId, consumed);
+            owner.SendErrorMessage(ErrorMessageType.NotEnoughItem);
+            return;
+        }
+
+        foreach (var (index, _, to) in changes)
+            equipItem.GemIds[index] = to;
+
+        if (labor > 0)
+            owner.ChangeLabor((short)-Math.Min(labor, short.MaxValue), 0);
+
+        equipItem.IsDirty = true;
+
+        // The piece goes out on the detail packet, as seating does; the tab re-reads it from the bag.
+        owner.SendPacket(new SCItemDetailUpdatedPacket(equipItem));
+        if (equipItem.SlotType == SlotType.Equipment)
+            owner.UpdateGearBonuses(null, null);
+
+        // Close the tab's run. The type is the gem the first ticked socket became, since the client's
+        // ITEM_SOCKET_UPGRADE notice names one gem.
+        owner.SendPacket(new SCItemSocketingLunagemResultPacket(1, equipItem.Id, changes[0].to, KindSocketChange, true));
+
+        Logger.Info("ItemSocketChange: {0} changed {1} socket(s) on item {2} with stone {3}: {4}",
+            owner.Name, changes.Count, equipItem.Id, stone.TemplateId,
+            string.Join(", ", changes.Select(c => $"[{c.index}] {c.from}->{c.to}")));
+
+        owner.BroadcastPacket(new SCSkillEndedPacket(skill.TlId), true);
+    }
+
+    /// <summary>
+    /// The socket bit mask the gear window sent with the cast, or 0 when the cast carried none.
+    /// </summary>
+    /// <remarks>
+    /// The tab hands its tick state to <c>X2ItemEnchant:Execute(selectSlotBit)</c> and the client
+    /// puts it, as is, in the first extra value. A cast with socket 1 ticked arrives as
+    /// <c>values=[00000001]</c> (flag 12, one value). Bit N is socket N, and nine sockets is all the
+    /// detail block has room for.
+    /// </remarks>
+    private static uint SelectedSockets(SkillObject skillObject)
+    {
+        if (skillObject is not SkillObjectExtraValues extras || extras.ReadCount == 0)
+            return 0;
+
+        return (uint)extras.Values[0] & ((1u << EquipItem.SocketSlots) - 1);
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ItemSocketing.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/ItemSocketing.cs
@@ -93,6 +93,15 @@ public class ItemSocketing : SpecialEffectAction
                 return;
             }
 
+            // item_socket_level_limits: a gem may only be seated into a piece of at least its level
+            // (the socket_target_level refusal). Zero, which most gems carry, means no restriction.
+            var levelLimit = ItemManager.Instance.GetSocketLevelLimit(gemItem.TemplateId);
+            if (levelLimit > 0 && (equipItem.Template?.Level ?? 0) < levelLimit)
+            {
+                owner.SendErrorMessage(ErrorMessageType.SocketTargetLevel);
+                return;
+            }
+
             // Formula 38 prices the attempt: it climbs with the gear's level, the gem's own level and
             // how many sockets are already filled. Charged before the roll, so a player who cannot
             // cover it keeps both their coin and their gem - and a failure that clears the item is


### PR DESCRIPTION
## What

Conversion and upgrade stones did nothing. Their use-skills carry special effect type 169 (`ItemSocketChange`), which had no implementation, and `item_socket_changes` (4815 rows, 75 stones) and `item_socket_level_limits` (762 rows, 194 with a level) were never read.

- `ItemManager` loads both tables.
- `ItemSocketChange` reads the sockets the gear window ticked from the cast's first extra value (bit mask, bit N for socket N), looks each seated gem up in `item_socket_changes` for the stone in hand, takes one stone and `value1` labor (200 on every shipped stone) per changed socket, rewrites the gems, and sends the piece on `SCItemDetailUpdatedPacket` followed by `SCItemSocketingLunagemResultPacket`, the way seating does. The stones are not `use_skill_as_reagent` and their skill rows have no `consume_source_item`, so the effect takes them itself.
- `ItemSocketing` refuses a gem seated into a piece below the gem's level limit with `socket_target_level`.

## One stone per socket

The client's upgrade tab (`X2ItemEnchant:SetSocketUpgradeSelect`) stops taking ticks once the ticked sockets equal the stones in the bag (checked with 2 and 3 stones) and charges 200 labor per tick. The stone's own description only mentions the labor.

## Review follow-up

- A cast without a socket mask, or with an empty one, is refused. It used to mean "every changeable socket".
- The stones are taken before the piece changes. A short take (the bag changed between the check and the take) puts the stones back and refuses the cast.

## Tested

Against the 10.0.2.13 client through the gear window:

- Seating a Copperglow Lunagem (43515) into a level-40 greatsword.
- One-socket change with Luna Charm Rank 1 (46151): 43515 to 46205, 200 labor, one stone.
- Three-socket change in one cast, mask `0x0E`, 600 labor.
- Two-socket change taking two stones and 400 labor.
- The change is in `items.details` after the next save, and the tab closes its run on the result packet.
- Level-limit refusal: the client blocks it first ("Requirements not met."), the server check covers hand-built casts. The labor and stone shortfall refusals are code-only for the same reason.