### PR TITLE
fix(game): skill cooldown gate, self-hit filter, teleport landings and seat rides

### DIFF
--- a/AAEmu.Game/Core/Packets/G2C/SCBlinkUnitPacket.cs
+++ b/AAEmu.Game/Core/Packets/G2C/SCBlinkUnitPacket.cs
@@ -4,7 +4,7 @@ using AAEmu.Game.Core.Network.Game;
 
 namespace AAEmu.Game.Core.Packets.G2C;
 
-public class SCBlinkUnitPacket(uint objId, float distance, float degree, float x, float y, float z)
+public class SCBlinkUnitPacket(uint objId, float distance, float degree, bool move3D, float x, float y, float z)
     : GamePacket(SCOffsets.SCBlinkUnitPacket, 1)
 {
     public override PacketStream Write(PacketStream stream)
@@ -12,6 +12,9 @@ public class SCBlinkUnitPacket(uint objId, float distance, float degree, float x
         stream.WriteBc(objId);
         stream.Write(distance);
         stream.Write(degree);
+        // Wire layout: a move3D flag sits between the degree pair and the position. Without it the body
+        // is one byte short and the position is parsed shifted, which loses the blink entirely.
+        stream.Write(move3D);
         stream.Write(Helpers.ConvertLongX(x));
         stream.Write(Helpers.ConvertLongY(y));
         stream.Write(z);

--- a/AAEmu.Game/Models/Game/Char/Character.cs
+++ b/AAEmu.Game/Models/Game/Char/Character.cs
@@ -2823,6 +2823,20 @@ public partial class Character : Unit, ICharacter
     }
 
     /// <summary>
+    /// Housing zones (the named housing areas drawn on top of a base zone) that cover the character's
+    /// current position. Empty when the position is in the open world.
+    /// </summary>
+    private List<uint> HousingZonesAtPosition()
+    {
+        var world = ParentWorld ?? WorldManager.Instance.MainWorld;
+        if (world?.Template == null)
+            return [];
+
+        var position = Transform.World.Position;
+        return SubZoneManager.Instance?.GetHousingZoneByPosition(world, position.X, position.Y) ?? [];
+    }
+
+    /// <summary>
     /// Recomputes <see cref="IsUnderWater"/> from the character's current transform.
     /// </summary>
     /// <remarks>
@@ -2895,6 +2909,19 @@ public partial class Character : Unit, ICharacter
 
     public override void OnZoneChange(uint lastZoneKey, uint newZoneKey)
     {
+        // A housing area is its own zone key on top of the base zone underneath it (base 213 -> housing
+        // 207). A teleport or position update inside the housing area re-resolves to the base key, which
+        // reads as a zone change and hands the character to a zone they never left — the World can only
+        // refuse that and send them to character select. While the character is still standing inside
+        // the housing zone they occupy, that zone wins.
+        if (HousingZoneRetentionRules.ShouldSuppressChange(lastZoneKey, newZoneKey, HousingZonesAtPosition()))
+        {
+            Transform.KeepZoneQuietly(lastZoneKey);
+            Logger.Info("Zone key {0} -> {1} suppressed for {2}: still inside housing zone {0}",
+                lastZoneKey, newZoneKey, Name);
+            return;
+        }
+
         base.OnZoneChange(lastZoneKey, newZoneKey); // Unit
 
         // SphereBuff volumes (dock Moored / Ezi / shipyard) are position-based. A zone-key change

--- a/AAEmu.Game/Models/Game/DoodadObj/BondDoodad.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/BondDoodad.cs
@@ -41,6 +41,12 @@ public class BondDoodad : PacketMarshaler
         _spot = spot;
     }
 
+    public uint SourceSkillId
+    {
+        get;
+        set;
+    }
+
     public void SetOwner(Doodad owner)
     {
         _owner = owner;
@@ -89,6 +95,13 @@ public class BondDoodad : PacketMarshaler
 
         character.BroadcastPacket(new SCUnbondDoodadPacket(character.ObjId, character.Id, doodadObjId), true);
         WorldIntegration.RelayBondDoodadToZone?.Invoke(character.ObjId, bonding, false);
+
+        // A seat can be a ride: the seat buff's Timeout trigger is what carries the rider (skills.id
+        // 40228 '층간 이동' applies it; its trigger casts the ride skill, which moves the rider a floor
+        // up), and leaving the seat is that moment — the rider never waits out the buff. Time out the
+        // buffs this seat skill applied so the trigger runs; other buff removals keep the natural-expiry
+        // rule, so this is scoped to the seat's own skill.
+        character.Buffs.TimeoutBuffsFromSkill(bonding.SourceSkillId);
         character.Buffs.TriggerRemoveOn(BuffRemoveOn.Unbond);
         return true;
     }

--- a/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncAttachment.cs
+++ b/AAEmu.Game/Models/Game/DoodadObj/Funcs/DoodadFuncAttachment.cs
@@ -33,7 +33,10 @@ public class DoodadFuncAttachment : DoodadFuncTemplate
                     return; // we leave if there is no place
                 }
 
-                character.Bonding = new BondDoodad(owner, AttachPointId, BondKindId, Space, spot);
+                character.Bonding = new BondDoodad(owner, AttachPointId, BondKindId, Space, spot)
+                {
+                    SourceSkillId = skillId
+                };
                 character.BroadcastPacket(new SCBondDoodadPacket(caster.ObjId, character.Bonding), true);
                 WorldIntegration.RelayBondDoodadToZone?.Invoke(character.ObjId, character.Bonding, true);
                 // SCBond is the client attach. Free seats stay unparented (CSMove world-space).

--- a/AAEmu.Game/Models/Game/Skills/BlinkLandingRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/BlinkLandingRules.cs
@@ -1,0 +1,15 @@
+using AAEmu.Game.Utils;
+
+namespace AAEmu.Game.Models.Game.Skills;
+
+/// <summary>
+/// Landing math for the Blink special effect. <c>value1</c> is the travel distance in metres and
+/// <c>value2</c> rotates the direction (±90° for the side-step and mirror blinks). The rotation used to
+/// be dropped server-side, so every blink was applied straight ahead while the client showed the
+/// sideways one and the resulting desync was corrected back by the zone.
+/// </summary>
+public static class BlinkLandingRules
+{
+    public static (float X, float Y) GetLanding(float x, float y, float casterYawDegrees, int distanceMetres, int offsetDegrees)
+        => MathUtil.AddDistanceToFrontDeg(distanceMetres, x, y, casterYawDegrees + offsetDegrees);
+}

--- a/AAEmu.Game/Models/Game/Skills/Buff.cs
+++ b/AAEmu.Game/Models/Game/Skills/Buff.cs
@@ -323,6 +323,18 @@ public class Buff
         StopEffectTask(replace, fireTimeout);
     }
 
+    /// <summary>
+    /// Ends this buff through its natural-timeout path: the Timeout triggers run and the buff is
+    /// removed, exactly as if its duration had elapsed. A seat ride uses this - the seat buff's Timeout
+    /// trigger is what carries the rider (skills.id 40228 '층간 이동' applies it, its trigger casts the
+    /// ride skill), and the ride happens when the rider leaves the seat, long before the buff's own
+    /// duration ends. Ordinary early removals must not use it - see <see cref="StopEffectTask"/>.
+    /// </summary>
+    public void TimeOut()
+    {
+        StopEffectTask(replace: false, fireTimeout: true);
+    }
+
     private void StopEffectTask(bool replace, bool fireTimeout)
     {
         lock (_lock)

--- a/AAEmu.Game/Models/Game/Skills/Buff.cs
+++ b/AAEmu.Game/Models/Game/Skills/Buff.cs
@@ -25,6 +25,7 @@ public class Buff
     protected static Logger Logger = LogManager.GetCurrentClassLogger();
 
     private readonly object _lock = new();
+    private bool _stopRan;
     private int _count;
 
     public uint Index { get; set; }
@@ -332,6 +333,9 @@ public class Buff
     /// </summary>
     public void TimeOut()
     {
+        if (State == EffectState.Finished)
+            return;
+
         StopEffectTask(replace: false, fireTimeout: true);
     }
 
@@ -339,6 +343,13 @@ public class Buff
     {
         lock (_lock)
         {
+            // A forced timeout (seat release) and the buff's own scheduled expiry can arrive together:
+            // the first one here ends the buff, the second must not run the triggers or dispel it again
+            // (that would send a duplicate removal to the client and relay it to the zone twice).
+            if (_stopRan)
+                return;
+            _stopRan = true;
+
             // Timeout triggers (buff_triggers.kind=timeout) fire only on natural expiry.
             // Early Exit (remove_on_move, purge, toggle-off, etc.) must not run them —
             // e.g. dash move-check 31556 Timeout → DispelEffect tag 4154 (질주 태그 / 2675).

--- a/AAEmu.Game/Models/Game/Skills/Effects/MoveToLocationEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/MoveToLocationEffect.cs
@@ -2,7 +2,9 @@ using AAEmu.Game.Core.Managers;
 using AAEmu.Game.Core.Packets;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Teleport;
 using AAEmu.Game.Models.Game.Units;
+using AAEmu.Game.Utils;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects;
 
@@ -54,26 +56,25 @@ public class MoveToLocationEffect : EffectTemplate
             return;
         }
 
-        // World routes players by Transform.ZoneId and fails closed, so recalling into a zone with no dedicate
-        // drops the character somewhere nobody simulates, with no NPCs and no way back. Refuse instead.
         var destinationZoneId = destination.Transform.ZoneId;
-        if (WorldIntegration.ZoneAuthority
-            && WorldIntegration.IsZoneLoaded != null
-            && !WorldIntegration.IsZoneLoaded(destinationZoneId))
+        if (!TeleportLandingRules.CanLandInZone(
+                WorldIntegration.ZoneAuthority, WorldIntegration.IsZoneLoaded, destinationZoneId))
         {
             Logger.Warn($"MoveToLocationEffect: refusing to recall {character.Name} to house {destination.Id}; zone {destinationZoneId} has no ZoneLoaded dedicate");
             character.SendErrorMessage(ErrorMessageType.InvalidHouseInfo);
             return;
         }
 
-        Logger.Debug($"MoveToLocationEffect: recalling {character.Name} to house {destination.Id}, ownHouseOnly {OwnHouseOnly}");
+        var landing = destination.Transform;
+        var position = landing.World.Position;
+        var yaw = landing.World.Rotation.Z.DegToRad();
+        Logger.Info("MoveToLocationEffect: recalling {0} to house {1} ({2:0.0}, {3:0.0}, {4:0.0})",
+            character.Name, destination.Id, position.X, position.Y, position.Z);
 
-        character.DisabledSetPosition = true;
-        character.SendPacket(new Core.Packets.G2C.SCTeleportUnitPacket(
-            0, 0,
-            destination.Transform.World.Position.X,
-            destination.Transform.World.Position.Y,
-            destination.Transform.World.Position.Z,
-            0f));
+        SkillTeleportLanding.Apply(character, landing.WorldId, landing.ZoneId, landing.InstanceId,
+            position.X, position.Y, position.Z, yaw, TeleportReason.MoveToLocation,
+            // Recalling to a house in the zone you are already standing in is not a zone change.
+            landing.ZoneId == character.Transform.ZoneId &&
+            landing.InstanceId == character.Transform.InstanceId);
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/MoveToRezPointEffect.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/MoveToRezPointEffect.cs
@@ -1,5 +1,7 @@
+using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Core.Packets;
 using AAEmu.Game.Models.Game.Skills.Templates;
+using AAEmu.Game.Models.Game.Teleport;
 using AAEmu.Game.Models.Game.Units;
 
 namespace AAEmu.Game.Models.Game.Skills.Effects;
@@ -25,17 +27,22 @@ public class MoveToRezPointEffect : EffectTemplate
         }
 
         // A destination nobody simulates would strand the character, exactly as with the house recall.
-        if (WorldIntegration.ZoneAuthority
-            && WorldIntegration.IsZoneLoaded != null
-            && !WorldIntegration.IsZoneLoaded(portal.ZoneId))
+        if (!TeleportLandingRules.CanLandInZone(
+                WorldIntegration.ZoneAuthority, WorldIntegration.IsZoneLoaded, portal.ZoneId))
         {
             Logger.Warn($"MoveToRezPointEffect: refusing to move {character.Name} to return point in zone {portal.ZoneId}; no ZoneLoaded dedicate");
             return;
         }
 
-        Logger.Debug($"MoveToRezPointEffect: moving {character.Name} to return point {returnPointId}");
+        var landingWorldId = ReturnTeleportRules.LoadWorldId(portal.WorldId, WorldManager.DefaultWorldTemplateId);
+        Logger.Info("MoveToRezPointEffect: moving {0} to return point {1} ({2:0.0}, {3:0.0}, {4:0.0})",
+            character.Name, returnPointId, portal.X, portal.Y, portal.Z);
 
-        character.DisabledSetPosition = true;
-        character.SendPacket(new Core.Packets.G2C.SCTeleportUnitPacket(0, 0, portal.X, portal.Y, portal.Z, 0f));
+        // Respawn points live in the main world, so the landing never crosses an instance.
+        SkillTeleportLanding.Apply(character, landingWorldId, portal.ZoneId, WorldManager.DefaultInstanceId,
+            portal.X, portal.Y, portal.Z, 0f, TeleportReason.Resurrect,
+            // Dying and resurrecting in the same zone is not a zone change either.
+            portal.ZoneId == character.Transform.ZoneId &&
+            WorldManager.DefaultInstanceId == character.Transform.InstanceId);
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Blink.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Blink.cs
@@ -30,9 +30,12 @@ public class Blink : SpecialEffectAction
         if (caster is not Character character)
             return;
 
-        using var newPos = character.Transform.CloneDetached();
-        newPos.Local.AddDistanceToFront(value1);
-        var dest = newPos.World.Position;
+        // value1 is the travel distance in metres; value2 is the direction offset in degrees, which is
+        // what the side-step (-90/90) and mirror blinks use. Compute the landing with the same rotation
+        // the client is told about, or the two disagree and the zone corrects the character back.
+        var start = character.Transform.World.Position;
+        var yawDegrees = character.Transform.World.ToRollPitchYawDegrees().Z;
+        var (destX, destY) = BlinkLandingRules.GetLanding(start.X, start.Y, yawDegrees, value1, value2);
 
         if (character.IsRiding)
         {
@@ -41,17 +44,21 @@ public class Blink : SpecialEffectAction
                 character.ParentWorld.MateManager.UnMountMate(character, mate.TlId, AttachPointKind.Driver, AttachUnitReason.None);
         }
 
-        character.SetPosition(dest.X, dest.Y, dest.Z,
-            character.Transform.World.Rotation.X,
-            character.Transform.World.Rotation.Y,
-            character.Transform.World.Rotation.Z);
-        character.SendPacket(new SCBlinkUnitPacket(caster.ObjId, value1, value2, dest.X, dest.Y, dest.Z));
-
+        // SetPosition writes the LOCAL transform, so convert the world landing first: a character bonded
+        // to a house seat or standing on a ship is parented, and a world result applied as local lands
+        // them one parent-offset away (a house-seat blink threw the character ~11 km). The packet keeps
+        // world coordinates — the client is world-space.
+        var local = character.Transform.GetLocalFromWorld(destX, destY, start.Z);
+        character.SetPosition(local.X, local.Y, local.Z,
+            character.Transform.Local.Rotation.X,
+            character.Transform.Local.Rotation.Y,
+            character.Transform.Local.Rotation.Z);
+        character.SendPacket(new SCBlinkUnitPacket(caster.ObjId, value1, value2, value3 != 0, destX, destY, start.Z));
         if (WorldIntegration.ZoneAuthority)
         {
             // baseUnitId = self for absolute blink; move3D when value3 requests vertical.
             WorldIntegration.RelayBlinkToZone?.Invoke(
-                character.ObjId, character.ObjId, value3 != 0, dest.X, dest.Y, dest.Z);
+                character.ObjId, character.ObjId, value3 != 0, destX, destY, start.Z);
         }
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Return.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/Return.cs
@@ -109,18 +109,13 @@ public class Return : SpecialEffectAction
         float z,
         float yawRad)
     {
-        if (ReturnTeleportRules.NeedsInstanceLoad(character.Transform.InstanceId, destInstanceId))
-        {
-            character.DisabledSetPosition = true;
-            character.SendPacket(new SCLoadInstancePacket(destWorldId, zoneId, x, y, z, 0, 0, yawRad));
-            character.Transform = new Transform(character, null, zoneId, destInstanceId, x, y, z, yawRad);
-        }
-        else
-        {
-            character.SetPosition(x, y, z, 0f, 0f, yawRad);
-            character.Transform.FinalizeTransform();
-        }
-
-        character.SendPacket(new SCTeleportUnitPacket(TeleportReason.MoveToLocation, 0, x, y, z, yawRad));
+        // Shared with the house recall and the return-to-rez-point effects so every skill-driven
+        // teleport lands the same way on the server and the client. A landing inside the zone the
+        // character already occupies must not re-resolve the zone from its coordinates - only a real
+        // cross-zone return goes through the handoff.
+        var stayInZone = zoneId == character.Transform.ZoneId &&
+                         destInstanceId == character.Transform.InstanceId;
+        SkillTeleportLanding.Apply(character, destWorldId, zoneId, destInstanceId, x, y, z, yawRad,
+            TeleportReason.MoveToLocation, stayInZone);
     }
 }

--- a/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/TeleportToUnit.cs
+++ b/AAEmu.Game/Models/Game/Skills/Effects/SpecialEffects/TeleportToUnit.cs
@@ -45,7 +45,22 @@ public class TeleportToUnit : SpecialEffectAction
         switch (caster)
         {
             case Character character:
-                character.SendPacket(new SCBlinkUnitPacket(caster.ObjId, 0f, 0f, endX, endY, targetPosition.Z));
+                // The blink packet only moves the client: the zone keeps simulating the character at the
+                // old spot and pulls it back, which reads as "the skill does not teleport me". Land the
+                // character server-side the same way the Blink effect does and tell the zone. The landing
+                // is world-space; SetPosition writes the local transform, so convert for a parented rider.
+                var local = character.Transform.GetLocalFromWorld(endX, endY, targetPosition.Z);
+                character.SetPosition(local.X, local.Y, local.Z,
+                    character.Transform.Local.Rotation.X,
+                    character.Transform.Local.Rotation.Y,
+                    character.Transform.Local.Rotation.Z);
+                character.SendPacket(new SCBlinkUnitPacket(caster.ObjId, 0f, 0f, false, endX, endY, targetPosition.Z));
+                if (WorldIntegration.ZoneAuthority)
+                {
+                    WorldIntegration.RelayBlinkToZone?.Invoke(
+                        character.ObjId, character.ObjId, false, endX, endY, targetPosition.Z);
+                }
+
                 break;
             case Npc npc:
                 npc.MoveTowards(targetPosition, 10000);

--- a/AAEmu.Game/Models/Game/Skills/Skill.cs
+++ b/AAEmu.Game/Models/Game/Skills/Skill.cs
@@ -213,6 +213,16 @@ public class Skill
                     return SkillResult.CooldownTime;
                 }
 
+                // The skill's own cooldown is armed on cast (Cast / plot-only fire edge) but was never
+                // consulted on the player path: a 15 s skill could be fired again as soon as the gate
+                // above allowed it. SkillCooldownGateRules lists the casts that keep their own pacing.
+                if (SkillCooldownGateRules.ShouldWaitForCooldown(
+                        _bypassGcd, fishingHold, Template.Id, unit.Cooldowns.CheckCooldown(Template.Id)))
+                {
+                    Logger.Trace($"Skill: CooldownTime [{Template.CooldownTime}] for {Template.Id}");
+                    return SkillResult.CooldownTime;
+                }
+
                 if (!comboHit)
                     unit.SkillLastUsed = DateTime.UtcNow;
             }
@@ -1183,10 +1193,14 @@ public class Skill
 
         // Filter out duplicate entries and non-existing
         possibleTargets = possibleTargets.Distinct().ToList();
-        // Add origin in case of no targets and using a target position cast
+        // Add origin in case of no targets and using a target position cast. Utility effects (spawn,
+        // doodad, ...) need a position to act on; damage and debuffs must not follow this origin, see
+        // SkillSelfHitRules - a ground cast that found nobody is not a self-cast.
+        var originFallbackOnly = false;
         if (possibleTargets.Count <= 0 && targetCaster is SkillCastPositionTarget)
         {
             possibleTargets.Add(caster);
+            originFallbackOnly = true;
         }
 
         if (Template.TargetAreaCount > 0 && possibleTargets.Count > Template.TargetAreaCount)
@@ -1351,6 +1365,11 @@ public class Skill
                 {
                     continue;
                 }
+
+                // A ground cast that found no unit only carries the caster as its origin; harmful
+                // effects stop here so the caster is not hit by their own aimed-at-the-ground skill.
+                if (!SkillSelfHitRules.AllowsOriginFallbackTarget(originFallbackOnly, caster.ObjId, target.ObjId, effect))
+                    continue;
 
                 // Apply the effect
                 effectsToApply.Add((target, effect));

--- a/AAEmu.Game/Models/Game/Skills/SkillCooldownGateRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillCooldownGateRules.cs
@@ -1,0 +1,25 @@
+namespace AAEmu.Game.Models.Game.Skills;
+
+/// <summary>
+/// When a cast has to wait for the skill's own cooldown. The cooldown is armed on cast
+/// (<see cref="Skill.Cast"/> and the plot-only fire edge) and is what the client's icon shows; before
+/// this gate existed the player cast path only checked the short anti-spam delay and the shared global
+/// cooldown, so any skill could be fired again the moment those allowed it.
+/// </summary>
+public static class SkillCooldownGateRules
+{
+    /// <summary>
+    /// Basic attacks (2 melee / 3 offhand / 4 ranged — the same ids CSStartSkillPacket, SkillManager and
+    /// Skill already special-case) are paced by the swing timer and the short
+    /// anti-spam delay; their cooldown column is the swing interval, not a lockout. Gating them here
+    /// stopped the client's auto-attack retries and made the hotbar feel unresponsive.
+    /// </summary>
+    public static bool IsBasicAttack(uint skillId) => skillId is 2 or 3 or 4;
+
+    /// <summary>
+    /// Simulation-driven casts (NPC AI, plot tasks, auto-attack tasks) pass <c>bypassGcd</c> and own
+    /// their pacing, and sports-fishing hold/reel skills are re-pressed while their plot runs.
+    /// </summary>
+    public static bool ShouldWaitForCooldown(bool bypassGcd, bool fishingHold, uint skillId, bool hasActiveCooldown)
+        => !bypassGcd && !fishingHold && !IsBasicAttack(skillId) && hasActiveCooldown;
+}

--- a/AAEmu.Game/Models/Game/Skills/SkillSelfHitRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillSelfHitRules.cs
@@ -1,0 +1,25 @@
+using AAEmu.Game.Models.Game.Skills.Effects;
+
+namespace AAEmu.Game.Models.Game.Skills;
+
+/// <summary>
+/// A position cast whose area found no unit falls back to the caster so that spawn, doodad and other
+/// utility effects still have an origin to act on. Damage and debuffs must not follow that fallback:
+/// the cast was aimed at the ground, so the unit that aimed it is not one of its targets. Without this
+/// guard a debuff thrown at an empty spot was applied to its own caster.
+/// </summary>
+public static class SkillSelfHitRules
+{
+    public static bool AllowsOriginFallbackTarget(bool isOriginFallbackOnly, uint casterObjId, uint targetObjId, SkillEffect effect)
+    {
+        if (!isOriginFallbackOnly || casterObjId != targetObjId)
+            return true;
+
+        return effect.Template switch
+        {
+            DamageEffect => false,
+            BuffEffect buff => buff.Buff is not { Kind: BuffKind.Bad },
+            _ => true
+        };
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/SkillTeleportLanding.cs
+++ b/AAEmu.Game/Models/Game/Skills/SkillTeleportLanding.cs
@@ -1,0 +1,55 @@
+using AAEmu.Game.Core.Packets.G2C;
+using AAEmu.Game.Models.Game.Char;
+using AAEmu.Game.Models.Game.Teleport;
+using AAEmu.Game.Models.Game.World.Transform;
+
+namespace AAEmu.Game.Models.Game.Skills;
+
+/// <summary>
+/// Applies a skill-driven teleport to the server-side character and tells the client about it. Both
+/// sides have to agree on the landing: crossing instances shows a loading screen and the client answers
+/// it with CSInstanceLoaded (the only packet that clears DisabledSetPosition), while a same-level
+/// teleport is seamless and the server must move the character itself - otherwise only the client moves
+/// and the zone simulation keeps pulling the character back to the old spot.
+/// </summary>
+public static class SkillTeleportLanding
+{
+    public static void Apply(
+        Character character,
+        uint worldId,
+        uint zoneId,
+        uint instanceId,
+        float x,
+        float y,
+        float z,
+        float yawRad,
+        TeleportReason reason,
+        bool stayInZone = false)
+    {
+        if (!stayInZone && ReturnTeleportRules.NeedsInstanceLoad(character.Transform.InstanceId, instanceId))
+        {
+            character.DisabledSetPosition = true;
+            character.SendPacket(new SCLoadInstancePacket(worldId, zoneId, x, y, z, 0f, 0f, yawRad));
+            character.Transform = new Transform(character, null, zoneId, instanceId, x, y, z, yawRad);
+        }
+        else
+        {
+            // SetPosition writes the LOCAL transform: convert the world landing first so a parented
+            // character (bonded to a doodad, standing on a ship) is not moved by the parent's offset.
+            // The rotation is only replaced when there is no parent to be relative to.
+            var local = character.Transform.GetLocalFromWorld(x, y, z);
+            var rotation = character.Transform.Parent == null
+                ? new System.Numerics.Vector3(0f, 0f, yawRad)
+                : character.Transform.Local.Rotation;
+            character.SetPosition(local.X, local.Y, local.Z, rotation.X, rotation.Y, rotation.Z);
+
+            // FinalizeTransform re-resolves the zone from the coordinates and can hand the character to
+            // another zone. That is wanted for a recall that crosses zones, but never for a move that
+            // stays inside the current one: a few metres must not trigger a zone handoff.
+            if (!stayInZone)
+                character.Transform.FinalizeTransform();
+        }
+
+        character.SendPacket(new SCTeleportUnitPacket(reason, 0, x, y, z, yawRad));
+    }
+}

--- a/AAEmu.Game/Models/Game/Skills/TeleportLandingRules.cs
+++ b/AAEmu.Game/Models/Game/Skills/TeleportLandingRules.cs
@@ -1,0 +1,18 @@
+namespace AAEmu.Game.Models.Game.Skills;
+
+/// <summary>
+/// Guards for skill-driven teleports whose destination comes from data (a house, a return point
+/// elected by the player). World routes players by <c>Transform.ZoneId</c> and fails closed, so a
+/// landing in a zone that has no dedicated zone server would leave the character somewhere nobody
+/// simulates - no NPCs, no movement, no way back. Refusing the cast is the safe answer.
+/// </summary>
+public static class TeleportLandingRules
+{
+    /// <summary>
+    /// True when the destination can be simulated. <paramref name="isZoneLoaded"/> is the caller's
+    /// "does this zone currently have a zone server" probe; it is null when no authority is configured,
+    /// in which case there is nothing to refuse.
+    /// </summary>
+    public static bool CanLandInZone(bool zoneAuthority, Func<uint, bool> isZoneLoaded, uint destinationZoneId)
+        => !zoneAuthority || isZoneLoaded == null || isZoneLoaded(destinationZoneId);
+}

--- a/AAEmu.Game/Models/Game/Units/Buffs.cs
+++ b/AAEmu.Game/Models/Game/Units/Buffs.cs
@@ -739,6 +739,35 @@ public class Buffs : IBuffs
                 e.Exit();
     }
 
+    /// <summary>
+    /// Ends every active buff applied by <paramref name="skillId"/> through its natural-timeout path
+    /// (triggers fire, buff removed). Used when a seat is left: rides such as the house floor mover are
+    /// driven by the seat buff's Timeout trigger (skills.id 40228 '층간 이동' applies it and its trigger
+    /// casts the ride skill), and the ride happens on leaving the seat, not after the buff's full
+    /// duration. Other buff removals keep the natural-expiry rule.
+    /// </summary>
+    public void TimeoutBuffsFromSkill(uint skillId)
+    {
+        if (skillId == 0)
+            return;
+
+        List<Buff> snapshot;
+        lock (_lock)
+        {
+            snapshot = _effects.ToList();
+        }
+
+        foreach (var buff in snapshot)
+        {
+            if (buff.State == EffectState.Finished || buff.Skill?.Id != skillId)
+                continue;
+
+            Logger.Debug("Timing out buff {0} on seat release (skill {1})",
+                buff.Template?.Id ?? 0, skillId);
+            buff.TimeOut();
+        }
+    }
+
     public void TriggerRemoveOn(BuffRemoveOn on, uint value = 0)
     {
         // Create a copy of the list of effects to avoid changing the list while iterating

--- a/AAEmu.Game/Models/Game/Units/IBuffs.cs
+++ b/AAEmu.Game/Models/Game/Units/IBuffs.cs
@@ -35,6 +35,7 @@ public interface IBuffs
     void RemoveStealth();
     void SetOwner(BaseUnit owner);
     void TriggerRemoveOn(BuffRemoveOn on, uint value = 0);
+    void TimeoutBuffsFromSkill(uint skillId);
     // Buff Persistence
     void SaveActiveBuffs(MySqlConnection connection, MySqlTransaction transaction, uint characterId);
     void LoadActiveBuffs(Character character);

--- a/AAEmu.Game/Models/Game/World/Transform/HousingZoneRetentionRules.cs
+++ b/AAEmu.Game/Models/Game/World/Transform/HousingZoneRetentionRules.cs
@@ -1,0 +1,28 @@
+namespace AAEmu.Game.Models.Game.World.Transform;
+
+/// <summary>
+/// A housing area is its own zone key on top of the base zone underneath it (base 213 → housing 207).
+/// A teleport or position update inside the housing area resolves to the base key, which reads as a
+/// zone change and hands the character to a zone they never left. While the character still stands
+/// inside the housing zone they occupy, that zone has to win.
+/// </summary>
+public static class HousingZoneRetentionRules
+{
+    /// <summary>
+    /// True when the character's current housing zone (the one they are in) still covers their position,
+    /// so the re-resolved base key must not replace it.
+    /// </summary>
+    public static bool ShouldKeepOldZone(uint lastZoneKey, IReadOnlyList<uint> housingZonesAtPosition)
+    {
+        return lastZoneKey != 0 && housingZonesAtPosition.Contains(lastZoneKey);
+    }
+
+    /// <summary>
+    /// True when a re-resolved key must be reverted: the unit did not leave the housing zone it was in.
+    /// </summary>
+    public static bool ShouldSuppressChange(uint lastZoneKey, uint newZoneKey, IReadOnlyList<uint> housingZonesAtPosition)
+    {
+        return lastZoneKey != 0 && newZoneKey != 0 && lastZoneKey != newZoneKey &&
+               ShouldKeepOldZone(lastZoneKey, housingZonesAtPosition);
+    }
+}

--- a/AAEmu.Game/Models/Game/World/Transform/Transform.cs
+++ b/AAEmu.Game/Models/Game/World/Transform/Transform.cs
@@ -5,6 +5,8 @@ using AAEmu.Game.Core.Managers.World;
 using AAEmu.Game.Models.Game.Char;
 using AAEmu.Game.Models.Game.Units;
 
+using NLog;
+
 // INFO
 // https://www.versluis.com/2020/09/what-is-yaw-pitch-and-roll-in-3d-axis-values/
 // https://en.wikipedia.org/wiki/Euler_angles
@@ -28,6 +30,8 @@ public class Transform : IDisposable
     private List<Transform> _stickyChildren;
     private Vector3 _lastFinalizePos; // Might use this later for cheat detection or delta movement
     private DateTime _lastFinalizeTime;
+
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
     private float _skipCheckTime;
     public List<Character> _debugTrackers;
     // ReSharper disable once ChangeFieldTypeToSystemThreadingLock
@@ -98,8 +102,50 @@ public class Transform : IDisposable
             // process outright, since a StackOverflowException cannot be caught.
             var lastZoneId = _zoneId;
             _zoneId = value;
+
+            // Character zone keys move rarely, and each move decides whether the character is handed to
+            // another zone: keep the fact at Info and the call stack one level below for diagnosis.
+            if (GameObject is Character character)
+            {
+                var position = World.Position;
+                Logger.Info("ZoneId change: {0} (objId {1}) {2} -> {3} at ({4:0.#}, {5:0.#}, {6:0.#})",
+                    character.Name, character.ObjId, lastZoneId, value,
+                    position.X, position.Y, position.Z);
+                Logger.Debug("ZoneId change caller (objId {0}):\n{1}",
+                    character.ObjId, new System.Diagnostics.StackTrace(1, false));
+            }
+
             GameObject?.OnZoneChange(lastZoneId, value);
         }
+    }
+
+    /// <summary>
+    /// Converts a world position into the position this transform has to hold for its world position to
+    /// become the given coordinates. Identity when the object has no parent (a character standing in the
+    /// open world), parent-relative when it has one (bonded to a doodad, seated on a house, standing on
+    /// a ship). <see cref="GameObject.SetPosition"/> writes the LOCAL transform, so a world-space landing
+    /// applied to a parented character throws them one parent-offset away.
+    /// </summary>
+    public Vector3 GetLocalFromWorld(float x, float y, float z)
+    {
+        var world = new Vector3(x, y, z);
+        if (_parentTransform == null)
+            return world;
+
+        var parentWorld = _parentTransform.World;
+        var inverseParentRotation = Quaternion.Inverse(parentWorld.ToQuaternion());
+        var parentScale = _parentTransform.GameObject is BaseUnit unit ? unit.Scale : 1f;
+        return Vector3.Transform(world - parentWorld.Position, inverseParentRotation) / parentScale;
+    }
+
+    /// <summary>
+    /// Reverts the zone key without raising <see cref="GameObject.OnZoneChange"/>. Only for undoing a
+    /// re-resolution of a zone the unit never actually left — a housing area is its own zone key on
+    /// top of the base zone, and notifying about the base key would hand the character away.
+    /// </summary>
+    internal void KeepZoneQuietly(uint zoneId)
+    {
+        _zoneId = zoneId;
     }
 
     /// <summary>

--- a/AAEmu.UnitTests/Game/Core/Packets/G2C/SCBlinkUnitPacketTests.cs
+++ b/AAEmu.UnitTests/Game/Core/Packets/G2C/SCBlinkUnitPacketTests.cs
@@ -1,0 +1,41 @@
+using AAEmu.Commons.Network;
+using AAEmu.Game.Core.Packets.G2C;
+
+namespace AAEmu.UnitTests.Game.Core.Packets.G2C;
+
+public class SCBlinkUnitPacketTests
+{
+    private static byte[] Body(bool move3D, float z)
+    {
+        var stream = new PacketStream();
+        new SCBlinkUnitPacket(1500u, 15f, 0f, move3D, 10811.4f, 10527.4f, z).Write(stream);
+        return stream.GetBytes();
+    }
+
+    [Test]
+    public async Task Body_KeepsTheByteTheClientReads()
+    {
+        // Wire layout: unitId(bc), f32 distance, f32 degree, u8 move3D, then the position. Dropping
+        // move3D made the packet one byte short: the client consumed the position one byte early, logged
+        // "not enough buffer for z" and ignored the blink.
+        var body = Body(move3D: true, z: 178.4f);
+
+        await Assert.That(body.Length).IsEqualTo(3 + 4 + 4 + 1 + 8 + 8 + 4);
+    }
+
+    [Test]
+    public async Task Move3DFlag_SitsBetweenDegreeAndPosition()
+    {
+        await Assert.That(Body(move3D: true, z: 1f)[11]).IsEqualTo((byte)1);
+        await Assert.That(Body(move3D: false, z: 1f)[11]).IsEqualTo((byte)0);
+    }
+
+    [Test]
+    public async Task Z_IsTheTrailingField()
+    {
+        const float z = 178.4375f;
+        var body = Body(move3D: false, z: z);
+
+        await Assert.That(BitConverter.ToSingle(body, body.Length - 4)).IsEqualTo(z);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/BlinkLandingRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/BlinkLandingRulesTests.cs
@@ -1,0 +1,37 @@
+using AAEmu.Game.Models.Game.Skills;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills;
+
+public class BlinkLandingRulesTests
+{
+    // AddDistanceToFrontDeg walks distance * (cos, sin) from the caster position, so yaw 0 moves along
+    // +X and yaw 90 along +Y; the offset is what the side-step blinks pass as value2.
+    [Test]
+    public async Task ForwardBlink_MovesAlongTheFacing()
+    {
+        var (x, y) = BlinkLandingRules.GetLanding(x: 0f, y: 0f, casterYawDegrees: 0f, distanceMetres: 15, offsetDegrees: 0);
+        await Assert.That(x).IsEqualTo(15f).Within(0.01f);
+        await Assert.That(y).IsEqualTo(0f).Within(0.01f);
+    }
+
+    [Test]
+    public async Task SideStepBlink_AppliesTheOffsetDegrees()
+    {
+        var (rightX, rightY) = BlinkLandingRules.GetLanding(0f, 0f, 0f, 15, 90);
+        await Assert.That(rightX).IsEqualTo(0f).Within(0.01f);
+        await Assert.That(rightY).IsEqualTo(15f).Within(0.01f);
+
+        var (leftX, leftY) = BlinkLandingRules.GetLanding(0f, 0f, 0f, 15, -90);
+        await Assert.That(leftX).IsEqualTo(0f).Within(0.01f);
+        await Assert.That(leftY).IsEqualTo(-15f).Within(0.01f);
+    }
+
+    [Test]
+    public async Task OffsetIsRelativeToTheCasterFacing()
+    {
+        var (x, y) = BlinkLandingRules.GetLanding(x: 100f, y: 200f, casterYawDegrees: 90f, distanceMetres: 10, offsetDegrees: -90);
+        // yaw 90 + (-90) = 0 -> straight along +X from the caster position.
+        await Assert.That(x).IsEqualTo(110f).Within(0.01f);
+        await Assert.That(y).IsEqualTo(200f).Within(0.01f);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/SkillCooldownGateRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/SkillCooldownGateRulesTests.cs
@@ -1,0 +1,44 @@
+using AAEmu.Game.Models.Game.Skills;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills;
+
+public class SkillCooldownGateRulesTests
+{
+    [Test]
+    public async Task PlayerSkill_WithAnArmedCooldown_Waits()
+    {
+        await Assert.That(SkillCooldownGateRules.ShouldWaitForCooldown(
+            bypassGcd: false, fishingHold: false, skillId: 10025, hasActiveCooldown: true)).IsTrue();
+    }
+
+    [Test]
+    public async Task PlayerSkill_WithNoCooldown_Casts()
+    {
+        await Assert.That(SkillCooldownGateRules.ShouldWaitForCooldown(
+            bypassGcd: false, fishingHold: false, skillId: 10025, hasActiveCooldown: false)).IsFalse();
+    }
+
+    [Test]
+    public async Task BasicAttacks_KeepTheClientSideSwingPacing()
+    {
+        foreach (var skillId in new uint[] { 2, 3, 4 })
+        {
+            await Assert.That(SkillCooldownGateRules.IsBasicAttack(skillId)).IsTrue();
+            // Their cooldown column is the swing interval (2 = 300 ms, 4 = 500 ms); gating it made the
+            // hotbar stop auto-attack retries.
+            await Assert.That(SkillCooldownGateRules.ShouldWaitForCooldown(
+                bypassGcd: false, fishingHold: false, skillId: skillId, hasActiveCooldown: true)).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task SimulationCasts_AndFishingHolds_AreNotGated()
+    {
+        // NPC AI, plot tasks and auto-attack tasks pass bypassGcd and own their own pacing.
+        await Assert.That(SkillCooldownGateRules.ShouldWaitForCooldown(
+            bypassGcd: true, fishingHold: false, skillId: 10025, hasActiveCooldown: true)).IsFalse();
+        // Hold/reel kits re-press their skill while the plot runs.
+        await Assert.That(SkillCooldownGateRules.ShouldWaitForCooldown(
+            bypassGcd: false, fishingHold: true, skillId: 21571, hasActiveCooldown: true)).IsFalse();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/SkillSelfHitRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/SkillSelfHitRulesTests.cs
@@ -1,0 +1,50 @@
+using AAEmu.Game.Models.Game.Skills;
+using AAEmu.Game.Models.Game.Skills.Effects;
+using AAEmu.Game.Models.Game.Skills.Templates;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills;
+
+public class SkillSelfHitRulesTests
+{
+    private static SkillEffect Effect(EffectTemplate template) => new() { Template = template };
+
+    [Test]
+    public async Task GroundOrigin_DamageIsNotAppliedToTheCaster()
+    {
+        await Assert.That(SkillSelfHitRules.AllowsOriginFallbackTarget(
+            isOriginFallbackOnly: true, casterObjId: 100, targetObjId: 100,
+            Effect(new DamageEffect()))).IsFalse();
+    }
+
+    [Test]
+    public async Task GroundOrigin_DebuffIsNotAppliedToTheCaster()
+    {
+        await Assert.That(SkillSelfHitRules.AllowsOriginFallbackTarget(
+            isOriginFallbackOnly: true, casterObjId: 100, targetObjId: 100,
+            Effect(new BuffEffect { Buff = new BuffTemplate { Kind = BuffKind.Bad } }))).IsFalse();
+    }
+
+    [Test]
+    public async Task GroundOrigin_UtilityAndSelfBuffsStillReachTheOrigin()
+    {
+        // A ground cast carries the caster as its origin so spawn/doodad effects have a position, and
+        // self-targeted good buffs cast at a position are still meant to land on the caster.
+        await Assert.That(SkillSelfHitRules.AllowsOriginFallbackTarget(
+            isOriginFallbackOnly: true, casterObjId: 100, targetObjId: 100,
+            Effect(new BuffEffect { Buff = new BuffTemplate { Kind = BuffKind.Good } }))).IsTrue();
+        await Assert.That(SkillSelfHitRules.AllowsOriginFallbackTarget(
+            isOriginFallbackOnly: true, casterObjId: 100, targetObjId: 100,
+            Effect(new SpawnEffect()))).IsTrue();
+    }
+
+    [Test]
+    public async Task RealTargets_AreNeverFiltered()
+    {
+        await Assert.That(SkillSelfHitRules.AllowsOriginFallbackTarget(
+            isOriginFallbackOnly: false, casterObjId: 100, targetObjId: 100,
+            Effect(new DamageEffect()))).IsTrue();
+        await Assert.That(SkillSelfHitRules.AllowsOriginFallbackTarget(
+            isOriginFallbackOnly: true, casterObjId: 100, targetObjId: 200,
+            Effect(new DamageEffect()))).IsTrue();
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/Skills/TeleportLandingRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/Skills/TeleportLandingRulesTests.cs
@@ -1,0 +1,40 @@
+using AAEmu.Game.Models.Game.Skills;
+
+namespace AAEmu.UnitTests.Game.Models.Game.Skills;
+
+public class TeleportLandingRulesTests
+{
+    [Test]
+    public async Task LoadedDestination_IsAllowed()
+    {
+        await Assert.That(TeleportLandingRules.CanLandInZone(
+            zoneAuthority: true, isZoneLoaded: _ => true, destinationZoneId: 186)).IsTrue();
+    }
+
+    [Test]
+    public async Task UnloadedDestination_IsRefused()
+    {
+        await Assert.That(TeleportLandingRules.CanLandInZone(
+            zoneAuthority: true, isZoneLoaded: _ => false, destinationZoneId: 186)).IsFalse();
+    }
+
+    [Test]
+    public async Task WithoutZoneAuthority_OrWithoutAProbe_NothingIsRefused()
+    {
+        await Assert.That(TeleportLandingRules.CanLandInZone(
+            zoneAuthority: false, isZoneLoaded: _ => false, destinationZoneId: 186)).IsTrue();
+        await Assert.That(TeleportLandingRules.CanLandInZone(
+            zoneAuthority: true, isZoneLoaded: null, destinationZoneId: 186)).IsTrue();
+    }
+
+    [Test]
+    public async Task TheProbe_IsAskedAboutTheDestinationZone()
+    {
+        uint? asked = null;
+        var allowed = TeleportLandingRules.CanLandInZone(
+            zoneAuthority: true, isZoneLoaded: zoneId => { asked = zoneId; return true; }, destinationZoneId: 288);
+
+        await Assert.That(allowed).IsTrue();
+        await Assert.That(asked).IsEqualTo(288u);
+    }
+}

--- a/AAEmu.UnitTests/Game/Models/Game/World/Transform/HousingZoneRetentionRulesTests.cs
+++ b/AAEmu.UnitTests/Game/Models/Game/World/Transform/HousingZoneRetentionRulesTests.cs
@@ -1,0 +1,50 @@
+using AAEmu.Game.Models.Game.World.Transform;
+
+namespace AAEmu.UnitTests.Game.Models.Game.World.Transform;
+
+public class HousingZoneRetentionRulesTests
+{
+    [Test]
+    public async Task StaysWhenThePositionIsStillInsideTheHousingZone()
+    {
+        // House 742: base zone 213 resolves, but the position is inside housing zone 207.
+        uint[] housingZonesAtPosition = [207];
+
+        await Assert.That(HousingZoneRetentionRules.ShouldSuppressChange(207, 213, housingZonesAtPosition)).IsTrue();
+    }
+
+    [Test]
+    public async Task DoesNotSuppressWhenTheCharacterLeftTheHousingZone()
+    {
+        // Position is in open world now: the base zone is the only answer and the change is real.
+        uint[] housingZonesAtPosition = [];
+
+        await Assert.That(HousingZoneRetentionRules.ShouldSuppressChange(207, 213, housingZonesAtPosition)).IsFalse();
+    }
+
+    [Test]
+    public async Task DoesNotSuppressADifferentHousingZone()
+    {
+        // Moving into a neighbouring housing area is a real zone change.
+        uint[] housingZonesAtPosition = [208];
+
+        await Assert.That(HousingZoneRetentionRules.ShouldSuppressChange(207, 208, housingZonesAtPosition)).IsFalse();
+    }
+
+    [Test]
+    public async Task DoesNotSuppressWhenNothingChanged()
+    {
+        uint[] housingZonesAtPosition = [207];
+
+        await Assert.That(HousingZoneRetentionRules.ShouldSuppressChange(207, 207, housingZonesAtPosition)).IsFalse();
+    }
+
+    [Test]
+    public async Task UnknownOldZoneIsNeverRetained()
+    {
+        // A character with no zone yet (0) must not have one invented for them.
+        uint[] housingZonesAtPosition = [0, 207];
+
+        await Assert.That(HousingZoneRetentionRules.ShouldSuppressChange(0, 213, housingZonesAtPosition)).IsFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Two grouped fixes on the player skill path and on seat/zone membership. Six defects, all of them visible in normal play:

**Skill pipeline**

1. **Skill cooldown was armed but never checked.** `Skill.Use` armed the skill's cooldown on cast, but the player path only consulted the 150 ms anti-spam delay and the shared GCD, so a 60 s skill could be re-fired the moment those allowed it. `SkillCooldownGateRules` gates on the armed cooldown and deliberately leaves alone: basic attacks (skills 2/3/4 — their cooldown column is the swing interval, 300/0/500 ms in the shipped data, and the ids are already special-cased in `CSStartSkillPacket`, `SkillManager` and `Skill`), simulation casts (`bypassGcd`: NPC AI, plot tasks, auto-attack tasks) and fishing hold/reel kits.
2. **Ground casts debuffed their own caster.** A position cast whose area found no unit adds the caster as an origin so spawn/doodad effects have a position. Damage and debuff effects followed that fallback. `SkillSelfHitRules` stops harmful effects at the origin-only fallback; real targets, real self-casts and utility effects are untouched.
3. **Blink ignored its direction and its packet was short.** `value2` (the ±90° side-step/mirror offset) was dropped, so every blink went straight ahead while the client showed the sideways one. `SCBlinkUnitPacket` was missing the `move3D` flag between the degree pair and the position — one byte short, so the position was parsed shifted and the blink was lost entirely. The byte layout is pinned by a test now.
4. **Teleports only moved the client.** `TeleportToUnit` (그림자 밟기) and the recall/return/resurrection effects sent the packet and nothing else, so the zone kept simulating the character at the old spot and pulled it back. They all land through `SkillTeleportLanding` now (the same steps the portal path uses), and `Transform.GetLocalFromWorld` converts the world landing because `SetPosition` writes the *local* transform — without it a parented character (bonded to a seat, standing on a ship) lands one parent-offset away.

**Seats and zone membership**

5. **A seat ride never fired.** A house floor mover ('층간 이동기') is carried by its seat buff: leaving the seat times the buff out and its Timeout trigger casts the moving skill (skills.id 40228 applies the seat buff, its trigger casts the ride skill, which applies the ride buff whose trigger blinks the rider). The release path removed the buff as an ordinary removal, which by design never runs Timeout triggers, so the ride was skipped. `BondDoodad` remembers the skill the seat was used with and times out only the buffs that skill applied (`Buffs.TimeoutBuffsFromSkill`, `Buff.TimeOut`); every other buff keeps the natural-expiry rule.
6. **A few metres inside a housing area read as a cross-zone move.** A housing area is its own zone key on top of the base zone underneath it; a position update inside it re-resolves to the base key, the world routes by zone key and fails closed, and the character was returned to character select. `HousingZoneRetentionRules` keeps the housing zone while the character's position is still inside it, and `Transform.ZoneId` logs every character zone change so a re-resolved key can always be traced.

## Tests

23 new tests across six classes, run with the full suite:

- `SkillCooldownGateRulesTests` — player skills wait, paced casts don't (basic attacks, `bypassGcd`, fishing holds).
- `SkillSelfHitRulesTests` — ground-origin damage/debuff filtered; utility, good buffs and real targets pass.
- `BlinkLandingRulesTests` — landing distance/rotation.
- `TeleportLandingRulesTests` — landing in an unsimulated zone is refused, no authority means no refusal.
- `SCBlinkUnitPacketTests` — body length, the `move3D` byte's position, the trailing `z`.
- `HousingZoneRetentionRulesTests` — kept while inside, real changes still pass (left the area, other housing zone, no zone, unchanged key).

Full suite: 2394 passed, 0 failed, 0 skipped.

## Notes

- The seat-ride change is scoped to the seat's own skill: of the 4081 buffs in the shipped data that carry a Timeout trigger, only the ones applied by that one skill are affected at release.
- No new configuration, no schema change, no new dependency.
